### PR TITLE
refactor: migrate logging from stdlib log to log/slog

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The exporter can optionally write metrics to PostgreSQL in addition to (or inste
 
 When configured, the exporter automatically creates and maintains typed tables for observations, rapid wind data, hub status, and events.
 
+### Logging (Optional)
+
+The exporter logs via the standard library's structured logger (`log/slog`). Two
+environment variables control verbosity and output format:
+
+* `LOG_LEVEL`: `debug`, `info`, `warn`, or `error` (default: `info`)
+* `LOG_FORMAT`: `text` or `json` (default: `text`)
+
+Unrecognized values fall back to the defaults.
+
 See `CLAUDE.md` for detailed configuration options and Docker Compose examples
 
 ## Source Credit

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,66 @@
+// Package logging configures the process-wide structured logger (log/slog).
+//
+// The logger is configured from the environment so operators can adjust
+// verbosity and output format without code changes:
+//
+//	LOG_LEVEL  = debug | info | warn | error   (default: info)
+//	LOG_FORMAT = text  | json                  (default: text)
+//
+// This aligns tempestwx-utilities with the log/slog logging pattern used across
+// the sibling services (ytdl-api, nextdns-operator, claude-code-api).
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Init builds a logger from the LOG_LEVEL and LOG_FORMAT environment variables,
+// installs it as the process default via slog.SetDefault, and returns it.
+func Init() *slog.Logger {
+	logger := New(os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT"))
+	slog.SetDefault(logger)
+	return logger
+}
+
+// New constructs a *slog.Logger for the given level and format strings. Unknown
+// or empty values fall back to info level and text format. Output is written to
+// stderr. It is exported so tests (and callers wanting a non-default logger) can
+// build a logger without touching the global default.
+func New(level, format string) *slog.Logger {
+	return newLogger(os.Stderr, level, format)
+}
+
+// newLogger is the writer-parameterized core of New, split out so tests can
+// capture output without touching os.Stderr.
+func newLogger(w io.Writer, level, format string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: ParseLevel(level)}
+
+	var handler slog.Handler
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "json":
+		handler = slog.NewJSONHandler(w, opts)
+	default: // "text", "", or anything unrecognized
+		handler = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(handler)
+}
+
+// ParseLevel maps a case-insensitive level name to a slog.Level, defaulting to
+// slog.LevelInfo for empty or unrecognized input.
+func ParseLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	case "info":
+		return slog.LevelInfo
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,158 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests are organized by the seven Go test categories:
+//   1. Happy path       2. Table-driven     3. Edge/boundary
+//   4. Error handling    5. Concurrency/race 6. Integration
+//   7. Benchmark (+ Fuzz)
+// ─────────────────────────────────────────────────────────────────────────
+
+// Category 1 — Happy path: New returns a usable logger and Init installs a
+// non-nil default without panicking.
+func TestNew_ReturnsLogger(t *testing.T) {
+	if got := New("info", "text"); got == nil {
+		t.Fatal("New returned nil")
+	}
+	if got := Init(); got == nil {
+		t.Fatal("Init returned nil")
+	}
+	if slog.Default() == nil {
+		t.Fatal("Init did not set a default logger")
+	}
+}
+
+// Category 2 — Table-driven: level names map to the expected slog.Level.
+func TestParseLevel_Table(t *testing.T) {
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"Info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"nonsense", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		if got := ParseLevel(tc.in); got != tc.want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Category 3 — Edge/boundary: surrounding whitespace and mixed case are
+// tolerated, and a below-threshold record is filtered out.
+func TestParseLevel_WhitespaceAndFiltering(t *testing.T) {
+	if got := ParseLevel("  Warn  "); got != slog.LevelWarn {
+		t.Errorf("whitespace/case not normalized: got %v", got)
+	}
+
+	var buf bytes.Buffer
+	logger := newLogger(&buf, "error", "text")
+	logger.Info("should be filtered") // info < error → dropped
+	logger.Error("should appear")
+	out := buf.String()
+	if strings.Contains(out, "should be filtered") {
+		t.Errorf("info record leaked at error level: %q", out)
+	}
+	if !strings.Contains(out, "should appear") {
+		t.Errorf("error record missing at error level: %q", out)
+	}
+}
+
+// Category 4 — Error handling: the public API has no error return paths (level
+// and format are best-effort with safe fallbacks). This test documents and
+// locks the fallback contract: unrecognized inputs must not panic and must not
+// silently disable logging.
+func TestNew_UnknownInputsFallBackSafely(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newLogger(&buf, "bogus-level", "bogus-format")
+	logger.Info("hello") // unknown level → info default, unknown format → text
+	if !strings.Contains(buf.String(), "hello") {
+		t.Errorf("unknown level/format did not fall back to a working logger: %q", buf.String())
+	}
+}
+
+// Category 5 — Concurrency/race: New and ParseLevel are pure and must be safe to
+// call from many goroutines (run under -race).
+func TestConcurrentConstruction(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = ParseLevel("warn")
+			if New("debug", "json") == nil {
+				t.Error("New returned nil under concurrency")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// Category 6 — Integration: the text and json formats each produce output in the
+// expected shape through the full New → handler → write path.
+func TestFormats_Integration(t *testing.T) {
+	t.Run("json is valid JSON with our attrs", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newLogger(&buf, "info", "json")
+		logger.Info("startup", "component", "test", "count", 3)
+		var m map[string]any
+		if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &m); err != nil {
+			t.Fatalf("json format did not emit valid JSON: %v (%q)", err, buf.String())
+		}
+		if m["msg"] != "startup" || m["component"] != "test" {
+			t.Errorf("json output missing expected fields: %v", m)
+		}
+	})
+	t.Run("text is not JSON but contains the message", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newLogger(&buf, "info", "text")
+		logger.Info("startup", "component", "test")
+		out := buf.String()
+		if !strings.Contains(out, "msg=startup") || !strings.Contains(out, "component=test") {
+			t.Errorf("text output missing key=value fields: %q", out)
+		}
+		var m map[string]any
+		if json.Unmarshal([]byte(out), &m) == nil {
+			t.Errorf("text format unexpectedly parsed as JSON: %q", out)
+		}
+	})
+}
+
+// Category 7a — Benchmark.
+func BenchmarkParseLevel(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = ParseLevel("warning")
+	}
+}
+
+// Category 7b — Fuzz: ParseLevel must never panic and must return one of the
+// four valid slog levels for arbitrary input.
+func FuzzParseLevel(f *testing.F) {
+	for _, s := range []string{"debug", "INFO", " warn ", "error", "", "??"} {
+		f.Add(s)
+	}
+	valid := map[slog.Level]bool{
+		slog.LevelDebug: true, slog.LevelInfo: true,
+		slog.LevelWarn: true, slog.LevelError: true,
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		if got := ParseLevel(s); !valid[got] {
+			t.Errorf("ParseLevel(%q) returned invalid level %v", s, got)
+		}
+	})
+}

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -121,7 +121,7 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
 
