### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2023 Will Glynn
+Copyright (c) 2025 Adam Caudill
+
+This project began as a fork of tempest_exporter
+(https://github.com/willglynn/tempest_exporter), which is distributed under the
+MIT License. As a derivative work, this project is likewise released under the
+MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The repository currently ships **no `LICENSE` file**.

Per the README's **Source Credit**, this project *"Started as a fork of"* [`tempest_exporter`](https://github.com/willglynn/tempest_exporter), which is distributed under the **MIT License**. As a derivative work, this project should carry the same license so downstream users have clear terms.

This adds a standard MIT `LICENSE` crediting both the original author (Will Glynn, 2023) and the fork maintainer (Adam Caudill, 2025), with a short note recording the fork provenance.

## Notes

- Docs-only change — no code touched, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)