### PR TITLE
feat: HTTP JSON API server for tempest-display (/api/station, /api/observation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ The exporter can optionally write metrics to PostgreSQL in addition to (or inste
 
 When configured, the exporter automatically creates and maintains typed tables for observations, rapid wind data, hub status, and events.
 
+### Display JSON API (Optional)
+
+In UDP mode the exporter can expose a small read-only JSON API that serves the
+latest observation and station metadata to the [`tempest-display`](https://github.com/jacaudi/tempest-display)
+SPA. Enable it with:
+
+* `ENABLE_API`: set to `true` to start the API server
+* `API_PORT`: listen port (default `8080`)
+
+Endpoints:
+
+* `GET /api/observation` — latest `obs_st` observation as JSON (wind, pressure,
+  temperature, humidity, illuminance, UV, solar, rain, lightning, battery, plus
+  derived dew point, wet-bulb, heat index, wind chill and "feels like"). Returns
+  `503` until the first report arrives.
+* `GET /api/station` — station metadata. The live `serial_number` and
+  `firmware_revision` come from incoming reports; the descriptive fields are
+  supplied via optional environment variables: `STATION_ID`, `STATION_NAME`,
+  `STATION_LATITUDE`, `STATION_LONGITUDE`, `STATION_ELEVATION`,
+  `STATION_TIMEZONE`, `DEVICE_ID`.
+* `GET /health` — liveness probe.
+
 See `CLAUDE.md` for detailed configuration options and Docker Compose examples
 
 ## Source Credit

--- a/internal/apiserver/calc.go
+++ b/internal/apiserver/calc.go
@@ -1,0 +1,93 @@
+package apiserver
+
+import "math"
+
+// This file holds the derived meteorological quantities that the tempest-display
+// SPA expects but that are not carried directly in the obs_st report: dew point,
+// heat index, wind chill, and a combined "feels like". All inputs and outputs
+// are in the units the obs_st report uses (°C, %, m/s).
+
+// cToF converts Celsius to Fahrenheit.
+func cToF(c float64) float64 { return c*9.0/5.0 + 32.0 }
+
+// fToC converts Fahrenheit to Celsius.
+func fToC(f float64) float64 { return (f - 32.0) * 5.0 / 9.0 }
+
+// mpsToMph converts metres per second to miles per hour.
+func mpsToMph(mps float64) float64 { return mps * 2.2369362920544 }
+
+// DewPointC returns the dew point in °C for the given air temperature (°C) and
+// relative humidity (%), using the Magnus-Tetens approximation. Relative
+// humidity is clamped to [1, 100] to keep the logarithm finite.
+func DewPointC(tempC, rh float64) float64 {
+	if rh < 1 {
+		rh = 1
+	}
+	if rh > 100 {
+		rh = 100
+	}
+	const a, b = 17.62, 243.12
+	gamma := math.Log(rh/100.0) + a*tempC/(b+tempC)
+	return b * gamma / (a - gamma)
+}
+
+// HeatIndexC returns the NWS heat index in °C for the given air temperature (°C)
+// and relative humidity (%). The heat index is only meaningful in warm
+// conditions; below 80 °F (~26.7 °C) the air temperature is returned unchanged.
+func HeatIndexC(tempC, rh float64) float64 {
+	tf := cToF(tempC)
+	if tf < 80 {
+		return tempC
+	}
+	r := rh
+	hi := -42.379 + 2.04901523*tf + 10.14333127*r - 0.22475541*tf*r -
+		6.83783e-3*tf*tf - 5.481717e-2*r*r + 1.22874e-3*tf*tf*r +
+		8.5282e-4*tf*r*r - 1.99e-6*tf*tf*r*r
+
+	// Rothfusz adjustments at the humidity extremes.
+	switch {
+	case r < 13 && tf >= 80 && tf <= 112:
+		hi -= ((13 - r) / 4) * math.Sqrt((17-math.Abs(tf-95))/17)
+	case r > 85 && tf >= 80 && tf <= 87:
+		hi += ((r - 85) / 10) * ((87 - tf) / 5)
+	}
+	return fToC(hi)
+}
+
+// WindChillC returns the NWS wind-chill temperature in °C for the given air
+// temperature (°C) and wind speed (m/s). Wind chill is only defined for cold,
+// breezy conditions (≤ 50 °F and wind > 3 mph); outside that range the air
+// temperature is returned unchanged.
+func WindChillC(tempC, windMps float64) float64 {
+	tf := cToF(tempC)
+	mph := mpsToMph(windMps)
+	if tf > 50 || mph <= 3 {
+		return tempC
+	}
+	v := math.Pow(mph, 0.16)
+	wc := 35.74 + 0.6215*tf - 35.75*v + 0.4275*tf*v
+	return fToC(wc)
+}
+
+// FeelsLikeC returns the apparent temperature in °C: the heat index in hot
+// conditions, the wind chill in cold/breezy conditions, and otherwise the plain
+// air temperature.
+func FeelsLikeC(tempC, rh, windMps float64) float64 {
+	tf := cToF(tempC)
+	switch {
+	case tf >= 80:
+		return HeatIndexC(tempC, rh)
+	case tf <= 50 && mpsToMph(windMps) > 3:
+		return WindChillC(tempC, windMps)
+	default:
+		return tempC
+	}
+}
+
+// round1 rounds to one decimal place for tidy JSON output of derived values.
+func round1(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	return math.Round(v*10) / 10
+}

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -1,0 +1,295 @@
+// Package apiserver exposes a small read-only HTTP JSON API that serves the
+// latest Tempest observation and station metadata to the tempest-display SPA
+// (see jacaudi/tempest-display and issue #35).
+//
+// It participates in the existing UDP pipeline by implementing
+// sink.MetricsWriter: every parsed report is fed to WriteReport, where the most
+// recent obs_st observation is cached in memory and then served as JSON.
+//
+// Scope: this implements the two core endpoints called out in the issue title —
+// GET /api/station and GET /api/observation — plus a GET /health probe. The
+// remaining endpoints from the issue (/api/status, /api/forecast, /api/almanac,
+// and the /ws relay) depend on external data sources (NWS API, Postgres history)
+// and are intentionally left for follow-up work.
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"tempestwx-utilities/internal/tempestudp"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// StationMeta is the static station metadata served at GET /api/station. The
+// live fields (SerialNumber, FirmwareRevision) are filled in from incoming
+// reports; the descriptive fields come from configuration because they are not
+// present in the UDP broadcast.
+type StationMeta struct {
+	StationID        int     `json:"station_id,omitempty"`
+	Name             string  `json:"name,omitempty"`
+	Latitude         float64 `json:"latitude,omitempty"`
+	Longitude        float64 `json:"longitude,omitempty"`
+	Elevation        float64 `json:"elevation,omitempty"`
+	Timezone         string  `json:"timezone,omitempty"`
+	FirmwareRevision string  `json:"firmware_revision,omitempty"`
+	SerialNumber     string  `json:"serial_number,omitempty"`
+	DeviceID         int     `json:"device_id,omitempty"`
+}
+
+// CurrentObservation is the latest observation served at GET /api/observation.
+// Field names match the shape the tempest-display SPA consumes.
+type CurrentObservation struct {
+	Timestamp                  int64   `json:"timestamp"`
+	WindLull                   float64 `json:"windLull"`
+	WindAvg                    float64 `json:"windAvg"`
+	WindGust                   float64 `json:"windGust"`
+	WindDirection              float64 `json:"windDirection"`
+	WindSampleInterval         float64 `json:"windSampleInterval"`
+	StationPressure            float64 `json:"stationPressure"`
+	AirTemperature             float64 `json:"airTemperature"`
+	RelativeHumidity           float64 `json:"relativeHumidity"`
+	Illuminance                float64 `json:"illuminance"`
+	UVIndex                    float64 `json:"uvIndex"`
+	SolarRadiation             float64 `json:"solarRadiation"`
+	RainAccumulated            float64 `json:"rainAccumulated"`
+	PrecipitationType          int     `json:"precipitationType"`
+	LightningStrikeAvgDistance float64 `json:"lightningStrikeAvgDistance"`
+	LightningStrikeCount       float64 `json:"lightningStrikeCount"`
+	Battery                    float64 `json:"battery"`
+	ReportInterval             float64 `json:"reportInterval"`
+	FeelsLike                  float64 `json:"feelsLike"`
+	DewPoint                   float64 `json:"dewPoint"`
+	WetBulbTemperature         float64 `json:"wetBulbTemperature"`
+	HeatIndex                  float64 `json:"heatIndex"`
+	WindChill                  float64 `json:"windChill"`
+}
+
+// Server is an HTTP JSON API server that caches the latest observation and
+// serves it, alongside station metadata, to the display SPA. It implements
+// sink.MetricsWriter.
+type Server struct {
+	port    string
+	server  *http.Server
+	handler http.Handler
+	wg      sync.WaitGroup
+
+	mu       sync.RWMutex
+	meta     StationMeta
+	obs      *CurrentObservation
+	serial   string
+	firmware int
+}
+
+// NewServer constructs an API server listening on the given port, seeded with
+// the supplied static station metadata.
+func NewServer(port string, meta StationMeta) *Server {
+	s := &Server{port: port, meta: meta}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/station", s.handleStation)
+	mux.HandleFunc("/api/observation", s.handleObservation)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+	s.handler = mux
+
+	s.server = &http.Server{
+		Addr:         ":" + port,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	return s
+}
+
+// StationMetaFromEnv builds StationMeta from optional environment variables.
+// All fields are optional; unset values are simply omitted from the response.
+//
+//	STATION_ID, STATION_NAME, STATION_LATITUDE, STATION_LONGITUDE,
+//	STATION_ELEVATION, STATION_TIMEZONE, DEVICE_ID
+func StationMetaFromEnv() StationMeta {
+	atoi := func(key string) int {
+		n, _ := strconv.Atoi(os.Getenv(key))
+		return n
+	}
+	atof := func(key string) float64 {
+		f, _ := strconv.ParseFloat(os.Getenv(key), 64)
+		return f
+	}
+	return StationMeta{
+		StationID: atoi("STATION_ID"),
+		Name:      os.Getenv("STATION_NAME"),
+		Latitude:  atof("STATION_LATITUDE"),
+		Longitude: atof("STATION_LONGITUDE"),
+		Elevation: atof("STATION_ELEVATION"),
+		Timezone:  os.Getenv("STATION_TIMEZONE"),
+		DeviceID:  atoi("DEVICE_ID"),
+	}
+}
+
+// Handler exposes the underlying HTTP handler for testing without binding a
+// TCP port.
+func (s *Server) Handler() http.Handler { return s.handler }
+
+// Start begins serving in a background goroutine.
+func (s *Server) Start() error {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		slog.Info("api: starting HTTP server", "port", s.port)
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("api: server error", "err", err)
+		}
+	}()
+	return nil
+}
+
+// WriteReport caches state from the latest obs_st report. Other report types are
+// ignored (they carry no data these two endpoints serve).
+func (s *Server) WriteReport(_ context.Context, report tempestudp.Report) error {
+	obsReport, ok := report.(*tempestudp.TempestObservationReport)
+	if !ok {
+		return nil
+	}
+	obs, ok := observationFromReport(obsReport)
+	if !ok {
+		return nil
+	}
+
+	s.mu.Lock()
+	s.obs = obs
+	if obsReport.SerialNumber != "" {
+		s.serial = obsReport.SerialNumber
+	}
+	if obsReport.FirmwareRevision != 0 {
+		s.firmware = obsReport.FirmwareRevision
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// WriteMetrics is a no-op: the API server serves typed observations, not
+// Prometheus metrics.
+func (s *Server) WriteMetrics(_ context.Context, _ []prometheus.Metric) error { return nil }
+
+// Flush is a no-op.
+func (s *Server) Flush(_ context.Context) error { return nil }
+
+// Close shuts the HTTP server down gracefully.
+func (s *Server) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		slog.Error("api: shutdown error", "err", err)
+		return err
+	}
+	s.wg.Wait()
+	slog.Info("api: server closed")
+	return nil
+}
+
+func (s *Server) handleStation(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	meta := s.meta
+	meta.SerialNumber = s.serial
+	if s.firmware != 0 {
+		meta.FirmwareRevision = strconv.Itoa(s.firmware)
+	}
+	s.mu.RUnlock()
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (s *Server) handleObservation(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	obs := s.obs
+	s.mu.RUnlock()
+
+	if obs == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error": "no observation received yet",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, obs)
+}
+
+// observationFromReport converts the most recent obs row of an obs_st report
+// into a CurrentObservation, computing the derived temperature quantities. It
+// returns false when the report carries no usable observation row.
+func observationFromReport(r *tempestudp.TempestObservationReport) (*CurrentObservation, bool) {
+	if len(r.Obs) == 0 {
+		return nil, false
+	}
+	ob := r.Obs[len(r.Obs)-1]
+	if len(ob) < 13 {
+		return nil, false
+	}
+
+	obs := &CurrentObservation{
+		Timestamp:          int64(ob[0]),
+		WindLull:           ob[1],
+		WindAvg:            ob[2],
+		WindGust:           ob[3],
+		WindDirection:      ob[4],
+		WindSampleInterval: ob[5],
+		StationPressure:    ob[6],
+		AirTemperature:     ob[7],
+		RelativeHumidity:   ob[8],
+		Illuminance:        ob[9],
+		UVIndex:            ob[10],
+		SolarRadiation:     ob[11],
+		RainAccumulated:    ob[12],
+	}
+	if len(ob) >= 14 {
+		obs.PrecipitationType = int(ob[13])
+	}
+	if len(ob) >= 16 {
+		obs.LightningStrikeAvgDistance = ob[14]
+		obs.LightningStrikeCount = ob[15]
+	}
+	if len(ob) >= 17 {
+		obs.Battery = ob[16]
+	}
+	if len(ob) >= 18 {
+		obs.ReportInterval = ob[17]
+	}
+
+	temp, rh, pressure, wind := ob[7], ob[8], ob[6], ob[2]
+	obs.DewPoint = round1(DewPointC(temp, rh))
+	obs.WetBulbTemperature = round1(safeWetBulbC(temp, rh, pressure))
+	obs.HeatIndex = round1(HeatIndexC(temp, rh))
+	obs.WindChill = round1(WindChillC(temp, wind))
+	obs.FeelsLike = round1(FeelsLikeC(temp, rh, wind))
+	return obs, true
+}
+
+// safeWetBulbC computes the wet-bulb temperature without ever panicking. The
+// upstream iterative solver can panic ("failed to converge") on physically
+// implausible inputs — e.g. a corrupt UDP packet carrying garbage floats. Since
+// WriteReport runs on a sink goroutine, an unrecovered panic there would take
+// the whole process down, so on failure we fall back to the air temperature.
+func safeWetBulbC(tempC, rh, pressureMb float64) (out float64) {
+	defer func() {
+		if recover() != nil {
+			out = tempC
+		}
+	}()
+	return tempestudp.WetBulbTemperatureC(tempC, rh, pressureMb)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("api: failed to encode response", "err", err)
+	}
+}

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -1,0 +1,235 @@
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"tempestwx-utilities/internal/tempestudp"
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests are organized by the seven Go test categories:
+//   1. Happy path       2. Table-driven     3. Edge/boundary
+//   4. Error handling    5. Concurrency/race 6. Integration
+//   7. Benchmark (+ Fuzz)
+// ─────────────────────────────────────────────────────────────────────────
+
+// A representative obs_st row (18 fields) matching the WeatherFlow field order.
+func sampleReport() *tempestudp.TempestObservationReport {
+	return &tempestudp.TempestObservationReport{
+		Type:             "obs_st",
+		SerialNumber:     "ST-00012345",
+		FirmwareRevision: 143,
+		Obs: [][]float64{{
+			1708560000, // 0  timestamp
+			0.5,        // 1  wind lull
+			2.1,        // 2  wind avg
+			4.2,        // 3  wind gust
+			270,        // 4  wind direction
+			3,          // 5  wind sample interval
+			1013.2,     // 6  station pressure MB
+			21.5,       // 7  air temperature C
+			55,         // 8  relative humidity %
+			12000,      // 9  illuminance lux
+			4,          // 10 UV index
+			450,        // 11 solar radiation W/m^2
+			0.1,        // 12 rain over previous minute mm
+			1,          // 13 precipitation type
+			8,          // 14 lightning avg distance km
+			2,          // 15 lightning strike count
+			2.62,       // 16 battery V
+			1,          // 17 report interval min
+		}},
+	}
+}
+
+// Category 1 — Happy path: after a report is written, /api/observation returns
+// 200 with the parsed obs_st fields.
+func TestObservationHappyPath(t *testing.T) {
+	s := NewServer("0", StationMeta{})
+	if err := s.WriteReport(context.Background(), sampleReport()); err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/observation", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var obs CurrentObservation
+	if err := json.Unmarshal(rec.Body.Bytes(), &obs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if obs.Timestamp != 1708560000 || obs.AirTemperature != 21.5 || obs.WindGust != 4.2 {
+		t.Errorf("unexpected core fields: %+v", obs)
+	}
+	if obs.PrecipitationType != 1 || obs.Battery != 2.62 || obs.ReportInterval != 1 {
+		t.Errorf("unexpected tail fields: %+v", obs)
+	}
+	if obs.DewPoint == 0 || obs.WetBulbTemperature == 0 {
+		t.Errorf("derived temps not populated: %+v", obs)
+	}
+}
+
+// Category 2 — Table-driven: the derived meteorological helpers against known
+// reference points (within tolerance).
+func TestDerivedCalcsTable(t *testing.T) {
+	approx := func(got, want, tol float64) bool { return math.Abs(got-want) <= tol }
+	cases := []struct {
+		name           string
+		got, want, tol float64
+	}{
+		{"dewpoint 21.5C/55%", DewPointC(21.5, 55), 12.0, 0.5},
+		{"dewpoint saturated", DewPointC(20, 100), 20.0, 0.2},
+		{"heatindex mild is passthrough", HeatIndexC(20, 50), 20.0, 0.01},
+		{"heatindex hot 35C/60%", HeatIndexC(35, 60), 45.0, 3.0},
+		{"windchill warm is passthrough", WindChillC(20, 5), 20.0, 0.01},
+		{"windchill cold -5C/10m/s", WindChillC(-5, 10), -15.0, 3.0},
+		{"feelslike temperate passthrough", FeelsLikeC(18, 50, 1), 18.0, 0.01},
+	}
+	for _, tc := range cases {
+		if !approx(tc.got, tc.want, tc.tol) {
+			t.Errorf("%s: got %.2f, want %.2f±%.2f", tc.name, tc.got, tc.want, tc.tol)
+		}
+	}
+}
+
+// Category 3 — Edge/boundary: no report yet → 503; station reflects live serial
+// and firmware once a report lands; short obs rows are rejected.
+func TestEdgeCases(t *testing.T) {
+	s := NewServer("0", StationMeta{Name: "Shoreline", Latitude: 47.75})
+
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/observation", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("observation before any report: status = %d, want 503", rec.Code)
+	}
+
+	// Station is served even before a report, from static config.
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/station", nil))
+	var meta StationMeta
+	_ = json.Unmarshal(rec.Body.Bytes(), &meta)
+	if meta.Name != "Shoreline" || meta.SerialNumber != "" {
+		t.Errorf("unexpected pre-report station: %+v", meta)
+	}
+
+	// After a report, serial + firmware appear.
+	_ = s.WriteReport(context.Background(), sampleReport())
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/station", nil))
+	_ = json.Unmarshal(rec.Body.Bytes(), &meta)
+	if meta.SerialNumber != "ST-00012345" || meta.FirmwareRevision != "143" {
+		t.Errorf("station missing live fields: %+v", meta)
+	}
+
+	// A too-short obs row must not overwrite state / must be rejected.
+	if _, ok := observationFromReport(&tempestudp.TempestObservationReport{Obs: [][]float64{{1, 2, 3}}}); ok {
+		t.Error("short obs row should be rejected")
+	}
+	if _, ok := observationFromReport(&tempestudp.TempestObservationReport{Obs: nil}); ok {
+		t.Error("empty obs should be rejected")
+	}
+}
+
+// Category 4 — Error handling: non-obs reports are ignored (no panic, no state
+// change) and WriteMetrics/Flush are no-ops.
+func TestNonObservationReportsIgnored(t *testing.T) {
+	s := NewServer("0", StationMeta{})
+	if err := s.WriteReport(context.Background(), &tempestudp.RapidWindReport{Type: "rapid_wind"}); err != nil {
+		t.Fatalf("WriteReport(rapid_wind): %v", err)
+	}
+	if err := s.WriteMetrics(context.Background(), nil); err != nil {
+		t.Fatalf("WriteMetrics: %v", err)
+	}
+	if err := s.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/observation", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("rapid_wind should not populate observation: status = %d", rec.Code)
+	}
+}
+
+// Category 5 — Concurrency/race: concurrent writers and readers under -race.
+func TestConcurrentReadWrite(t *testing.T) {
+	s := NewServer("0", StationMeta{})
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = s.WriteReport(context.Background(), sampleReport()) }()
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/observation", nil))
+		}()
+	}
+	wg.Wait()
+}
+
+// Category 6 — Integration: over a real httptest server, /health and the two API
+// endpoints respond through the full HTTP stack.
+func TestIntegrationEndpoints(t *testing.T) {
+	s := NewServer("0", StationMeta{Name: "Shoreline"})
+	_ = s.WriteReport(context.Background(), sampleReport())
+
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		path string
+		want int
+	}{
+		{"/health", http.StatusOK},
+		{"/api/station", http.StatusOK},
+		{"/api/observation", http.StatusOK},
+	} {
+		resp, err := http.Get(srv.URL + tc.path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", tc.path, err)
+		}
+		if resp.StatusCode != tc.want {
+			t.Errorf("GET %s: status = %d, want %d", tc.path, resp.StatusCode, tc.want)
+		}
+		resp.Body.Close()
+	}
+}
+
+// Category 7a — Benchmark: report-to-cache conversion throughput.
+func BenchmarkWriteReport(b *testing.B) {
+	s := NewServer("0", StationMeta{})
+	r := sampleReport()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.WriteReport(context.Background(), r)
+	}
+}
+
+// Category 7b — Fuzz: observationFromReport must never panic on arbitrary obs
+// rows, and derived values must be finite when it succeeds.
+func FuzzObservationFromReport(f *testing.F) {
+	f.Add(21.5, 55.0, 1013.2, 2.1)
+	f.Add(-40.0, 0.0, 900.0, 30.0)
+	f.Add(50.0, 100.0, 1100.0, 0.0)
+	f.Fuzz(func(t *testing.T, temp, rh, pressure, wind float64) {
+		r := &tempestudp.TempestObservationReport{
+			Obs: [][]float64{{1708560000, 0, wind, 0, 0, 0, pressure, temp, rh, 0, 0, 0, 0}},
+		}
+		obs, ok := observationFromReport(r)
+		if !ok {
+			return
+		}
+		for _, v := range []float64{obs.DewPoint, obs.HeatIndex, obs.WindChill, obs.FeelsLike, obs.WetBulbTemperature} {
+			if math.IsInf(v, 0) || math.IsNaN(v) {
+				t.Errorf("non-finite derived value for temp=%v rh=%v p=%v wind=%v: %v", temp, rh, pressure, wind, v)
+			}
+		}
+	})
+}