-	log.Printf("postgres: connected, schema ready")
+	slog.Info("postgres: connected, schema ready")
 
 	// Initialize writer
 	w := &PostgresWriter{
@@ -517,7 +517,7 @@ func (w *PostgresWriter) handleObservationReport(ctx context.Context, r *tempest
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			log.Printf("postgres: observation batch channel full, dropping")
+			slog.Warn("postgres: observation batch channel full, dropping")
 		}
 	}
 
@@ -545,7 +545,7 @@ func (w *PostgresWriter) handleRapidWindReport(ctx context.Context, r *tempestud
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		log.Printf("postgres: rapid_wind batch channel full, dropping")
+		slog.Warn("postgres: rapid_wind batch channel full, dropping")
 	}
 
 	return nil
@@ -574,7 +574,7 @@ func (w *PostgresWriter) handleHubStatusReport(ctx context.Context, r *tempestud
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		log.Printf("postgres: hub_status batch channel full, dropping")
+		slog.Warn("postgres: hub_status batch channel full, dropping")
 	}
 
 	return nil
@@ -602,7 +602,7 @@ func (w *PostgresWriter) handleRainStartReport(ctx context.Context, r *tempestud
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		log.Printf("postgres: event batch channel full, dropping")
+		slog.Warn("postgres: event batch channel full, dropping")
 	}
 
 	return nil
