### PR TITLE
chore(deps): migrate to shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,8 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "config:recommended",
-      ":dependencyDashboard",
-      ":disableRateLimiting",
-      ":timezone(America/Los_Angeles)",
-      ":semanticCommits"
-    ],
-    "dependencyDashboardTitle": "Renovate Dashboard 🤖",
-    "suppressNotifications": [
-      "prEditedNotification",
-      "prIgnoreNotification"
-    ],
-    "postUpdateOptions": [
-      "gomodTidy"
-    ],
-    "forkProcessing": "enabled",
-    "assignees": ["jacaudi"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jacaudi/renovate-config:base",
+    "github>jacaudi/renovate-config:go",
+    "github>jacaudi/renovate-config:fork"
+  ]
 }


### PR DESCRIPTION
## Summary
- Use shared presets from `jacaudi/renovate-config`

## Presets Used
- `base` - Common settings, GitHub Actions grouping
- `go` - Go mod tidy
- `fork` - Enable fork processing

Generated with [Claude Code](https://claude.com/claude-code)