--- a/internal/apiserver/testdata/fuzz/FuzzObservationFromReport/64487790b9f03eb1
+++ b/internal/apiserver/testdata/fuzz/FuzzObservationFromReport/64487790b9f03eb1
@@ -1,0 +1,5 @@
+go test fuzz v1
+float64(-234)
+float64(79)
+float64(900)
+float64(240)

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"tempestwx-utilities/internal/apiserver"
 	"tempestwx-utilities/internal/config"
 	"tempestwx-utilities/internal/postgres"
 	"tempestwx-utilities/internal/prometheus"
@@ -62,6 +63,20 @@ func main() {
 				log.Fatalf("failed to start metrics server: %v", err)
 			}
 			metricsSink.AddWriter(metricsServer)
+		}
+
+		// Configure the display JSON API server (/api/station, /api/observation)
+		enableAPI, _ := strconv.ParseBool(os.Getenv("ENABLE_API"))
+		if enableAPI {
+			port := os.Getenv("API_PORT")
+			if port == "" {
+				port = "8080"
+			}
+			apiServer := apiserver.NewServer(port, apiserver.StationMetaFromEnv())
+			if err := apiServer.Start(); err != nil {
+				log.Fatalf("failed to start API server: %v", err)
+			}
+			metricsSink.AddWriter(apiServer)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes #35 (scoped to the two endpoints in the issue title).

Adds a small read-only HTTP JSON API — a new `internal/apiserver` package — that backs the [`tempest-display`](https://github.com/jacaudi/tempest-display) SPA. It plugs into the existing UDP pipeline by implementing `sink.MetricsWriter`: each parsed report flows through `WriteReport`, where the latest `obs_st` observation is cached in memory and served as JSON. No new dependencies.

## Endpoints

- **`GET /api/observation`** — the latest `obs_st` observation. All directly-parsed fields (wind lull/avg/gust/direction, sample interval, station pressure, air temperature, humidity, illuminance, UV, solar radiation, rain, precipitation type, lightning distance/count, battery, report interval) plus the derived quantities the display needs: `dewPoint`, `wetBulbTemperature`, `heatIndex`, `windChill`, `feelsLike`. Returns `503` until the first report arrives.
- **`GET /api/station`** — station metadata. Live `serial_number` and `firmware_revision` come from incoming reports; the descriptive fields (`station_id`, `name`, `latitude`, `longitude`, `elevation`, `timezone`, `device_id`) are supplied via optional env vars, since the UDP broadcast doesn't carry them.
- **`GET /health`** — liveness probe.

## Wiring

Enabled in UDP mode via `ENABLE_API` (+ `API_PORT`, default `8080`) and registered as a sink writer alongside the Prometheus writers. README documents the new variables and endpoints.

## Robustness

The upstream wet-bulb solver panics (`"failed to converge"`) on physically implausible inputs. Because `WriteReport` runs on a sink goroutine, an unrecovered panic there would kill the whole process, so the wet-bulb call is guarded (falls back to air temperature). A corrupt UDP packet therefore cannot crash the exporter — this exact case is captured by the committed fuzz seed corpus.

## Out of scope (documented)

`/api/status`, `/api/forecast`, `/api/almanac`, and the `/ws` relay depend on external data sources (NWS API, Postgres observation history) and are intentionally left for follow-up, per the issue's "scope to the two endpoints if it balloons" guidance.

## Test categories (Go conventions)

1. **Happy path** — `TestObservationHappyPath`.
2. **Table-driven** — `TestDerivedCalcsTable` (dew point / heat index / wind chill / feels-like vs. reference points).
3. **Edge/boundary** — `TestEdgeCases` (503 before data; live station fields appear after a report; short/empty obs rows rejected).
4. **Error handling** — `TestNonObservationReportsIgnored` (non-obs reports ignored; `WriteMetrics`/`Flush` no-ops).
5. **Concurrency/race** — `TestConcurrentReadWrite` (green under `-race`).
6. **Integration** — `TestIntegrationEndpoints` (httptest server over `/health` + both API endpoints).
7. **Benchmark + Fuzz** — `BenchmarkWriteReport`, `FuzzObservationFromReport` (found and fixed the wet-bulb panic).

## Verification

`go build ./... && go vet ./... && go test ./...` — all green (also `-race` and an 8s fuzz run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)