@@ -632,7 +632,7 @@ func (w *PostgresWriter) handleLightningStrikeReport(ctx context.Context, r *tem
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		log.Printf("postgres: event batch channel full, dropping")
+		slog.Warn("postgres: event batch channel full, dropping")
 	}
 
 	return nil
@@ -652,7 +652,7 @@ func (w *PostgresWriter) WriteMetrics(ctx context.Context, metrics []prometheus.
 	for _, metric := range metrics {
 		var dto io_prometheus_client.Metric
 		if err := metric.Write(&dto); err != nil {
-			log.Printf("postgres: failed to write metric: %v", err)
+			slog.Error("postgres: failed to write metric", "err", err)
 			continue
 		}
 
@@ -754,7 +754,7 @@ func (w *PostgresWriter) WriteMetrics(ctx context.Context, metrics []prometheus.
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			log.Printf("postgres: observation batch channel full during WriteMetrics, dropping")
+			slog.Warn("postgres: observation batch channel full during WriteMetrics, dropping")
 		}
 	}
 
@@ -779,24 +779,23 @@ func (w *PostgresWriter) flushWithRetry(flushFn func() error, tableName string, 
 			return
 		}
 
-		log.Printf("postgres: failed to write %d rows to %s (attempt %d/%d): %v",
-			batchSize, tableName, attempt, w.maxRetries, err)
+		slog.Error("postgres: failed to write rows",
+			"rows", batchSize, "table", tableName, "attempt", attempt, "max_attempts", w.maxRetries, "err", err)
 
 		if !isRetryable(err) {
-			log.Printf("postgres: non-retryable error for %s, dropping batch: %v",
-				tableName, err)
+			slog.Error("postgres: non-retryable error, dropping batch", "table", tableName, "err", err)
 			return
 		}
 
 		if attempt == w.maxRetries {
-			log.Printf("postgres: max retries exceeded for %s, dropping %d rows", tableName, batchSize)
+			slog.Error("postgres: max retries exceeded, dropping batch", "table", tableName, "rows", batchSize)
 			return
 		}
 
 		// Check if context is still valid before sleeping
 		select {
 		case <-w.ctx.Done():
-			log.Printf("postgres: context cancelled during retry for %s, dropping batch", tableName)
+			slog.Warn("postgres: context cancelled during retry, dropping batch", "table", tableName)
 			return
 		case <-time.After(backoff):
 			// Continue to next attempt
@@ -864,7 +863,7 @@ func (w *PostgresWriter) Close() error {
 
 	// Close connection pool
 	w.pool.Close()
-	log.Printf("postgres: closed")
+	slog.Info("postgres: closed")
 
 	return nil
 }

--- a/internal/prometheus/server.go
+++ b/internal/prometheus/server.go
@@ -3,7 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -65,9 +65,9 @@ func (s *MetricsServer) Start() error {
 	s.shutdownWg.Add(1)
 	go func() {
 		defer s.shutdownWg.Done()
-		log.Printf("metrics: starting HTTP server on port %s", s.port)
+		slog.Info("metrics: starting HTTP server", "port", s.port)
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("metrics: server error: %v", err)
+			slog.Error("metrics: server error", "err", err)
 		}
 	}()
 	return nil
@@ -96,12 +96,12 @@ func (s *MetricsServer) Close() error {
 	defer cancel()
 
 	if err := s.server.Shutdown(ctx); err != nil {
-		log.Printf("metrics: shutdown error: %v", err)
+		slog.Error("metrics: shutdown error", "err", err)
 		return err
 	}
 
 	s.shutdownWg.Wait()
-	log.Printf("metrics: server closed")
+	slog.Info("metrics: server closed")
 	return nil
 }
 

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -2,7 +2,7 @@ package prometheus
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 
 	"tempestwx-utilities/internal/tempestudp"
@@ -43,7 +43,7 @@ func NewPrometheusWriter(pushURL, jobName string) *PrometheusWriter {
 	w.wg.Add(1)
 	go w.pushWorker()
 
-	log.Printf("prometheus: configured push to %q with job %q", pushURL, jobName)
+	slog.Info("prometheus: configured pushgateway", "url", pushURL, "job", jobName)
 
 	return w
 }
@@ -62,7 +62,7 @@ func (w *PrometheusWriter) WriteMetrics(ctx context.Context, metrics []prometheu
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			log.Printf("prometheus: outbox full, dropping metric")
+			slog.Warn("prometheus: outbox full, dropping metric")
 		}
 	}
 
@@ -91,7 +91,7 @@ func (w *PrometheusWriter) Close() error {
 	close(w.outbox)
 	close(w.more)
 	w.wg.Wait() // Wait for pushWorker to finish
-	log.Printf("prometheus: closed")
+	slog.Info("prometheus: closed")
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (w *PrometheusWriter) pushWorker() {
 	defer w.wg.Done()
 	for range w.more {
 		if err := w.pusher.Add(); err != nil {
-			log.Printf("prometheus: push error: %v", err)
+			slog.Error("prometheus: push error", "err", err)
 		}
 	}
 }

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -2,7 +2,7 @@ package sink
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 
 	"tempestwx-utilities/internal/tempestudp"
@@ -68,7 +68,7 @@ func (s *MetricsSink) SendReport(ctx context.Context, report tempestudp.Report) 
 		go func(writer MetricsWriter) {
 			defer wg.Done()
 			if err := writer.WriteReport(ctx, report); err != nil {
-				log.Printf("writer error (report): %v", err)
+				slog.Error("sink: writer error handling report", "err", err)
 			}
 		}(w)
 	}
@@ -91,7 +91,7 @@ func (s *MetricsSink) SendMetrics(ctx context.Context, metrics []prometheus.Metr
 		go func(writer MetricsWriter) {
 			defer wg.Done()
 			if err := writer.WriteMetrics(ctx, metrics); err != nil {
-				log.Printf("writer error (metrics): %v", err)
+				slog.Error("sink: writer error handling metrics", "err", err)
 			}
 		}(w)
 	}
@@ -115,12 +115,12 @@ func (s *MetricsSink) Close() error {
 
 			// Flush first
 			if err := writer.Flush(s.ctx); err != nil {
-				log.Printf("writer flush error: %v", err)
+				slog.Error("sink: writer flush error", "err", err)
 			}
 
 			// Then close
 			if err := writer.Close(); err != nil {
-				log.Printf("writer close error: %v", err)
+				slog.Error("sink: writer close error", "err", err)
 			}
 		}(w)
 	}

--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -105,7 +105,7 @@ func (c Client) GetObservations(ctx context.Context, station Station, startAt ti
 	}
 	report, err := tempestudp.ParseReport(bytes)
 	if err != nil {
-		log.Printf("read %s", string(bytes))
+		slog.Warn("tempestapi: failed to parse report", "body", string(bytes), "err", err)
 		return nil, err
 	}
 
@@ -113,7 +113,7 @@ func (c Client) GetObservations(ctx context.Context, station Station, startAt ti
 	case *tempestudp.TempestObservationReport:
 		r.SerialNumber = station.serialNumber
 	default:
-		log.Fatalf("unhandled report type")
+		return nil, fmt.Errorf("tempestapi: unhandled report type %T", report)
 	}
 
 	metrics := report.Metrics()

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"tempestwx-utilities/internal/config"
+	"tempestwx-utilities/internal/logging"
 	"tempestwx-utilities/internal/postgres"
 	"tempestwx-utilities/internal/prometheus"
 	"tempestwx-utilities/internal/sink"
@@ -25,7 +26,16 @@ import (
 
 // Old collector implementation removed - now using MetricsSink
 
+// fatal logs msg at error level with the given structured attributes and exits
+// the process. It replaces the previous log.Fatal/log.Fatalf usage.
+func fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
+	os.Exit(1)
+}
+
 func main() {
+	logging.Init()
+
 	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer done()
 
@@ -40,7 +50,7 @@ func main() {
 		if enablePushgateway {
 			pushURL := os.Getenv("PROMETHEUS_PUSHGATEWAY_URL")
 			if pushURL == "" {
-				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true")
+				fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true")
 			}
 			jobName := os.Getenv("JOB_NAME")
 			if jobName == "" {
@@ -59,7 +69,7 @@ func main() {
 			}
 			metricsServer := prometheus.NewMetricsServer(port)
 			if err := metricsServer.Start(); err != nil {
-				log.Fatalf("failed to start metrics server: %v", err)
+				fatal("failed to start metrics server", "err", err)
 			}
 			metricsSink.AddWriter(metricsServer)
 		}
@@ -70,21 +80,21 @@ func main() {
 	if enablePostgres {
 		dbConfig, err := config.GetDatabaseConfig()
 		if err != nil {
-			log.Fatalf("database configuration error: %v", err)
+			fatal("database configuration error", "err", err)
 		}
 		if dbConfig == "" {
-			log.Fatal("POSTGRES_URL or POSTGRES_HOST is required when ENABLE_POSTGRES is true")
+			fatal("POSTGRES_URL or POSTGRES_HOST is required when ENABLE_POSTGRES is true")
 		}
 		pgWriter, err := postgres.NewPostgresWriter(ctx, dbConfig)
 		if err != nil {
-			log.Fatalf("failed to initialize postgres: %v", err)
+			fatal("failed to initialize postgres", "err", err)
 		}
 		metricsSink.AddWriter(pgWriter)
 	}
 
 	// Require at least one writer
 	if metricsSink.WriterCount() == 0 {
-		log.Fatal("no writers configured - set ENABLE_PROMETHEUS_PUSHGATEWAY, ENABLE_PROMETHEUS_METRICS, and/or ENABLE_POSTGRES")
+		fatal("no writers configured - set ENABLE_PROMETHEUS_PUSHGATEWAY, ENABLE_PROMETHEUS_METRICS, and/or ENABLE_POSTGRES")
 	}
 
 	// Choose operational mode
@@ -97,27 +107,27 @@ func main() {
 
 func listenAndPushWithSink(ctx context.Context, metricsSink *sink.MetricsSink) {
 	logUDP, _ := strconv.ParseBool(os.Getenv("LOG_UDP"))
-	log.Printf("starting UDP listener mode")
+	slog.Info("starting UDP listener mode")
 
 	if err := listen(ctx, func(b []byte, addr *net.UDPAddr) error {
 		if logUDP {
-			log.Printf("UDP in: %s", string(b))
+			slog.Info("received UDP packet", "payload", string(b))
 		}
 
 		report, err := tempestudp.ParseReport(b)
 		if err != nil {
-			log.Printf("error parsing report from %s: %s", addr, err)
+			slog.Warn("error parsing report", "addr", addr, "err", err)
 			return nil
 		}
 
 		// Send report to all configured writers
 		if err := metricsSink.SendReport(ctx, report); err != nil {
-			log.Printf("error sending report: %v", err)
+			slog.Error("error sending report", "err", err)
 		}
 
 		return nil
 	}); err != nil {
-		log.Fatal(err)
+		fatal("UDP listener error", "err", err)
 	}
 }
 
@@ -132,7 +142,7 @@ func listen(ctx context.Context, rx func([]byte, *net.UDPAddr) error) error {
 		return err
 	}
 	defer sock.Close()
-	log.Printf("listening on UDP :50222")
+	slog.Info("listening on UDP", "port", 50222)
 
 	readErr := make(chan error, 1)
 
@@ -168,17 +178,17 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 	client := tempestapi.NewClient(token)
 	stations, err := client.ListStations(ctx)
 	if err != nil {
-		log.Fatalf("error listing stations: %v", err)
+		fatal("error listing stations", "err", err)
 	}
 
 	if len(stations) == 0 {
-		log.Fatalf("no stations found")
+		fatal("no stations found")
 	}
 
-	log.Printf("found stations:")
+	slog.Info("found stations", "count", len(stations))
 	var startAt time.Time
 	for _, station := range stations {
-		log.Printf("  - %s (station #%d)", station.Name, station.StationID)
+		slog.Info("station", "name", station.Name, "station_id", station.StationID)
 		if startAt.IsZero() || startAt.Before(station.CreatedAt) {
 			startAt = station.CreatedAt
 		}
@@ -196,10 +206,10 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 			next = cur.AddDate(0, 0, 1)
 
 			for _, station := range stations {
-				log.Printf("fetching %s starting %s", station.Name, cur.Format(time.RFC3339))
+				slog.Info("fetching observations", "station", station.Name, "start", cur.Format(time.RFC3339))
 				stationMetrics, err := client.GetObservations(ctx, station, cur, next)
 				if err != nil {
-					log.Fatalf("error fetching %#v for %d-%d: %v", station, cur.Unix(), next.Unix(), err)
+					fatal("error fetching observations", "station", station.Name, "from", cur.Unix(), "to", next.Unix(), "err", err)
 				}
 				metrics = append(metrics, stationMetrics...)
 			}
@@ -210,22 +220,22 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 		}
 
 		// Send to sink (Postgres)
-		log.Printf("sending %d metrics to sink", len(metrics))
+		slog.Info("sending metrics to sink", "count", len(metrics))
 		if err := metricsSink.SendMetrics(ctx, metrics); err != nil {
-			log.Printf("error sending metrics: %v", err)
+			slog.Error("error sending metrics", "err", err)
 		}
 
 		// Optionally write to .gz files
 		if keepFiles {
 			filename := fmt.Sprintf("tempest_%03d.txt.gz", fileNum)
 			if err := writeMetricsToFile(filename, metrics); err != nil {
-				log.Fatalf("error writing file: %v", err)
+				fatal("error writing file", "err", err)
 			}
 			fileNum++
 		}
 	}
 
-	log.Printf("export complete")
+	slog.Info("export complete")
 }
 
 func writeMetricsToFile(filename string, metrics []promclient.Metric) error {
@@ -239,7 +249,7 @@ func writeMetricsToFile(filename string, metrics []promclient.Metric) error {
 		return fmt.Errorf("gather metrics: %w", err)
 	}
 
-	log.Printf("writing %s", filename)
+	slog.Info("writing metrics file", "filename", filename)
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)


### PR DESCRIPTION
## Summary

Closes #39.

Migrates the project's logging from Go's basic `log`/`fmt` output to structured `log/slog`, and adds configurable level and format.

## Changes

- **New `internal/logging` package** — `Init()` builds a logger from the environment and installs it as `slog.Default`:
  - `LOG_LEVEL` = `debug` | `info` | `warn` | `error` (default `info`)
  - `LOG_FORMAT` = `text` | `json` (default `text`)
  - Unrecognized values fall back safely. `New`/`ParseLevel` are exported and unit-tested.
- **`main.go`** — calls `logging.Init()` at startup; a `fatal()` helper (`slog.Error` + `os.Exit(1)`) replaces the old `log.Fatal*` calls; every `log.Printf` becomes `slog.Info/Warn/Error` with key-value attributes.
- **`internal/{sink,prometheus,postgres,tempestapi}`** — dropped the bare `log` import for `log/slog`; messages converted to structured attributes (e.g. `slog.Error("postgres: failed to write rows", "table", …, "err", err)`).
- **`internal/tempestapi`** — the library-level `log.Fatalf("unhandled report type")` now **returns an error** instead of killing the whole process, which is the correct behavior for a library call path.
- **README** — documents `LOG_LEVEL` / `LOG_FORMAT`.

No bare `log` or logging `fmt` imports remain in non-test code.

## Test categories (Go conventions)

1. **Happy path** — `TestNew_ReturnsLogger` (New/Init non-nil, default installed).
2. **Table-driven** — `TestParseLevel_Table`.
3. **Edge/boundary** — `TestParseLevel_WhitespaceAndFiltering` (whitespace/case + below-threshold filtering).
4. **Error handling / fallback** — `TestNew_UnknownInputsFallBackSafely` (the public API has no error returns; this locks the safe-fallback contract).
5. **Concurrency/race** — `TestConcurrentConstruction` (green under `-race`).
6. **Integration** — `TestFormats_Integration` (json emits valid JSON, text emits `key=value`).
7. **Benchmark + Fuzz** — `BenchmarkParseLevel`, `FuzzParseLevel`.

## Verification

`go build ./... && go vet ./... && go test ./...` — all green (also `-race` and a short fuzz run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)