### PR TITLE
Workstream 0: foundation — lifecycle & review-fix bedrock

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,11 +5,17 @@
 # Documentation
 README.md
 *.md
+docs/
 
 # CI/CD
 .github/
 .gitlab-ci.yml
 .travis.yml
+
+# Local build artifacts / agent tooling
+/tempestwx-utilities
+.superpowers/
+.claude/
 
 # IDE
 .vscode/

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -6,7 +6,19 @@ inputs:
   token:
     description: Github token
     required: true
-    
+  push:
+    description: Whether to push the built image
+    required: false
+    default: "false"
+  latest:
+    description: Also tag the image as latest
+    required: false
+    default: "false"
+  tag-strategy:
+    description: Tag strategy (e.g. latest, semver)
+    required: false
+    default: "latest"
+
 runs:
   using: composite
   steps:
@@ -23,15 +35,15 @@ runs:
         fi
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Login to GitHub Container Registry
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -39,7 +51,7 @@ runs:
 
     - name: Build and push with Bake
       if: github.event_name != 'pull_request'
-      uses: docker/bake-action@v7
+      uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
       env:
         BUILD_DATE: ${{ github.event.head_commit.timestamp }}
         REGISTRY_IMAGE: ghcr.io/${{ github.repository }}

--- a/.github/actions/go-release/action.yml
+++ b/.github/actions/go-release/action.yml
@@ -11,17 +11,17 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: ">=1.20"
+        go-version: "1.24"
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v7
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
         version: "~> v2"
         args: release --clean

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -6,9 +6,9 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: ">=1.20"
+        go-version: "1.24"
 
     - name: Prepare Go modules
       shell: bash

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,12 +8,29 @@ on:
       - reopened
       - synchronize
 
-jobs:        
+permissions:
+  contents: read
+
+jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.24"
+
+      - name: Run actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.24"
+          # actionlint@v1.7.12 requires Go >= 1.25 to build; setup-go@v6 pins
+          # GOTOOLCHAIN=local, so the build Go must satisfy that here. Matches
+          # go.mod's toolchain (go1.26.1).
+          go-version: "1.26"
 
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -14,12 +14,15 @@ on:
       - 'Dockerfile*'
       - 'docker-bake.hcl'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
@@ -27,9 +30,12 @@ jobs:
   release-image:
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build Latest Image
         uses: ./.github/actions/docker

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -6,12 +6,15 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
@@ -19,9 +22,12 @@ jobs:
   release-image:
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build Tagged Image
         uses: ./.github/actions/docker
@@ -34,9 +40,11 @@ jobs:
   release-binaries:
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Release Binaries
         uses: ./.github/actions/go-release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gosec
+    - unused
+    - gocritic

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,14 @@
+---
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: .
+    binary: tempestwx-utilities
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w

--- a/docs/designs/2026-07-17-unified-weather-platform-design.md
+++ b/docs/designs/2026-07-17-unified-weather-platform-design.md
@@ -1,0 +1,804 @@
+# Unified Weather Platform — Design
+
+**Date:** 2026-07-17
+**Status:** Design (Phase 1 of Design → Plan → Cold-Review). No code changes.
+**Repo:** `tempestwx-exporter` (module `tempestwx-utilities`, go 1.24)
+**Author:** senior-Go design pass (non-interactive; open decisions surfaced in-doc, see §17)
+**Revisions:**
+- 2026-07-17 — per user: **O1** radar decode → **Python Py-ART sidecar** (reuse DRAS), **O3** output → **contoured GeoJSON isobands**, **O5** → **the app only ships OTLP signals; trace/log backends are the operator's choice** (not prescribed). Reflected throughout.
+- 2026-07-17 (v2, plan cold-review coherence) — per user: **B1** the legacy Postgres tunables (`POSTGRES_BATCH_SIZE`/`FLUSH_INTERVAL`/`MAX_RETRIES`) are now wired from env, so **C-H2 is resolved for the Postgres path too** (not only carried as a lesson into the SQLite writer); **B2** the map basemap is **OpenStreetMap served via a same-origin Protomaps `.pmtiles` file** (no external tile server, no API key, offline-capable, OSM attribution required) — so the **CSP becomes self-only**; **B3** `/api/almanac` **proxies WeatherFlow** (the §11 "proxy or computed" ambiguity is resolved to proxy). Reflected in §4, §6, §7, §9, §11, §15, §16.
+
+---
+
+## 1. Summary
+
+Evolve `tempestwx-utilities` from a headless UDP/API exporter into a **single-binary weather
+platform**: it keeps ingesting Tempest UDP broadcasts and historical REST data, but now also (1)
+**serves its own embedded React UI**, (2) **overlays NOAA NEXRAD Level 3 radar** decoded
+server-side by an **opt-in Python (Py-ART) sidecar** (reusing the DRAS approach) and served as
+contoured GeoJSON, (3) **defaults to SQLite + Litestream** for storage while keeping PostgreSQL as a
+supported option, (4) ships a **Grafana dashboard for weather enthusiasts**, (5) gets a **prioritized
+UX overhaul** of the absorbed UI, and (6) **exports all telemetry (logs, metrics, traces) over a
+unified OpenTelemetry (OTLP) backbone** — the app ships the signals to a configurable Collector and
+leaves backend storage to the operator — superseding the bespoke Prometheus push/scrape path.
+
+All six workstreams are built **additively on the existing `internal/sink` fan-out seam** and a new
+HTTP surface, and each **fixes or supersedes the CRITICAL/HIGH review findings it touches**. A
+**Workstream 0 (foundation)** lands the cross-cutting lifecycle fixes first, because every later
+workstream depends on correct shutdown, panic isolation, and context handling.
+
+The two source reviews this design is grounded in:
+- Exporter: `docs/review/2026-07-17-code-review-summary.md` (1 CRITICAL, 17 HIGH).
+- UI: `docs/review/2026-07-17-ui-code-review-summary.md` (0 CRITICAL, 8 HIGH).
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- One deployable artifact: Go binary with the UI embedded via `//go:embed`, plus a documented
+  docker-compose for the full stack (app + OTel Collector + Prometheus + Grafana + object storage).
+- Move the WeatherFlow token **server-side** (resolves UI **B-H1** and exporter **F-H1**).
+- Real data in the UI (resolves UI **B-H2**): local observations from the exporter's own DB, forecast/
+  almanac proxied through the backend.
+- Radar overlay from NOAA NEXRAD Level 3, decoded server-side, cached, rendered on a map.
+- SQLite + Litestream as the **default** store; PostgreSQL retained as an option (ratified).
+- Unified OTLP telemetry (ratified): weather readings become OTel metric instruments; ingest, sink
+  writes, and HTTP are traced and logged; a Collector fans out to Prometheus/trace-store/log-store.
+- Fix/supersede the review's CRITICAL/HIGH lifecycle findings (graceful shutdown + drain, RadioStats
+  panic, send-on-closed-channel panics, token-in-URL, dead error checks).
+
+### Non-goals (explicitly out of scope; some are follow-ups in §14/§17)
+- No new auth/user system for the UI (single-tenant appliance assumption).
+- No alerting engine (surfaced as a UX suggestion only — §13).
+- No multi-station clustering / HA of the SQLite node (Litestream is backup/PITR, not clustering).
+- No OAuth flow for WeatherFlow (Personal Access Token via server-side proxy is sufficient).
+- No rewrite of the correct-and-praised pieces (UDP field mapping, wet-bulb math, SQL column mapping,
+  unit conversions, moon-phase geometry).
+
+---
+
+## 3. Ratified decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| R1 | **Telemetry = unified OTLP; the app only *ships* signals.** In-process OTel SDK + OTLP exporter → a configurable Collector endpoint. The app emits metrics+logs+traces over OTLP and stops there; **which backends store them is the operator's choice**, not prescribed here. The example compose includes only what the Grafana deliverable needs (Collector + Prometheus + Grafana); trace/log stores are optional. | Single backbone; supersedes the panic-prone bespoke writers (D-H1/D-H2); avoids over-prescribing infra (KISS/YAGNI). |
+| R2 | **DB = SQLite default + PostgreSQL optional.** New `internal/sqlite` writer; `internal/postgres` retained untouched. | Simplest self-contained default; Postgres stays for users who want it. Additive on the sink seam (No-Wall). |
+| R3 | **Radar = server-side decode via a Python Py-ART sidecar** (reusing DRAS's approach) of NEXRAD Level 3 base reflectivity from `s3://unidata-nexrad-level3`, output as **contoured GeoJSON isobands**; the Go backend proxies + caches it. | Reuses DRAS's proven server-side Python radar decode (no risky hand-written Go NIDS decoder); keeps S3/decode off the browser and shared-cached. Radar is an **opt-in, separable sidecar**, so the core exporter stays a single static Go binary when radar is disabled — see §9, decisions O1/O3. |
+
+---
+
+## 4. Current-state grounding (key facts, with finding IDs)
+
+From the **exporter review**:
+- **C-1 (CRITICAL):** `report.go:263-264` indexes `RadioStats[1]/[2]` with no length guard → remote
+  panic/DoS from any LAN host sending a short `hub_status` packet.
+- **A-H1 (HIGH):** `main.go:29` traps only SIGINT, not SIGTERM → `docker stop`/k8s never trigger the
+  graceful path → buffered DB rows lost.
+- **A-H2 (HIGH):** gzip-only API export mode unreachable (writer-count invariant enforced in all modes).
+- **A-H3 / D-H2 (HIGH):** `MetricsServer.Start()` swallows bind errors in a goroutine, always returns
+  nil → main's error check is dead code; `/metrics` can be silently dead.
+- **C-H1 (HIGH):** Postgres flush inserts derive their context from the (likely-cancelled) constructor
+  ctx; the `ctx.Done()` worker branch flushes only the local slice, not the 1000-deep channel → data
+  loss on shutdown.
+- **C-H2 (HIGH):** `POSTGRES_BATCH_SIZE/FLUSH_INTERVAL/MAX_RETRIES` documented but hardcoded/inert. **(v2/B1: now wired from env in WS0 — see §6 — so C-H2 is fixed for the legacy Postgres path, not only avoided in the new SQLite writer.)**
+- **C-H3 / D-H1 (HIGH):** send-on-closed-channel + double-close panics in **both** postgres and
+  prometheus writers (no `sync.Once`, no `done` gate; `default:` does not protect a closed-channel send).
+- **F-H1..H4 (HIGH):** API client — token in URL query string (leaks to logs and into `*url.Error`),
+  no status-code check, no request timeout, `log.Fatalf` inside a library method.
+- **G-H1..H3 (HIGH):** broken Docker action input, stale README env vars, no workflow `permissions:`.
+- **B-HIGH:** `database.go:52` builds the Postgres DSN with raw `fmt.Sprintf` (no credential escaping);
+  schema DDL effectively untested; no migration path.
+- **Positives to preserve:** UDP field-index mapping (Review E), wet-bulb Bolton math, all four SQL
+  column mappings, UUIDv7-once + `ON CONFLICT DO NOTHING` idempotency, static Chainguard non-root image.
+
+From the **UI review** (`tempest-display`, React 19 + TS + Vite + 63-line Go static server):
+- **B-H1 (HIGH):** commented live design embeds the WeatherFlow PAT in the frontend (`?token=`), no
+  backend proxy exists.
+- **B-H2 (HIGH):** the entire API client returns **stub data**; no real data path.
+- **A-H1..H4 (HIGH):** no error boundary; loading/error/Retry CSS referenced but never defined; zero
+  media queries (non-responsive); no `prefers-reduced-motion`.
+- **E-H1 (HIGH):** Go static server has no HTTP timeouts (Slowloris).
+- **F-H1 (HIGH):** UI container runs as root.
+- **MEDIUM:** dead SettingsPanel Station-ID/Token inputs; no dialog semantics; hemisphere `°N/°W`
+  bug; forecast weekday-across-year-boundary bug; theme-var leak; no focus-visible.
+- **Positives to preserve:** all 10 unit conversions correct; moon-phase geometry correct; embed-FS
+  path-traversal safety; strict TS; wind compass shortest-arc.
+
+---
+
+## 5. Target architecture
+
+```
+                         ┌──────────────────────────────────────────────────────────┐
+                         │  tempestwx-utilities  (single Go binary)                   │
+                         │                                                            │
+   Tempest UDP :50222 ─► │  udp listener ─┐                                           │
+   WeatherFlow REST ───► │  api client ───┤                                           │
+                         │                ▼                                           │
+                         │           internal/sink  (fan-out seam, +recover, +drain)  │
+                         │            ├─► internal/sqlite   (default, WAL)  ──► file ──┼──► Litestream ─► S3/MinIO
+                         │            ├─► internal/postgres (optional)               │
+                         │            └─► internal/otel     (OTLP exporter) ─────────┼──► OTel Collector ─► Prometheus ─► Grafana
+                         │                                                            │     (+ operator's trace/log backends,
+                         │  HTTP server (chi/std mux):                                │      e.g. Tempo/Loki — not prescribed)
+                         │   /                → embedded React UI (go:embed)          │
+                         │   /api/observations/current|history → reads sqlite DB      │
+                         │   /api/forecast|almanac|station     → proxies WF (token svr)│
+                         │   /api/radar/{site}   → proxy+cache ─► radar sidecar ───────┼──► (Python/Py-ART) ─► s3://unidata-nexrad-level3
+                         │   /healthz  /metrics (legacy, deprecated)                  │
+                         └──────────────────────────────────────────────────────────┘
+```
+
+Data flow, UDP path (unchanged core, additively wired): packet → `tempestudp.ParseReport` → `Report`
+→ `sink.SendReport(ctx, report)` → fan-out to {sqlite, postgres?, otel}. The UI reads the **sqlite
+DB** for live/historical observations (no token needed); forecast/almanac come from the **server-side
+WeatherFlow proxy**; radar comes from the **server-side NIDS decoder**.
+
+---
+
+## 6. Workstream 0 — Foundation: lifecycle & review-fix bedrock (do FIRST)
+
+Every later workstream depends on correct shutdown, panic isolation, and context handling. These are
+cross-cutting fixes owned at the **seam** (`main.go` + `internal/sink`) plus the UDP source, so all
+writers — including the new sqlite and otel writers — inherit correctness (DRY / No-Wall: fix once at
+the seam, not per-writer).
+
+**Design:**
+- `main.go`: `signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)` (fixes **A-H1**).
+- On signal: cancel the **ingest** context, but run cleanup under a **fresh** `cleanupCtx, cancel :=
+  context.WithTimeout(context.Background(), 30*time.Second)` passed into `sink.Close(cleanupCtx)`
+  (fixes **A-MEDIUM**; enables writers to drain after the ingest ctx is dead).
+- `internal/sink`:
+  - `Close(ctx)` takes the cleanup context (drop the stored `s.ctx` field — Review A NIT + C-LOW).
+  - Fan-out goroutines get `defer func(){ if r:=recover(); r!=nil { log/metric } }()` (fixes
+    **A-MEDIUM panic-recovery**; contains the blast radius of **C-1** and the wet-bulb panic).
+  - `SendReport`/`SendMetrics` aggregate per-writer errors and return a meaningful error (all-writers-
+    failed vs partial), removing the dead nil-return contract (**A-LOW**).
+- `internal/tempestudp`:
+  - Guard `if len(r.RadioStats) >= 3 { … }` before indexing (fixes **C-1**).
+  - `wetBulb` returns `math.NaN()` (or best estimate) instead of `panic("failed to converge")`; caller
+    skips emitting NaN (fixes **E-MEDIUM**). Modernize the solver loop to `for range 10000`.
+- `internal/config`: build the Postgres DSN with `net/url` (percent-encoded credentials) instead of
+  raw `fmt.Sprintf` (fixes **B-HIGH** escaping/injection).
+- `internal/postgres` (**v2/B1**): read `POSTGRES_BATCH_SIZE`/`POSTGRES_FLUSH_INTERVAL`/`POSTGRES_MAX_RETRIES`
+  from env into the writer (currently hardcoded `100`/`10s`/`3` and inert), via a pure `postgresTunables(getenv)`
+  helper that falls back to those defaults. **Fixes C-H2 for the legacy Postgres path** (the SQLite writer
+  already honors its own `SQLITE_*` tunables; this closes the same gap on the retained Postgres writer).
+- `internal/tempestapi`: dedicated `&http.Client{Timeout: 30s}`; `Authorization: Bearer` header (drop
+  token-from-URL); status-code check before decode; return an error instead of `log.Fatalf`; check
+  `status.status_code`; bound the body with `io.LimitReader` (fixes **F-H1..H4, F-MEDIUM**).
+- Config booleans: parse explicitly and fail/log on a non-empty unparseable value (fixes A-MEDIUM
+  silent-typo-disables-a-sink).
+
+**Note on the existing prometheus/postgres writers:** apply the **C-H3 / D-H1** `sync.Once`+`done`-gate
+fixes here too, even though OTel will supersede the prometheus path and sqlite becomes default — both
+writers remain in the tree during the transition and must not crash on shutdown.
+
+**Resolves:** C-1, A-H1, A-H3, A-MEDIUM(×2), C-H1 (context half), **C-H2 (Postgres path, v2/B1)**, C-H3,
+D-H1, D-H2, F-H1..H4, B-HIGH, E-MEDIUM.
+
+---
+
+## 7. Workstream 1 — Absorb the UI as a Go-embedded app
+
+### Design
+- **Vendor** the `tempest-display` React app (MIT, `Copyright (c) 2026 jacaudi` — same owner, license
+  compatible; retain the `LICENSE` and add a provenance note in the vendored dir header) into this
+  repo under `web/`.
+- **Build pipeline:** multi-stage Docker — stage 1 `node:22-alpine` runs `npm ci --ignore-scripts` +
+  `vite build` → `web/dist`; stage 2 `golang:1.25-alpine` compiles the Go binary that embeds
+  `web/dist` via `//go:embed`; final stage `cgr.dev/chainguard/static` non-root (preserve the
+  praised hardening). A local (non-Docker) build path uses a committed pre-built `web/dist` or a
+  `task ui-build` target; the `go:embed` directive must have a non-empty target dir at `go build`
+  time (document a `web/dist/.gitkeep` + build-order requirement).
+- **Serve** the SPA from the same Go HTTP server that hosts the API, with SPA fallback and the
+  embed-FS path-traversal safety the UI review praised. Apply the UI backend fixes: explicit
+  `http.Server` timeouts (**E-H1**), graceful shutdown, security headers (nosniff/CSP/referrer), and
+  fix the `immutable`-cache-on-index.html bug (only set immutable after a real asset stat; 404 on
+  missing `/assets/*`).
+- **Make the data layer real** (resolves UI **B-H2**). Replace the stub `tempestApi.ts` calls with
+  fetches to the backend JSON endpoints in §11. The UI stops shipping fixtures.
+- **Token server-side** (resolves UI **B-H1** + exporter **F-H1**): the exporter already holds
+  `TOKEN`. Forecast/almanac/station endpoints proxy WeatherFlow REST with the token injected
+  server-side (`Authorization: Bearer`), and the browser only ever calls tokenless relative URLs. The
+  dead SettingsPanel Station-ID/Token inputs (UI D-MEDIUM) are **removed** (the token is an env var on
+  the server, not a browser input) — or repurposed to select among the server's configured stations.
+
+### Key decisions
+- Single binary and single HTTP port for UI + API (KISS; the UI's separate 63-line static server is
+  absorbed and deleted).
+- **CSP is self-only (v2/B2):** the map basemap is an OpenStreetMap Protomaps `.pmtiles` file served
+  **same-origin**, so the CSP names **no external hosts** — no map-tile host and no font CDN (self-host
+  Inter, resolving UI A-MEDIUM offline/kiosk). The only non-origin allowances are `worker-src blob:` and
+  `script-src 'wasm-unsafe-eval'` for MapLibre GL JS's Web Worker + WebAssembly renderer (they add no
+  network origin). This makes the appliance fully offline/air-gap capable.
+
+### Alternatives considered
+- **Keep the UI a separate container** talking to the exporter over HTTP: rejected — defeats the
+  single-artifact goal and re-opens the token-location question. (No-Wall: the seam is the JSON API,
+  which we build anyway; a second container is speculative separation.)
+- **Server-side render**: rejected (YAGNI; the SPA is fine for an appliance display).
+
+### Risks
+- `go:embed` requires `web/dist` to exist at build time → CI/build ordering must guarantee the Vite
+  build runs first. Mitigation: document + a `.gitkeep` and a Taskfile target.
+- Vendoring drifts from upstream `tempest-display`. Mitigation: record the exact source commit
+  (`49892063`) and treat `web/` as owned-fork henceforth.
+
+### Resolves
+UI B-H1, B-H2, E-H1, F-H1 (root user → non-root), E-MEDIUM (graceful shutdown, cache, headers),
+exporter F-H1 (token off the wire).
+
+### External deps
+Node/Vite toolchain in the build image; no new Go runtime deps for embedding (`embed` is stdlib).
+
+---
+
+## 8. Workstream 6 — Unified OpenTelemetry (OTLP) backbone
+
+> Ordered before WS2–WS5 in this doc because WS4 (Grafana) and the observability of every other
+> workstream depend on it. In the execution plan it runs after WS0 foundation.
+
+### Design
+- New `internal/otel` package providing:
+  - **Setup**: `otel.Setup(ctx, cfg) (shutdown func(context.Context) error, err error)` that
+    configures a `Resource` (service.name=`tempestwx`, service.version, host/station attributes), a
+    `MeterProvider`, `TracerProvider`, and `LoggerProvider`, each with an **OTLP exporter**
+    (`otlptracegrpc`/`otlpmetricgrpc`/`otlploggrpc` or the HTTP variants) pointed at
+    `OTEL_EXPORTER_OTLP_ENDPOINT` (the Collector). Metrics/traces OTLP are **stable**; the logs
+    signal is **still experimental** but the SDK + OTLP log exporter are usable today — isolate logs
+    behind the same package so an API bump is a one-file change (No-Wall).
+  - **A sink writer** `otel.Writer` implementing `sink.MetricsWriter`. On `WriteReport`, it records
+    each weather field to a pre-registered **OTel instrument** (Gauges for temperature/humidity/
+    pressure/wind/UV/irradiance/battery/rssi; Counters for reboots/bus_errors/lightning_strike_count
+    and rain accumulation; the wet-bulb/dew-point/heat-index derived values as Gauges). Instruments
+    are named to **preserve the existing `tempest_*` Prometheus names** after the Collector's
+    OTLP→Prometheus translation (e.g. instrument `tempest.temperature.c` → `tempest_temperature_c`),
+    so WS4 dashboards and any existing scrapers stay stable.
+  - **Tracing**: spans around UDP ingest (`udp.receive` → `report.parse` → `sink.write` children per
+    writer), the API export loop, and each HTTP request (via `otelhttp` middleware).
+  - **Structured logs**: bridge the app's logging to the OTel `LoggerProvider` (or emit via `slog`
+    with an OTel handler), so logs carry trace/span IDs for correlation.
+- **Metric-hygiene fixes folded in** (from Review D): rename the reserved `instance` label → `serial`
+  (**D-MEDIUM**); `tempest_wind_ms` → `tempest_wind_meters_per_second` (**D-MEDIUM**); uptime becomes
+  a **Gauge** `tempest_uptime_seconds` (drop `_total`, **D-MEDIUM/E-LOW**); drop the dead `RainTotal`
+  or wire it as a proper `tempest_rainfall_mm_total` counter (**D-MEDIUM**).
+- **Scope boundary (per R1/O5):** the *app's* responsibility ends at exporting OTLP to
+  `OTEL_EXPORTER_OTLP_ENDPOINT`. It ships metrics+logs+traces and does **not** prescribe or bundle
+  storage backends — that is the operator's choice. The **example** compose includes a Collector that
+  routes **metrics → Prometheus** (required, because the WS4 Grafana dashboard is a deliverable and
+  needs a metrics source) and sends traces/logs to a debug exporter by default, with
+  **optional/commented** Tempo+Loki blocks for operators who want the full Grafana-native trace/log
+  experience.
+
+### Migration (careful, not big-bang)
+1. WS0 fixes the bespoke prometheus writers so they don't crash during transition.
+2. Ship `internal/otel` as an **additive** sink writer, enabled by `ENABLE_OTEL=true` +
+   `OTEL_EXPORTER_OTLP_ENDPOINT`.
+3. Once OTel is proven against Prometheus (metric names match, dashboards work), **deprecate** the
+   pushgateway and scrape writers (log a deprecation warning; keep them for one release).
+4. A later release removes the bespoke prometheus path. The `/metrics` legacy endpoint remains until
+   then for users mid-migration. (Open decision O4: deprecate-then-remove vs remove-now.)
+
+### Alternatives considered
+- **Keep Prometheus-native, skip OTel**: rejected (ratified R1; also leaves logs/traces unaddressed).
+- **OTel Collector as the only metrics scraper (Prometheus receiver scraping the app)**: rejected in
+  favor of in-process SDK push — the app's data is event-driven (sporadic broadcasts), which suits
+  push/OTLP better than scrape (mirrors why the project chose push originally).
+
+### Risks
+- Logs API instability (experimental) — isolated in `internal/otel`; fall back to `slog`-only if a
+  breaking change lands.
+- Metric-name translation (OTLP→Prometheus dotted→underscore, unit suffixes) can surprise; the plan
+  must include an assertion test that the Collector emits the exact `tempest_*` names WS4 queries.
+
+### Resolves / supersedes
+D-H1, D-H2 (bespoke writer panics/bind-swallow superseded), D-MEDIUM metric-hygiene set, A-H3.
+
+### External deps
+`go.opentelemetry.io/otel`, `.../sdk`, `.../exporters/otlp/*`, `.../contrib/instrumentation/net/http/otelhttp`; an OTel Collector image + Prometheus + Grafana in the example compose (Tempo/Loki optional/commented).
+
+---
+
+## 9. Workstream 2 — NEXRAD Level 3 radar overlay
+
+### Verified externals (researched live — do not trust memory)
+- **Bucket:** `s3://unidata-nexrad-level3/` (region `us-east-1`, **anonymous** access, real-time).
+  (Registry of Open Data on AWS; NSF Unidata.) The older `noaa-nexrad-level2/` archive bucket was
+  deprecated 2025-09-01 — not relevant here (that's Level II).
+- **Object naming:** flat keys `SSS_PPP_YYYY_MM_DD_HH_MM_SS` where `SSS` = 3-char site (no leading K,
+  e.g. `TLX` for `KTLX`), `PPP` = product code.
+- **Product (base reflectivity):** `N0B` = super-resolution base reflectivity (0.5° tilt, 256 levels,
+  0.54nm×1° res) — the **current** product; `N0Q` = legacy base reflectivity, same geometry. IEM now
+  sources N0Q from N0B. **Recommendation:** default to **N0B**, fall back to **N0Q** if a site lacks
+  a recent N0B object. (Open decision O2.)
+
+### Prior art (DRAS — the user's own repo, studied)
+DRAS is a Go orchestrator that decodes radar **server-side** and ships a rendered image/JSON
+downstream; it never puts S3 or decode logic in the browser/notifier. Its **Advanced** mode uses a
+**Python Py-ART sidecar** to decode **Level II** volumes assembled from
+`s3://unidata-nexrad-level2-chunks/` (server-side, anonymous S3, `boto3`), caches per
+`(station_id, latest_chunk_time)`, and hard-fails cleanly (notification with no image) on decode
+error. Its **Basic** mode just downloads the NWS pre-rendered ridge GIF. **Key architectural lessons
+this design adopts:** (a) decode server-side; (b) cache keyed on the volume/scan timestamp, not the
+slot; (c) anonymous S3, egress to `*.s3.amazonaws.com:443`; (d) a clean error envelope.
+
+### Recommendation: **server-side decode via a Python Py-ART sidecar (reuse DRAS), output contoured GeoJSON**
+Per the user's direction (O1/O3), radar is decoded by a **Python sidecar service** rather than a
+hand-written Go NIDS decoder. Py-ART reads Level 3 NIDS directly (`pyart.io.read_nexrad_level3`),
+exactly mirroring how DRAS already decodes radar server-side in Python — so this **reuses proven prior
+art** and removes the design's single highest-risk item (no mature pure-Go L3 decoder exists). The
+sidecar fetches the newest NIDS object from S3 (anonymous), decodes to a gridded reflectivity field,
+and emits **contoured GeoJSON isobands** (dBZ banded polygons via `geojsoncontour`/matplotlib
+`contourf`). The Go backend calls the sidecar over HTTP, **caches** the result per `(site, product,
+scanTime)`, and serves it at `/api/radar/{site}`.
+
+**Why a Python sidecar (O1):** reuses DRAS; no risky bespoke Go decoder; Py-ART is the de-facto
+radar-decode library. Cost: it is a separate container, so the *pure single Go binary* no longer holds
+**when radar is enabled** — but radar is **opt-in** (`ENABLE_RADAR`), so users who don't want it keep
+the single static binary, and the deployment is already a compose stack, so one more sidecar is
+consistent. The core exporter never imports Python; it only HTTP-calls the sidecar.
+
+**Why contoured GeoJSON over a PNG overlay (O3):** full-resolution radar is a raster of >1M gate
+values, which is why a raw-GeoJSON-per-gate payload was rejected — but **contoured isobands** collapse
+that to a few thousand banded polygons: light, **vector** (crisp at any zoom), **restylable**
+client-side, and interactive (click a band → dBZ range). This is the conventional modern web-radar
+representation and is cheap for Py-ART to produce. A georeferenced PNG overlay remains the simpler
+fallback if the GeoJSON proves too heavy on weak clients.
+
+**Why server-side over client-side decode:**
+- Keeps S3 access and the decode CPU **off the browser** (no AWS credentials or SDK in client JS;
+  weak kiosk/Pi clients stay light).
+- Enables a **shared server cache** (all UI clients reuse one decoded scan), impossible client-side.
+- Matches DRAS's proven pattern and the token-proxy pattern from WS1 (the backend is already the
+  trusted egress point).
+
+### Design
+- New `internal/radar` package:
+  - **Site selection:** map the station's lat/lon (from WeatherFlow station meta) to the nearest
+    WSR-88D site. Ship a small static table of site codes + coordinates (the ~160 CONUS sites),
+    reusing DRAS's `ValidateStationID`/site conventions. `RADAR_SITE` env can override.
+  - **Fetch:** anonymous S3 discovery of the newest scan (`ListObjectsV2` prefix `SSS_PPP_`, pick the
+    largest `YYYY_MM_DD_HH_MM_SS` suffix, `GetObject`). **Owned by the Python sidecar** (`boto3`
+    anonymous, as DRAS does) to keep S3+decode in one place; the Go backend triggers a refresh on the
+    scan cadence (~4–6 min, VCP-dependent) and caches the result. (Alternative: Go does S3 discovery
+    and passes bytes to the sidecar — the plan picks the simpler split.)
+  - **Decode (in the Python sidecar):** the sidecar exposes `GET /radar?site=&product=`; it
+    `read_nexrad_level3`s the fetched NIDS bytes via **Py-ART**, grids the base-reflectivity field,
+    contours it into dBZ isobands (e.g. 5-dBZ steps over the NWS reflectivity scale) with
+    `geojsoncontour`, and returns **GeoJSON** (+ metadata: scan time, site, lat/lon extent). The Go
+    `internal/radar` package owns caching + serving and never decodes NIDS itself. References: Py-ART
+    `read_nexrad_level3`; DRAS's Py-ART sidecar; `geojsoncontour`.
+  - **Cache:** in-memory LRU keyed on `(site, product, scanTime)` (DRAS pattern), TTL ~ one scan
+    cycle; bound size.
+  - **Serve:** `GET /api/radar/{site}?product=N0B` → the PNG/GeoJSON + metadata (scan time, site,
+    lat/lon extent) with a clean error envelope (`no_recent_scan`, `decode_failed`, `internal`).
+- **UI render:** add a map card (MapLibre GL JS — open-source; no API key). **Basemap = OpenStreetMap
+  via a same-origin Protomaps `.pmtiles` file (v2/B2):** the backend serves (or the image embeds) one
+  `.pmtiles` OSM vector-tile file and MapLibre reads it via the `pmtiles://` protocol with byte-range
+  requests to `'self'` — **no external tile server, no API key, offline-capable, and OSM attribution
+  (`© OpenStreetMap contributors`) is rendered on the map (required).** The public
+  `tile.openstreetmap.org` raster server is an online-only, light-use **fallback only**, not the default.
+  The radar overlay is a **GeoJSON fill layer** (dBZ isobands, styled by band via a data-driven color
+  ramp; restylable client-side), centered on the station, auto-refreshing on the scan cadence.
+  Respects `prefers-reduced-motion` (no auto-pan). (PNG image-layer is the O3 fallback.)
+
+### Alternatives considered
+- **Pure-Go in-process NIDS decoder:** rejected per O1 — no mature Go L3 decoder exists (`go-nexrad`
+  is Level II only), making it the highest-risk/effort item; the Python sidecar reuses DRAS's proven
+  code instead. Its only advantage (preserving the single binary) is largely retained because radar is
+  opt-in and separable.
+- **Full-resolution GeoJSON (polygon per gate):** rejected — >1M features, tens of MB, kills the
+  browser. **Contoured isobands** (the chosen output) give the GeoJSON benefits without the payload.
+- **Georeferenced PNG overlay:** viable and simpler; kept as the O3 fallback if contoured GeoJSON is
+  too heavy on weak clients.
+- **Client-side JS decode / pre-rendered NWS ridge GIF:** rejected (bundle bloat + no shared cache;
+  GIF is low quality) — the NWS ridge GIF remains a degraded last-resort for sites with no decodable
+  NIDS.
+
+### Risks
+- **Sidecar image size / operational surface:** Py-ART + SciPy is a large image (~hundreds of MB) and
+  a second moving part. Mitigation: radar is **opt-in** (`ENABLE_RADAR`), separable, and only deployed
+  when wanted; the core exporter stays a single static binary otherwise.
+- **Go↔sidecar contract:** define a stable HTTP contract + a clean error envelope (`no_recent_scan`,
+  `decode_failed`, `internal`) so a sidecar failure degrades gracefully (mirror DRAS's soft-fail).
+- **Contouring fidelity:** banded isobands lose smooth gradients — acceptable (conventional radar
+  look) and tunable via band count; PNG fallback if needed.
+- S3 egress/network in restricted deployments; radar is opt-in (`ENABLE_RADAR=true`).
+
+### Resolves
+No direct review finding (new feature), but corrects the UI review's **phantom `VITE_ENABLE_RADAR`
+docs (F-MEDIUM)** by making radar a real, server-configured feature.
+
+### External deps
+**Radar sidecar (Python):** Py-ART, `boto3` (anonymous S3), `geojsoncontour`/matplotlib, a small HTTP
+framework (Flask/FastAPI) — packaged as its own container (reuse/adapt DRAS's sidecar). **Go side:**
+just an HTTP client + cache (stdlib); no NIDS/S3 Go deps required when the sidecar owns S3. **UI:**
+MapLibre GL JS + the `pmtiles` protocol plugin. **Basemap asset (v2/B2):** one OpenStreetMap `.pmtiles`
+vector-tile file — produced/obtained via the Protomaps tooling (a documented `pmtiles extract` of a
+regional extract, or a download from `build.protomaps.com`) and served **same-origin**; no external tile
+service or API key. OSM attribution is required.
+
+---
+
+## 10. Workstream 3 — SQLite + Litestream (default), Postgres retained
+
+### Design
+- New `internal/sqlite` package implementing `sink.MetricsWriter`, mirroring the postgres writer's
+  **praised** parts (UUIDv7 PKs generated once per row, `INSERT … ON CONFLICT DO NOTHING` on the
+  natural unique key, correct column mappings) while **not repeating** its lifecycle bugs:
+  - **Single serialized writer goroutine** (SQLite is single-writer; this is simpler than postgres's
+    4-goroutine design and makes the drain trivially correct).
+  - **Drain on `Close(ctx)`** using the fresh cleanup context from WS0, draining the **channel
+    buffer** (not just a local slice) — fixes the class of **C-H1**.
+  - **`sync.Once` + `done`-gate on sends**, idempotent `Close` — fixes the class of **C-H3**.
+  - **Honor tunables** `SQLITE_BATCH_SIZE`, `SQLITE_FLUSH_INTERVAL`, `SQLITE_BUSY_TIMEOUT` (don't
+    repeat **C-H2** inert-knobs).
+  - **Events are not dropped under backpressure** (don't repeat **C-MEDIUM**): block-with-bounded-
+    timeout for discrete lightning/rain-start rows.
+- **Driver: `modernc.org/sqlite` (pure Go, CGO-free).** **Load-bearing:** this preserves the
+  `CGO_ENABLED=0` static Chainguard image the exporter review praised. Do **not** use
+  `mattn/go-sqlite3` (CGO) — it would break the static build. (Throughput is irrelevant at ~1 write/
+  min; the static-build benefit dominates.)
+- **PRAGMAs (must be exact):** `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`,
+  `foreign_keys=ON`. **Let Litestream own checkpointing** — do not set aggressive
+  `wal_autocheckpoint`; Litestream holds a read transaction and drives checkpoints itself.
+- **Schema:** typed tables mirroring the postgres schema — `tempest_observations`,
+  `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events` — with UUIDv7 text PKs, `TIMESTAMPTZ`→
+  ISO-8601 text or unix-epoch integers, and the same UNIQUE constraints backing dedup (§12 has DDL).
+  Fix the postgres review's LOW: integer counts as `INTEGER`, not float.
+- **Litestream** runs as a sidecar in compose, streaming the WAL to S3/MinIO. It composes with
+  `modernc.org/sqlite` because Litestream operates on the on-disk SQLite file/WAL independent of the
+  Go driver. Config: replica → object storage; document credentials via env (§15).
+- **Migrations:** adopt a lightweight versioned-migration approach (embedded `.sql` + a `schema_version`
+  table) so schema evolution is handled — addresses the postgres review's **B-MEDIUM** (no migration
+  path) for the new default store.
+
+### Key decisions
+- SQLite **default**, Postgres **opt-in** (R2). `main.go` selects: if `ENABLE_POSTGRES` → postgres;
+  else default to sqlite at `SQLITE_PATH` (default `/data/tempest.db`). Both can run concurrently
+  (fan-out) if both enabled.
+- Additive on the sink seam: new package + main wiring; `internal/postgres` untouched (No-Wall).
+
+### Alternatives considered
+- **`mattn/go-sqlite3`:** rejected (CGO breaks the static image).
+- **LiteFS / rqlite / dqlite:** rejected (YAGNI — clustering/HA is a non-goal; Litestream's
+  backup/PITR is the actual requirement).
+
+### Risks
+- Misconfigured PRAGMAs silently lose Litestream data — the design pins exact values and the plan must
+  include a restore-from-replica test.
+- Single-writer contention if the executor copies postgres's multi-goroutine design — the design
+  mandates a single writer goroutine.
+
+### Resolves
+Applies the **lessons of** C-H1, C-H2, C-H3, C-MEDIUM, B-MEDIUM to the new writer so they are not
+reintroduced.
+
+### External deps
+`modernc.org/sqlite`, `github.com/google/uuid` (already present), Litestream (sidecar binary/image).
+
+---
+
+## 11. Backend JSON API (bridges UI ↔ data)
+
+New endpoints on the single HTTP server (all tokenless from the browser; `otelhttp`-traced):
+
+| Endpoint | Source | Notes |
+|---|---|---|
+| `GET /api/observations/current` | sqlite DB (latest row) | Real-time local data, **no token**. Resolves UI B-H2. |
+| `GET /api/observations/history?field=&from=&to=` | sqlite DB | Powers UI historical charts (§13) and Grafana-lite in-UI. |
+| `GET /api/station` | WeatherFlow REST proxy | Token injected server-side (`Bearer`). |
+| `GET /api/forecast` | WeatherFlow REST proxy | Better-Forecast; token server-side. |
+| `GET /api/almanac` | WeatherFlow REST proxy (**v2/B3: proxy, not computed**) | Sunrise/sunset/moon; token injected server-side (`Bearer`). |
+| `GET /api/radar/{site}` | `internal/radar` → Python sidecar | Proxies+caches the sidecar's **contoured-GeoJSON** reflectivity (Py-ART). Opt-in (`ENABLE_RADAR`). |
+| `GET /healthz` | — | Liveness (resolves UI F-LOW/G-LOW health probe gap). |
+| `GET /metrics` | legacy prometheus scrape | **Deprecated**; removed after OTel migration (O4). |
+
+Shapes should match the UI's existing `types/weather.ts` (SI units — °C, m/s, mb, mm) so the vendored
+components need minimal change; the UI's unit hook (verified correct) handles display conversion.
+
+---
+
+## 12. Unified data model
+
+### SQLite schema (default store) — DDL sketch
+
+```sql
+-- All timestamps stored as INTEGER unix-epoch seconds (UTC). UUIDv7 text PKs generated in Go.
+CREATE TABLE IF NOT EXISTS tempest_observations (
+  id TEXT PRIMARY KEY,                 -- UUIDv7
+  serial_number TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,          -- ob[0] epoch
+  wind_lull REAL, wind_avg REAL, wind_gust REAL, wind_direction REAL,
+  wind_sample_interval INTEGER,
+  pressure REAL, temp_air REAL, temp_wetbulb REAL, humidity REAL,
+  illuminance REAL, uv_index REAL, irradiance REAL, rain_rate REAL,
+  precip_type INTEGER,
+  lightning_distance REAL, lightning_strike_count INTEGER,   -- INTEGER not float (fix B-LOW)
+  battery REAL, report_interval INTEGER,
+  UNIQUE(serial_number, timestamp)     -- backs ON CONFLICT DO NOTHING
+);
+CREATE TABLE IF NOT EXISTS tempest_rapid_wind (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  wind_speed REAL, wind_direction REAL, UNIQUE(serial_number, timestamp)
+);
+CREATE TABLE IF NOT EXISTS tempest_hub_status (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  uptime INTEGER, rssi REAL, reboot_count INTEGER, bus_errors INTEGER,
+  UNIQUE(serial_number, timestamp)
+);
+CREATE TABLE IF NOT EXISTS tempest_events (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  event_type TEXT NOT NULL, distance_km REAL, energy REAL,
+  UNIQUE(serial_number, timestamp, event_type)
+);
+CREATE INDEX IF NOT EXISTS idx_obs_serial_time ON tempest_observations(serial_number, timestamp);
+CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+```
+
+The Postgres schema is unchanged; the two schemas are parallel representations of the same knowledge
+(the DRY answer: they must change together, so migrations for both live in one place per store).
+
+### OTel semantic conventions
+- Resource: `service.name=tempestwx`, `service.version`, `host.name`, and a `tempest.serial` resource
+  attribute (replaces the reserved `instance` label — fixes D-MEDIUM).
+- Instruments → Prometheus names (via Collector translation), preserving existing `tempest_*`:
+  `tempest.temperature.c`→`tempest_temperature_c` (Gauge), `tempest.wind.meters_per_second`
+  →`tempest_wind_meters_per_second` (Gauge, fixes `_ms`), `tempest.uptime.seconds`
+  →`tempest_uptime_seconds` (Gauge, fixes `_total`), `tempest.reboots`→`tempest_reboots_total`
+  (Counter), etc. Derived: `tempest.dewpoint.c`, `tempest.heat_index.c`, `tempest.wetbulb.c`.
+- Spans: `udp.receive`, `report.parse`, `sink.write` (child span per writer), `http.server.request`.
+
+---
+
+## 13. Grafana dashboard spec (WS4) — "Weather Nerd" dashboard
+
+Data source = Prometheus (fed by the OTel Collector). PromQL uses the preserved `tempest_*` names and
+the `serial` label. Layout top-to-bottom; panels grouped in rows.
+
+**Row 1 — Current conditions (stat panels):**
+- Temperature: `tempest_temperature_c{kind="air", serial="$serial"}`
+- Dew point (derived): `tempest_dewpoint_c{serial="$serial"}`
+- Heat index / Wet-bulb: `tempest_heat_index_c`, `tempest_wetbulb_c`
+- Humidity: `tempest_humidity_percent`
+- Pressure: `tempest_pressure_mb`
+- Wind (avg/gust): `tempest_wind_meters_per_second{kind="avg"}`, `{kind="gust"}`
+
+**Row 2 — Trends (time series, 24h):**
+- Temperature vs dew point vs wet-bulb overlaid.
+- Pressure with **tendency**: `deriv(tempest_pressure_mb{serial="$serial"}[3h])` (mb/3h — the
+  meteorological pressure-tendency window).
+- Humidity trend.
+
+**Row 3 — Wind:**
+- **Wind rose** (Grafana wind-rose/polar panel or a heatmap of
+  `tempest_wind_direction_degrees` bucketed vs `tempest_wind_meters_per_second`).
+- Gust factor: `tempest_wind_meters_per_second{kind="gust"} / tempest_wind_meters_per_second{kind="avg"}`.
+
+**Row 4 — Rain:**
+- Rate: `tempest_rain_rate_mm_min`.
+- Accumulation (last 24h): `sum_over_time(tempest_rain_rate_mm_min{serial="$serial"}[24h]) * <interval>`
+  or `increase(tempest_rainfall_mm_total[24h])` if RainTotal is wired as a counter (preferred; see
+  D-MEDIUM fix).
+
+**Row 5 — Lightning:**
+- Strike rate: `increase(tempest_lightning_strike_count[1h])` (needs the count as a counter, or
+  `sum_over_time` of the per-minute gauge).
+- Nearest distance: `min_over_time(tempest_lightning_distance_km{serial="$serial"}[1h])`.
+
+**Row 6 — Solar / UV:**
+- UV index: `tempest_uv_index`. Solar irradiance: `tempest_irradiance_w_m2`. Illuminance:
+  `tempest_illuminance_lux`.
+
+**Row 7 — Station health:**
+- Battery: `tempest_battery_volts`. RSSI: `tempest_rssi_dbm`. Uptime:
+  `tempest_uptime_seconds`. Reboots/bus errors: `increase(tempest_reboots_total[24h])`,
+  `increase(tempest_bus_errors_total[24h])`.
+
+**Row 8 — Records / almanac (stat, `max_over_time`/`min_over_time` over `$__range`):**
+- Today's high/low temp: `max_over_time(tempest_temperature_c{kind="air",serial="$serial"}[$__range])`
+  / `min_over_time(...)`. Peak gust, max UV, total rain, closest lightning — same pattern.
+
+**Template variables:** `$serial` (label_values(tempest_temperature_c, serial)), `$__range`.
+Delivered as a provisioned dashboard JSON + Grafana datasource/provisioning config in the compose
+stack.
+
+---
+
+## 14. UX improvement scan (WS5) — prioritized, weather-nerd-focused
+
+Grounded in the UI review + fresh product ideas. Priority: **P0 = correctness/broken-first-screen,
+P1 = high-value, P2 = polish, P3 = follow-up (not built now)**.
+
+**P0 — make it not break (from UI review HIGH):**
+1. Add a React **error boundary** around the dashboard/cards (A-H1) — one bad card must not blank a
+   24/7 display.
+2. Define the missing `.loading-screen/.loading-spinner/.error-screen/.glass-btn` CSS (A-H2) — this is
+   literally the first screen users see.
+3. Add responsive breakpoints (A-H3) — collapse the 3-col grid to 2/1 on tablets/phones (the devices
+   these displays run on).
+4. Add `prefers-reduced-motion` + `:focus-visible` (A-H4/A-MEDIUM) — vestibular safety + keyboard a11y.
+5. Route UV through a `formatX` helper so a missing field renders `NaN` not a hard crash (C-MEDIUM).
+
+**P1 — high value for enthusiasts:**
+6. **Real data** (B-H2 → §11 endpoints) with a clear "live vs stale" indicator (retain prior data on
+   fetch failure, show last-updated age).
+7. **Historical charts** in-UI from `/api/observations/history` (sparklines on each card + a
+   drill-down trend view) — the biggest enthusiast upgrade; the exporter now has the DB to back it.
+8. **Radar map card** (WS2) with the reflectivity overlay centered on the station.
+9. Fix civil-calendar/i18n bugs users see: hemisphere `°N/°S/°E/°W` (C-MEDIUM), forecast weekday
+   across year boundary (D-MEDIUM), station-local timezone for sunrise/sunset/updated-time.
+10. Remove or repurpose the **dead SettingsPanel Station-ID/Token inputs** (D-MEDIUM) — token is now
+    server-side; expose real settings (units, theme, station selector, kiosk toggle).
+11. **Kiosk mode**: fullscreen, no-cursor, auto-refresh, wake-lock — these run on wall displays.
+12. Self-host fonts (A-MEDIUM) so the appliance works offline/air-gapped.
+
+**P2 — polish:**
+13. `React.memo` the leaf cards (re-render on every 3s tick — A-MEDIUM); `useMemo` the RainCard
+    raindrops (C-LOW reshuffle).
+14. Settings modal dialog semantics: `role="dialog"`, `aria-modal`, Escape, focus trap/restore
+    (D-MEDIUM).
+15. Theme-var leak fix (`desert-sunset` missing `--text-shadow`; `applyTheme` should clear prior
+    vars) (D-MEDIUM); `aria-hidden` on decorative SVGs; `°N/°W` etc.
+16. `100dvh` over `100vh`; drop `background-attachment: fixed`; enumerate `transition` props.
+17. Add Vitest + cover the pure math (already-correct conversions, moon phase, day-name); add CI
+    (lint/typecheck/build) — the UI has none today.
+
+**P3 — follow-ups (surfaced, NOT built now — YAGNI):**
+18. In-UI **alerting** (threshold notifications for lightning proximity, freeze, high wind) — a real
+    feature but its own project; note as a follow-up.
+19. Multi-station switcher UI (backend already lists stations).
+20. PWA/offline caching for the kiosk.
+21. Unit/theme user profiles beyond localStorage.
+
+---
+
+## 15. Security
+
+- **WeatherFlow token proxy** (resolves UI B-H1, exporter F-H1): token lives only in the server
+  process (`TOKEN` env), sent to WeatherFlow as `Authorization: Bearer`; the browser calls tokenless
+  relative URLs. Scrub any `*url.Error` before logging so the token never reaches logs. Never place
+  the token in `localStorage` or the bundle.
+- **Radar fetch:** anonymous S3 (no credentials); egress restricted to `*.s3.amazonaws.com:443`;
+  `ENABLE_RADAR` opt-in. Validate/allowlist the `{site}` path param against the static site table (no
+  arbitrary S3 key construction from user input — SSRF guard).
+- **Litestream creds:** object-storage credentials via env (`LITESTREAM_ACCESS_KEY_ID`,
+  `LITESTREAM_SECRET_ACCESS_KEY`, endpoint) — never committed; documented in `.env.example` with the
+  file gitignored.
+- **HTTP hardening** (resolves UI E-H1/E-MEDIUM): explicit `http.Server` timeouts
+  (`ReadHeaderTimeout`/`ReadTimeout`/`WriteTimeout`/`IdleTimeout`), security headers (nosniff,
+  referrer-policy, and a **self-only CSP** — v2/B2: `default-src 'self'; img-src 'self' data: blob:;
+  worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline';
+  connect-src 'self'; object-src 'none'; base-uri 'self'` — no external tile/font host because the OSM
+  `.pmtiles` basemap is same-origin; the `blob:`/`wasm-unsafe-eval` allowances are only for MapLibre's
+  worker/WASM), non-root container (`USER 65532`), graceful shutdown.
+- **CI/supply-chain** (resolves G-H1..H3): fix the Docker action input mismatch, add least-privilege
+  `permissions:` blocks, digest-pin base images, commit a `.goreleaser.yaml`.
+
+---
+
+## 15a. Full-stack docker-compose (service inventory)
+
+The single-binary app runs standalone; the full observability + backup stack is a documented compose
+file (the plan phase writes the exact YAML). Services:
+
+| Service | Image | Role | Key wiring |
+|---|---|---|---|
+| `tempestwx` | this repo's image | app (UI + API + ingest) | `network_mode: host` (UDP broadcast); `OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317`; `SQLITE_PATH=/data/tempest.db`; `ENABLE_RADAR`; `TOKEN`; volume `/data`. |
+| `litestream` | `litestream/litestream` | continuous WAL backup | mounts the same `/data`; replicates `tempest.db` → `minio`; `LITESTREAM_*` creds. |
+| `otel-collector` | `otel/opentelemetry-collector-contrib` | fan-out | OTLP receiver `:4317`; **metrics → Prometheus** (required for the dashboard); traces/logs → debug exporter by default, with optional/commented Tempo/Loki. |
+| `prometheus` | `prom/prometheus` | metrics store | receives from Collector; datasource for Grafana. |
+| `grafana` | `grafana/grafana` | dashboards | provisioned Prometheus datasource + the WS4 dashboard JSON. |
+| `radar-sidecar` *(opt-in)* | Python/Py-ART — this repo's `radar/` image | radar decode | enabled with `ENABLE_RADAR`; fetches NIDS from S3 (anonymous), returns contoured GeoJSON; called only by `tempestwx`. |
+| `tempo` / `loki` *(optional)* | `grafana/tempo` / `grafana/loki` | traces / logs | commented-out example backends; the app already exports OTLP, so operators can point the Collector at any store. (O5) |
+| `minio` | `minio/minio` | object storage | Litestream replica target (S3-compatible); prod can point at real S3. |
+
+`ENABLE_POSTGRES` deployments swap `litestream`+`minio` for a `postgres` service.
+
+## 16. Migration & backward-compatibility
+
+- **Env vars:** additive — `ENABLE_OTEL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `SQLITE_PATH`,
+  `SQLITE_*` tunables, `ENABLE_RADAR`, `RADAR_SITE`, `LITESTREAM_*`, UI served automatically.
+  `ENABLE_PROMETHEUS_*` retained but **deprecated** once OTel is proven. `ENABLE_POSTGRES` retained.
+  **`POSTGRES_BATCH_SIZE`/`POSTGRES_FLUSH_INTERVAL`/`POSTGRES_MAX_RETRIES` are now honored (v2/B1)** —
+  previously documented but inert; behavior for unset values is unchanged (defaults `100`/`10s`/`3`).
+- **Default store change:** existing Postgres users set `ENABLE_POSTGRES=true` and are unaffected. New
+  users get SQLite by default. Both can run together.
+- **Metric names preserved** so existing Prometheus/Grafana consumers keep working through the OTel
+  transition (the `serial` label rename from `instance` is the one intentional break — documented).
+- **README/docs:** rewrite to match reality (resolves G-H2 stale env vars; UI F-MEDIUM phantom radar
+  args). Update the operational-mode matrix for the new default.
+- **Mode fix:** enforce the "at least one writer" invariant **only in UDP mode**; API-export mode
+  requires a DB writer *or* `KEEP_EXPORT_FILES` (resolves A-H2).
+
+---
+
+## 17. Open decisions for the user
+
+- **O1 — Radar decoder — RESOLVED (user, 2026-07-17): Python Py-ART sidecar.** Reuses DRAS's proven
+  server-side decode; removes the risky bespoke-Go-decoder item. Radar is opt-in, so the core binary
+  stays single/static when radar is off. See §9.
+- **O2 — Radar product default: `N0B` (super-res) vs `N0Q` (legacy).** Recommendation (open): N0B with
+  N0Q fallback.
+- **O3 — Radar output format — RESOLVED (user, 2026-07-17): contoured GeoJSON isobands** (vector,
+  interactive, restylable; far lighter than full-res GeoJSON). Georeferenced PNG kept as fallback.
+  See §9.
+- **O4 — Bespoke Prometheus path: deprecate-then-remove (one release) vs remove-now.** Recommendation
+  (open): deprecate-then-remove to avoid a metrics gap.
+- **O5 — Telemetry backends — RESOLVED (user, 2026-07-17): the app only ships OTLP; backends are the
+  operator's choice.** Not prescribed. The example compose runs only Collector + Prometheus + Grafana
+  (needed for the WS4 dashboard); Tempo/Loki are optional/commented examples. See §8, R1.
+- **O6 — SQLite driver.** Recommendation (strong, open): `modernc.org/sqlite` (CGO-free, preserves the
+  static image). Confirm the CGO-free constraint holds.
+
+---
+
+## 18. Testing strategy
+
+- **Foundation (WS0):** table-driven test for the `RadioStats` short-array case (would have caught
+  C-1); wet-bulb NaN/edge tests; sink panic-recovery test (a panicking writer is contained); SIGTERM
+  graceful-shutdown test asserting buffered rows are drained; DSN round-trip through `pgxpool.
+  ParseConfig` with special-char credentials (catches B-HIGH); API client status-code/timeout/header
+  tests.
+- **SQLite writer:** unit tests for routing + optional-field population + boundary lengths; a real DB
+  test (temp file) asserting column values, `ON CONFLICT` idempotency on retry, and drain-on-`Close`;
+  a **Litestream restore** test (write → replicate to MinIO → restore → assert equality).
+- **OTel:** assert the Collector emits the exact `tempest_*` Prometheus names WS4 queries (name-
+  translation guard); span/trace-context propagation test.
+- **Radar:** sidecar — decode a captured NIDS fixture → expected GeoJSON isobands (Py-ART/pytest);
+  Go side — site-selection nearest-site test, cache-key correctness, sidecar error-envelope handling,
+  and `{site}` allowlist (SSRF guard).
+- **UI:** Vitest for the (correct) pure math + new formatX helpers; error-boundary render test;
+  responsive smoke; CI running lint/typecheck/build/`docker build`.
+- **Verification:** `go build ./...`, `go test -race ./...` for touched packages, `go vet`, `gofmt`
+  (fix `metrics.go`), the linter; report real output.
+
+---
+
+## 19. Execution sequencing (for the plan phase)
+
+1. **WS0 foundation** (lifecycle + review fixes) — everything depends on it.
+2. **WS3 SQLite** (default store; UI needs a DB to read).
+3. **WS6 OTel** (metrics backbone; WS4 needs it).
+4. **WS1 embedded UI + backend JSON API** (needs WS3 for data, WS0 for the token proxy).
+5. **WS2 radar** (needs WS1's HTTP surface + UI map card; adds the Python radar sidecar + the Go
+   proxy/cache — separable/opt-in).
+6. **WS4 Grafana** (needs WS6).
+7. **WS5 UX scan** (folds into WS1's UI work; P0/P1 alongside, P2 after).
+
+Each task: TDD, `superpowers:verification-before-completion`, per-task review; a fresh cold-review on
+the full diff before finishing.
+
+---
+
+## 20. References (cited)
+
+- Exporter review: `docs/review/2026-07-17-code-review-summary.md` and the per-file agent reports
+  (review-a … review-g).
+- UI review: `docs/review/2026-07-17-ui-code-review-summary.md` and review-ui-a … review-ui-f.
+- DRAS (radar prior art): `github.com/jacaudi/DRAS` — `docs/architecture.md` (server-side decode,
+  `s3://unidata-nexrad-level2-chunks/`, per-scan cache, anonymous S3, error envelope) and
+  `dras/internal/radar/radar.go` (site validation, VCP catalog, soft-fail parsing).
+- NEXRAD Level 3 on AWS: Registry of Open Data on AWS (`registry.opendata.aws/noaa-nexrad/`); NSF
+  Unidata "NEXRAD Archive data available on Amazon S3" — bucket `s3://unidata-nexrad-level3/`,
+  `us-east-1`, anonymous, naming `SSS_PPP_YYYY_MM_DD_HH_MM_SS`.
+- NIDS base reflectivity products `N0B` (super-res) / `N0Q` (legacy): IEM NEXRAD Mosaics docs;
+  Supercell-Wx NEXRAD-L3 docs; MetPy NEXRAD Level 3 example. Decode references: NOAA/NWS ICD "RPG to
+  Class 1 User"; `github.com/jjhelmus/nexrad_level3` (Python); `github.com/netbymatt/nexrad-level-3-data`
+  (JS). Go Level II (not L3): `github.com/bwiggs/go-nexrad`.
+- Litestream + SQLite WAL: `litestream.io/how-it-works/` and `/tips/` — takes over checkpointing via a
+  long read transaction + shadow WAL; requires WAL mode; streams to object storage.
+- OpenTelemetry Go: `opentelemetry.io/docs/languages/go/`; metrics/traces OTLP **stable**, logs
+  **experimental** (`opentelemetry.io/docs/specs/status/`). Collector Prometheus path:
+  Grafana "collect Prometheus metrics with the OpenTelemetry Collector"; OTel `prometheus` /
+  `prometheusremotewrite` exporters.
+- WeatherFlow Tempest API: `weatherflow.github.io/Tempest/api/` — supports `Authorization: Bearer`
+  header (and query-param token); OAuth available but PAT via server proxy is sufficient here.
+- Basemap (v2/B2): MapLibre GL JS (`maplibre.org`) + the `pmtiles` protocol (`github.com/protomaps/PMTiles`);
+  OpenStreetMap vector `.pmtiles` built/obtained via Protomaps (`build.protomaps.com`, `pmtiles extract`);
+  OSM attribution required (`© OpenStreetMap contributors`, `openstreetmap.org/copyright`). Radar site
+  table generated from NOAA HOMR WSR-88D station list (`ncei.noaa.gov/access/homr/file/nexrad-stations.txt`).
+```
+

--- a/docs/plans/2026-07-17-unified-weather-platform-implementation.md
+++ b/docs/plans/2026-07-17-unified-weather-platform-implementation.md
@@ -1,0 +1,1739 @@
+# Unified Weather Platform — Implementation Plan
+
+## Revisions
+
+- **v2 2026-07-17 — cold-review remediation + user decisions.** Applied the cold review's prioritized fix list (`docs/review/2026-07-17-plan-cold-review.md`): resolved the Task 2.1 fixture BLOCKER; Task 1.1 now emits a concrete UI manifest (real file tree + `weather.ts` types) so downstream UI tasks cite present symbols; inlined concrete Go code in the GREEN steps of the concurrency/DSN/lifecycle tasks (0.4, 0.7, 0.8, 0.9a/0.9b, 3.3) and the `main.go` extraction seams (`signalContext`, `requireWriters`, `selectStore`); pinned previously-unstated constants and asserted them in RED tests (3.3 backpressure timeout + channel caps; 2.4 LRU size/TTL); repaired Task 4.1 to drive the real OTel Prometheus exporter; split oversized Task 1.7 into 1.7a/1.7b/1.7c; disambiguated Contract A error transport (non-200 + JSON envelope); made Task 3.6 a default (non-integration) filesystem-replica test; provided the radar site-table data acquisition inline. Applied user decisions: **B1** wire legacy Postgres tunables (new Task 0.13, resolves C-H2 for Postgres); **B2** basemap = OpenStreetMap via Protomaps `.pmtiles` served same-origin (CSP now self-only + MapLibre worker allowance); **B3** `/api/almanac` = proxy WeatherFlow. Design doc updated in lockstep.
+- **v2.1 2026-07-17 — focused re-review cleanup.** Patched the 4 MINOR nits from `docs/review/2026-07-17-plan-cold-review-v2.md`: fixed the stale `CurrentWeather`→`CurrentObservation` type reference (Task 1.4); reworded Task 0.8 so it no longer forward-references the Task 0.9a `done` gate (which lands later); made the `insertObservations`/`insertRapidWind`/`insertHubStatus`/`insertEvents` context-parameter ripple explicit in Task 0.8; fixed a garbled comment in the 3.3 `eventBlockTimeout` const. No structural changes; re-review verdict was READY-WITH-MINORS.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Every task uses TDD (`superpowers:test-driven-development`): write the failing test, watch it fail for the right reason, then make it pass.
+
+**Goal:** Evolve `tempestwx-utilities` from a headless UDP/API exporter into a single-binary weather platform — embedded React UI, server-side WeatherFlow token proxy, NEXRAD Level 3 radar overlay (opt-in Python Py-ART sidecar → contoured GeoJSON), SQLite+Litestream default storage (Postgres retained), a unified OpenTelemetry (OTLP) backbone, a Grafana dashboard, and a prioritized UX overhaul — while fixing the CRITICAL/HIGH lifecycle findings from the two source reviews.
+
+**Architecture:** All new sinks are additive on the existing `internal/sink` fan-out seam; a new HTTP surface serves the embedded UI + a tokenless JSON API. Foundation lifecycle fixes (Workstream 0) land first because every later workstream depends on correct shutdown, panic isolation, and context handling. **Rationale for every decision lives in the design doc — do not duplicate it here. Read it first:** `docs/designs/2026-07-17-unified-weather-platform-design.md` (§ references throughout this plan point there).
+
+**Source reviews this plan resolves:**
+- Exporter: `docs/review/2026-07-17-code-review-summary.md` (1 CRITICAL, 17 HIGH). Finding IDs: `C-1`, `A-H1..H3`, `C-H1..H3`, `D-H1..H2`, `F-H1..H4`, `G-H1..H3`, `B-HIGH`, plus MEDIUMs cited per task.
+- UI: `docs/review/2026-07-17-ui-code-review-summary.md` (0 CRITICAL, 8 HIGH). Finding IDs: `A-H1..H4`, `B-H1..H2`, `E-H1`, `F-H1`. (UI findings referenced with a `UI-` prefix below to disambiguate from exporter findings that reuse the same letters.)
+
+**Tech Stack:** Go 1.24 (toolchain 1.25), `modernc.org/sqlite` (pure Go, CGO-free), OpenTelemetry Go SDK + OTLP exporters, `otelhttp`; React 19 + TypeScript 5.9 + Vite 7 + Vitest + MapLibre GL JS; Python 3.12 + FastAPI + Py-ART + boto3 + geojsoncontour (radar sidecar); Litestream, OTel Collector, Prometheus, Grafana, MinIO (compose stack).
+
+---
+
+## Execution Workflow
+
+> **For Claude:** REQUIRED EXECUTION WORKFLOW (follow in order):
+> 1. `superpowers:using-git-worktrees` — Isolate work in a dedicated worktree
+> 2. `superpowers:subagent-driven-development` — Dispatch a fresh subagent per task
+> 3. `superpowers:test-driven-development` — All subagents use TDD
+> 4. `superpowers:verification-before-completion` — Verify all tests pass per task
+> 5. `superpowers:requesting-code-review` — Code review after each task (built in)
+> 6. After all tasks: comprehensive code review on full diff from branch point (automatic)
+> 7. `superpowers:finishing-a-development-branch` — Complete the branch
+>
+> Skills carry their own model and effort settings. Do not override them.
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are copied verbatim from the design (§ noted).
+
+- **Go version floor:** module `go 1.24.0`, toolchain `go1.25.5`. Use modern Go idioms up to 1.24 (`any`, `slices`/`maps`/`cmp`, `min`/`max`, `for range n`, `errors.Is/As`, `t.Context()` in tests, `omitzero` JSON tags for time/duration/struct/slice/map fields, `b.Loop()` in benchmarks). (go.mod)
+- **CGO-free static build is load-bearing:** `CGO_ENABLED=0` MUST hold. SQLite driver MUST be `modernc.org/sqlite` — never `mattn/go-sqlite3` (CGO). This preserves the praised static Chainguard image. (design §10, O6)
+- **Radar product default:** `N0B` (super-res base reflectivity), fall back to `N0Q` (legacy) if a site lacks a recent N0B object. (design §9, O2)
+- **Bespoke Prometheus path:** deprecate-then-remove (keep for one release, log a deprecation warning) — do NOT remove-now. (design §8, O4)
+- **Telemetry scope:** the app only *ships* OTLP to `OTEL_EXPORTER_OTLP_ENDPOINT`; it does NOT bundle or prescribe trace/log backends. Example compose = Collector + Prometheus + Grafana only; Tempo/Loki commented. (design §8, R1, O5)
+- **Metric names preserved:** OTel instruments MUST translate (via the Collector) to the exact existing `tempest_*` Prometheus names (see Contract B). The `instance`→`serial` label rename is the one intentional break. (design §12)
+- **API/JSON units:** all backend JSON and OTel instruments use SI units (°C, m/s, mb, mm) so the vendored UI's unit hook handles display conversion. (design §11)
+- **HTTP hardening:** every `http.Server` sets `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, `IdleTimeout`; graceful shutdown; containers run non-root `USER 65532`. (design §15)
+- **CSP is self-only (B2):** the map basemap is an OpenStreetMap Protomaps `.pmtiles` file served **same-origin** — there is no external tile server and no API key. The Content-Security-Policy therefore names **no external hosts**. Exact directive: `default-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self'; object-src 'none'; base-uri 'self'`. The `blob:`/`wasm-unsafe-eval` allowances exist solely for MapLibre GL JS's Web Worker + WebAssembly renderer; they add no network origin. Plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer`. (design §7/§9/§15, B2)
+- **Logging:** standardize new packages on `log/slog` (structured, stdout). Do not add zerolog/logrus. (go-standards §7)
+- **Testing/verification per task:** `go build ./...` clean; `go test -race ./<touched-pkg>/...` passes; `go vet ./...` clean; `gofmt -l` reports nothing; `golangci-lint run` clean (add `.golangci.yml` in Task 0.1 if absent). Report real command output — never "looks correct". (go-standards §8, §8.5)
+- **Secrets:** WeatherFlow `TOKEN`, `LITESTREAM_*` creds, and any S3 creds live only in env; never in the bundle, `localStorage`, logs, or committed files. Scrub `*url.Error` before logging. (design §15)
+- **Commit discipline:** one commit per task at minimum; conventional-commit messages; end commit messages with the Co-Authored-By trailer.
+
+---
+
+## Dependencies to Add (pinned)
+
+Add these as tasks reach them (do not add all up front — YAGNI; add per consuming task). Versions are floors; run `go mod tidy` after each `go get`.
+
+**Go modules:**
+| Module | Version | Consuming workstream |
+|---|---|---|
+| `modernc.org/sqlite` | `v1.34.4` | WS3 (SQLite writer) |
+| `go.opentelemetry.io/otel` | `v1.32.0` | WS6 |
+| `go.opentelemetry.io/otel/sdk` | `v1.32.0` | WS6 |
+| `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc` | `v1.32.0` | WS6 |
+| `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` | `v1.32.0` | WS6 |
+| `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc` | `v0.8.0` (experimental) | WS6 |
+| `go.opentelemetry.io/otel/log` + `.../sdk/log` | `v0.8.0` | WS6 |
+| `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` | `v0.57.0` | WS6/WS1 |
+| `go.opentelemetry.io/otel/exporters/prometheus` | `v0.54.0` | WS4 (Task 4.1 name-translation assertion) |
+| `github.com/google/uuid` | `v1.6.0` (already present) | WS3 |
+
+> Before writing any OTel code, confirm current APIs via Context7 (`resolve-library-id` → `query-docs` for `go.opentelemetry.io/otel`) — the OTLP log signal is experimental and its API moves. Do not code OTel from memory.
+
+**Python (radar sidecar, `radar/requirements.txt`):**
+| Package | Version | Purpose |
+|---|---|---|
+| `fastapi` | `>=0.115,<1` | HTTP framework |
+| `uvicorn[standard]` | `>=0.32,<1` | ASGI server |
+| `arm-pyart` | `>=1.19` | NEXRAD L3 decode (`pyart.io.read_nexrad_level3`) |
+| `boto3` | `>=1.35` | anonymous S3 (`s3://unidata-nexrad-level3`) |
+| `geojsoncontour` | `>=0.4` | contour → GeoJSON isobands |
+| `matplotlib` | `>=3.9` | contourf backend (headless `Agg`) |
+| `pytest` | `>=8.3` | sidecar tests |
+
+**JS (UI, `web/package.json` — vendored from `tempest-display@49892063`):**
+| Package | Version | Purpose |
+|---|---|---|
+| `maplibre-gl` | `^4.7` | radar map card |
+| `pmtiles` | `^3.2` | read the same-origin OSM `.pmtiles` basemap (MapLibre protocol) |
+| `vitest` | `^2.1` | unit tests (currently none) |
+| `@testing-library/react` | `^16` | component/error-boundary tests |
+
+**Compose images (digest-pin at task time):** `otel/opentelemetry-collector-contrib`, `prom/prometheus`, `grafana/grafana`, `litestream/litestream`, `minio/minio`, and this repo's `radar-sidecar` image.
+
+---
+
+## Cross-Task Contracts (single source of truth — dependents cite these by name)
+
+These three contracts have consumers on both sides of a task boundary. They are defined once here; tasks that produce or consume them reference **Contract A/B/C** rather than re-deriving. Changing a contract is a one-edit change here.
+
+### Contract A — Go ↔ Radar Sidecar HTTP contract (WS2)
+
+- **Request:** `GET /radar?site={SSS}&product={N0B|N0Q}` on the sidecar (default sidecar addr `http://radar-sidecar:8081`). `{SSS}` = 3-char uppercase WSR-88D site (no leading `K`), validated by the Go side against the static site table before the call (SSRF guard).
+- **Success (HTTP 200), `Content-Type: application/json`:**
+  ```json
+  {
+    "type": "FeatureCollection",
+    "features": [ { "type": "Feature", "properties": { "dbz_min": 20, "dbz_max": 25 }, "geometry": { "type": "Polygon", "coordinates": [ ... ] } } ],
+    "metadata": { "site": "TLX", "product": "N0B", "scan_time": "2026-07-17T18:42:10Z", "bbox": [minLon, minLat, maxLon, maxLat] }
+  }
+  ```
+  Isobands are 5-dBZ steps over the NWS reflectivity scale; each `Feature.properties` carries `dbz_min`/`dbz_max` (band bounds) for client-side data-driven styling.
+- **Error — single transport, no ambiguity: a non-200 status code + a JSON error envelope**, `Content-Type: application/json`. (Chosen over "HTTP 200 + envelope" so the Go client can branch on `resp.StatusCode` alone; the Python side MUST NOT return 200 on error.) Status→error mapping the sidecar emits:
+  - `503` → `{ "error": "no_recent_scan" }` (no decodable NIDS object in S3 for the requested `site`/`product`)
+  - `502` → `{ "error": "decode_failed" }` (object found but Py-ART/contour raised)
+  - `500` → `{ "error": "internal" }` (any other server-side failure)
+  ```json
+  { "error": "no_recent_scan" }
+  ```
+  `error` ∈ {`no_recent_scan`, `decode_failed`, `internal`}. The Go side reads `resp.StatusCode != 200` → decode the envelope → map to `/api/radar/{site}` responses (see Contract C) and degrade gracefully (soft-fail, mirroring DRAS).
+- **Cache key (Go side):** `(site, product, scan_time)`. TTL ≈ one scan cycle (~5 min). Bounded in-memory LRU.
+
+### Contract B — OTel instrument → Prometheus name map (WS6, consumed by WS4)
+
+Instruments are named with dotted OTel convention; the Collector's OTLP→Prometheus translation yields the underscore names on the right. WS4 PromQL uses ONLY the right column. `serial` is a metric label (resource attribute `tempest.serial`); `kind` distinguishes air/gust/avg etc.
+
+| OTel instrument | Kind | Prometheus name | Notes |
+|---|---|---|---|
+| `tempest.temperature.c` | Gauge | `tempest_temperature_c` | label `kind="air"` |
+| `tempest.dewpoint.c` | Gauge | `tempest_dewpoint_c` | derived |
+| `tempest.heat_index.c` | Gauge | `tempest_heat_index_c` | derived |
+| `tempest.wetbulb.c` | Gauge | `tempest_wetbulb_c` | derived (skip if NaN) |
+| `tempest.humidity.percent` | Gauge | `tempest_humidity_percent` | |
+| `tempest.pressure.mb` | Gauge | `tempest_pressure_mb` | |
+| `tempest.wind.meters_per_second` | Gauge | `tempest_wind_meters_per_second` | fixes `_ms` (D-MEDIUM); `kind` ∈ {avg,gust,lull} |
+| `tempest.wind.direction.degrees` | Gauge | `tempest_wind_direction_degrees` | |
+| `tempest.uv.index` | Gauge | `tempest_uv_index` | |
+| `tempest.irradiance.w_m2` | Gauge | `tempest_irradiance_w_m2` | |
+| `tempest.illuminance.lux` | Gauge | `tempest_illuminance_lux` | |
+| `tempest.rain_rate.mm_min` | Gauge | `tempest_rain_rate_mm_min` | |
+| `tempest.rainfall.mm` | Counter | `tempest_rainfall_mm_total` | wires dead `RainTotal` (D-MEDIUM) |
+| `tempest.lightning.distance.km` | Gauge | `tempest_lightning_distance_km` | |
+| `tempest.lightning.strike_count` | Counter | `tempest_lightning_strike_count_total` | |
+| `tempest.battery.volts` | Gauge | `tempest_battery_volts` | |
+| `tempest.rssi.dbm` | Gauge | `tempest_rssi_dbm` | |
+| `tempest.uptime.seconds` | Gauge | `tempest_uptime_seconds` | fixes `_total` (D-MEDIUM) |
+| `tempest.reboots` | Counter | `tempest_reboots_total` | |
+| `tempest.bus_errors` | Counter | `tempest_bus_errors_total` | |
+
+Resource attributes: `service.name=tempestwx`, `service.version`, `host.name`, `tempest.serial` (replaces reserved `instance` label — fixes D-MEDIUM).
+
+### Contract C — Backend JSON API shapes (WS1, consumed by UI data layer)
+
+All endpoints are tokenless from the browser and `otelhttp`-traced. Shapes match the UI's existing `web/src/types/weather.ts` (SI units). The exact TypeScript interfaces are reproduced verbatim in **Task 1.1's UI manifest** (below) — that manifest is the single source for these field names; do NOT invent names. The Go handlers marshal JSON whose keys match those interface field names exactly (e.g. `airTemperature`, `stationPressure`, `windAvg`, `dewPoint`).
+
+| Endpoint | Source | Response (interface from `web/src/types/weather.ts`) |
+|---|---|---|
+| `GET /api/observations/current` | sqlite latest row | one `CurrentObservation` object (SI; keys `timestamp,windLull,windAvg,windGust,windDirection,windSampleInterval,stationPressure,airTemperature,relativeHumidity,illuminance,uvIndex,solarRadiation,rainAccumulated,precipitationType,lightningStrikeAvgDistance,lightningStrikeCount,battery,reportInterval,localDayRainAccumulation,feelsLike,dewPoint,wetBulbTemperature,heatIndex,windChill,pressureTrend`). Derived fields (`feelsLike`,`dewPoint`,`wetBulbTemperature`,`heatIndex`,`windChill`,`pressureTrend`) are computed server-side from the stored row. Resolves UI B-H2. |
+| `GET /api/observations/history?field=&from=&to=` | sqlite range query | `{ "points": [ { "t": <epoch>, "v": <float> } ] }` |
+| `GET /api/station` | WeatherFlow REST proxy (`Bearer`) | `StationMeta` (`station_id,name,latitude,longitude,elevation,timezone,firmware_revision,serial_number,device_id`) |
+| `GET /api/forecast` | WeatherFlow REST proxy (`Bearer`) | Better-Forecast → `ForecastDay[]`/`HourlyForecast[]` passthrough |
+| `GET /api/almanac` | **WeatherFlow REST proxy (`Bearer`)** — B3: proxy, not computed | `StationAlmanac` (`today/week/month/year: TempRecord`, `sunrise,sunset,moonPhase,moonPhaseName,moonIllumination`) proxied from the WeatherFlow Better-Forecast/station endpoints |
+| `GET /api/radar/{site}?product=N0B` | `internal/radar` → sidecar (Contract A) | GeoJSON + metadata, or `{ "error": "..." }` with HTTP 502/503 mapping. Opt-in `ENABLE_RADAR`. |
+| `GET /healthz` | — | `200 {"status":"ok"}` |
+| `GET /metrics` | legacy prometheus scrape | deprecated; kept one release (O4) |
+
+---
+
+# Task List
+
+Grouped by workstream in the design's §19 execution order. Task IDs are `W<workstream>.<n>`. Each task ends with an independently testable deliverable.
+
+---
+
+## Workstream 0 — Foundation: lifecycle & review-fix bedrock
+
+> Design §6. Do FIRST. Early tasks (0.1–0.6) are self-contained and do NOT depend on the interface change, so they keep the tree green. Task 0.7 changes the `MetricsWriter` interface and MUST update all existing implementers in the same task.
+
+### Task 0.1: Add project tooling — `.golangci.yml`, slog baseline, gofmt fix — no deps
+
+**Files:**
+- Create: `.golangci.yml`
+- Modify: `internal/tempest/metrics.go` (gofmt only)
+
+**Steps:**
+- [ ] **Step 1:** Add `.golangci.yml` enabling `govet, errcheck, staticcheck, gosec, unused, gocritic` (go-standards §8.5).
+- [ ] **Step 2:** Run `gofmt -w internal/tempest/metrics.go` (fixes the review's gofmt-clean finding).
+- [ ] **Step 3 (verify):** `gofmt -l ./...` → prints nothing; `golangci-lint run ./...` → exits clean (fix or `//nolint`-with-justification any pre-existing hits, documenting each).
+- [ ] **Step 4:** Commit `chore: add golangci config, gofmt metrics.go`.
+
+**Acceptance:** `gofmt -l ./...` empty; `golangci-lint run ./...` clean; `go build ./...` clean.
+**Implements:** review NIT (gofmt), go-standards §8.5.
+
+### Task 0.2: Guard `RadioStats` indexing (CRITICAL C-1) — no deps
+
+**Files:**
+- Modify: `internal/tempestudp/report.go` (`HubStatusReport.Metrics`, ~line 258-266)
+- Test: `internal/tempestudp/report_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `TestHubStatusReport_ShortRadioStats` to `internal/tempestudp/report_test.go`: parse a `hub_status` packet whose `radio_stats` is `[]` (and separately `null`, and `[1]`), call `.Metrics()`, assert it returns without panicking and omits the reboots/bus_errors metrics (len reflects only uptime+rssi).
+- [ ] **Step 2:** Run `go test ./internal/tempestudp/ -run TestHubStatusReport_ShortRadioStats` → FAIL with index-out-of-range panic.
+- [ ] **Step 3 (GREEN):** Wrap the `RadioStats[1]`/`[2]` metrics in `if len(r.RadioStats) >= 3 { ... }`; build the slice conditionally.
+- [ ] **Step 4:** Run the test → PASS.
+- [ ] **Step 5:** Commit `fix: guard RadioStats index to prevent remote panic (C-1)`.
+
+**Acceptance:** `go test -race ./internal/tempestudp/ -run TestHubStatusReport_ShortRadioStats` passes; `go build ./...` clean.
+**Implements:** design §6; resolves **C-1** (CRITICAL).
+
+### Task 0.3: `wetBulb` returns NaN instead of panicking (E-MEDIUM) — no deps
+
+**Files:**
+- Modify: `internal/tempestudp/wetbulb.go`
+- Test: `internal/tempestudp/wetbulb_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `TestWetBulb_NonConvergentReturnsNaN`: call `WetBulbTemperatureC` with inputs that do not converge, assert `math.IsNaN(result)` (not a panic). Keep an existing convergent-case assertion.
+- [ ] **Step 2:** Run → FAIL (panic "failed to converge").
+- [ ] **Step 3 (GREEN):** Replace `panic("failed to converge")` with `return math.NaN()`. Modernize the loop to `for range 10000`.
+- [ ] **Step 4:** In `internal/tempestudp/report.go`, ensure the caller skips emitting the wet-bulb metric when the value is NaN (guard `if !math.IsNaN(wb)`).
+- [ ] **Step 5:** Run `go test -race ./internal/tempestudp/` → PASS.
+- [ ] **Step 6:** Commit `fix: wetBulb returns NaN instead of panicking (E-MEDIUM)`.
+
+**Acceptance:** `go test -race ./internal/tempestudp/` passes.
+**Implements:** design §6; resolves **E-MEDIUM** (wet-bulb panic).
+
+### Task 0.4: Postgres DSN via `net/url` (B-HIGH credential escaping) — no deps
+
+**Files:**
+- Modify: `internal/config/database.go` (`GetDatabaseConfig`)
+- Test: `internal/config/database_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `TestGetDatabaseConfig_EscapesCredentials`: set `POSTGRES_HOST/USERNAME/PASSWORD/NAME` via `t.Setenv`, with a password containing `@ : / ? # &` special chars; assert the returned DSN round-trips through `net/url.Parse` and `url.User.Password()` returns the exact original password.
+- [ ] **Step 2:** Run → FAIL (raw `fmt.Sprintf` corrupts special chars).
+- [ ] **Step 3 (GREEN):** Replace the raw `fmt.Sprintf` at `internal/config/database.go:52-53` with a `net/url`-built DSN. The full function body after the change (the `POSTGRES_URL` precedence branch and the required-field checks above line 47 are unchanged — only the construction at the bottom changes):
+
+```go
+import (
+	"cmp"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+)
+
+// ... (POSTGRES_URL precedence + host/username/password/dbname required-field
+//      checks unchanged from the current file) ...
+
+	port := cmp.Or(os.Getenv("POSTGRES_PORT"), "5432")
+	sslmode := cmp.Or(os.Getenv("POSTGRES_SSLMODE"), "disable")
+
+	u := url.URL{
+		Scheme: "postgresql",
+		User:   url.UserPassword(username, password), // percent-encodes @ : / ? # &
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/" + dbname,
+	}
+	u.RawQuery = url.Values{"sslmode": {sslmode}}.Encode()
+	return u.String(), nil
+```
+
+  Note: `url.UserPassword` percent-encodes the credentials, and `u.String()` round-trips cleanly through `url.Parse`, which is exactly what the RED test asserts. `pgxpool.ParseConfig` (used by the postgres writer) accepts this URL form.
+- [ ] **Step 4:** Run `go test ./internal/config/` → PASS.
+- [ ] **Step 5:** Commit `fix: build postgres DSN with net/url to escape credentials (B-HIGH)`.
+
+**Acceptance:** `go test ./internal/config/` passes.
+**Implements:** design §6; resolves **B-HIGH**.
+
+### Task 0.5: Harden the WeatherFlow API client (F-H1..H4, F-MEDIUM) — no deps
+
+**Files:**
+- Modify: `internal/tempestapi/client.go`
+- Test: `internal/tempestapi/client_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add tests using `httptest.Server`:
+  - `TestClient_UsesBearerHeader_NotURLToken`: assert the request `Authorization` header == `"Bearer "+token` and the request URL query has NO `token=` param.
+  - `TestClient_ReturnsErrorOn401`: server returns 401 → `ListStations`/`GetObservations` return a non-nil error mentioning the status, do NOT decode as success.
+  - `TestClient_HasTimeout`: assert the client's `Timeout` is `30 * time.Second` (via an exported field or a slow server + short ctx that returns a deadline error).
+  - `TestClient_UnhandledReportType_ReturnsError`: feed an observation the switch can't handle → returns error (NOT `log.Fatalf`).
+  - `TestClient_ChecksStatusCode` (F-MEDIUM): API JSON `status.status_code != 0` → error.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Rework `internal/tempestapi/client.go`:
+  - `Client` gains an owned client: `type Client struct { token string; http *http.Client }`; `NewClient` returns `*Client` with `http: &http.Client{Timeout: 30 * time.Second}`. Change both methods (`ListStations`, `GetObservations`) to **pointer receiver** `func (c *Client) ...` to match.
+  - **Bearer, not URL token:** drop the `?token=`/`&token=` from both request URLs (`client.go:34` and `client.go:90`); after building the request, `req.Header.Set("Authorization", "Bearer "+c.token)`. (WeatherFlow's REST API accepts `Authorization: Bearer <PAT>` — design §20.) The `GetObservations` URL becomes `fmt.Sprintf("https://swd.weatherflow.com/swd/rest/observations/device/%d?time_start=%d&time_end=%d", station.deviceID, startAt.Unix(), endAt.Unix())`.
+  - Use `c.http.Do(req)` (not `http.DefaultClient`).
+  - After `Do`: `if resp.StatusCode != http.StatusOK { return nil, fmt.Errorf("weatherflow API status %d", resp.StatusCode) }` **before** decode.
+  - Bound the body: `body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))` (10 MB).
+  - After decode, check the API envelope: `if data.Status.StatusCode != 0 { return nil, fmt.Errorf("weatherflow status_code %d: %s", data.Status.StatusCode, data.Status.StatusMessage) }` (F-MEDIUM).
+  - Replace `log.Fatalf("unhandled report type")` at `client.go:116` with `return nil, fmt.Errorf("unhandled report type %T", report)`.
+  - The URL no longer contains the token, so a `*url.Error` from `Do` cannot leak it; do not log raw request URLs elsewhere.
+- [ ] **Step 4:** Update `main.go` call sites for the pointer-receiver ripple: `client := tempestapi.NewClient(token)` now yields `*tempestapi.Client` (line ~168 in `exportWithSink`); the `client.ListStations`/`client.GetObservations` calls are unchanged (method set is identical on the pointer). Confirm `go build ./...` — no other call sites exist.
+- [ ] **Step 5:** Run `go test -race ./internal/tempestapi/` → PASS; `go build ./...` clean.
+- [ ] **Step 6:** Commit `fix: harden API client — bearer header, status check, timeout, no log.Fatalf (F-H1..H4)`.
+
+**Acceptance:** `go test -race ./internal/tempestapi/` passes; `go build ./...` clean.
+**Implements:** design §6; resolves **F-H1, F-H2, F-H3, F-H4, F-MEDIUM**.
+
+### Task 0.6: Explicit boolean env parsing (A-MEDIUM silent-typo) — no deps
+
+**Files:**
+- Create: `internal/config/env.go`
+- Test: `internal/config/env_test.go`
+- Modify: `main.go` (replace `strconv.ParseBool(os.Getenv(...))` discards)
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `TestParseBoolEnv`: `ParseBoolEnv("KEY")` where the env is unset → `false, nil`; `"true"`/`"1"` → `true, nil`; `"yes"`/`"nonsense"` → `false, error` naming the key and value.
+- [ ] **Step 2:** Run → FAIL (function missing).
+- [ ] **Step 3 (GREEN):** Implement `func ParseBoolEnv(key string) (bool, error)` — empty ⇒ false; otherwise `strconv.ParseBool`, wrapping the error with the key.
+- [ ] **Step 4:** In `main.go`, replace each discarded `strconv.ParseBool` with `config.ParseBoolEnv`, logging and treating a parse error as fatal-at-startup (fail fast, go-standards §15.3). Keep behavior identical for valid values.
+- [ ] **Step 5:** Run `go test ./internal/config/`; `go build ./...` → clean.
+- [ ] **Step 6:** Commit `fix: fail loud on unparseable boolean env vars (A-MEDIUM)`.
+
+**Acceptance:** `go test ./internal/config/` passes; `go build ./...` clean.
+**Implements:** design §6; resolves **A-MEDIUM** (silent-typo-disables-a-sink).
+
+### Task 0.7: Rework the sink seam — `Close(ctx)`, panic recovery, error aggregation; update all writers — depends on: Task 0.2
+
+**Files:**
+- Modify: `internal/sink/sink.go` (interface + `MetricsSink`)
+- Modify: `internal/postgres/writer.go` (implement new `Close(ctx)`)
+- Modify: `internal/prometheus/writer.go`, `internal/prometheus/server.go` (implement new `Close(ctx)`)
+- Modify: `main.go` (call `Close(cleanupCtx)`)
+- Test: `internal/sink/sink_test.go`
+
+> **Compile-breaking ripple — do it all in this one task:** changing `MetricsWriter.Close() error` → `Close(ctx context.Context) error` breaks every implementer. Update postgres AND prometheus AND server writers AND main.go in this task or `go build ./...` fails and acceptance cannot pass.
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add to `internal/sink/sink_test.go`:
+  - `TestSink_RecoversPanickingWriter`: a fake writer whose `WriteReport` panics; `SendReport` must not propagate the panic, must log/count it, and must still call the other (non-panicking) writer. Run with `-race`.
+  - `TestSink_SendReportAggregatesErrors`: two fake writers both returning errors → `SendReport` returns a non-nil aggregated error (`errors.Join`); one failing + one ok → still non-nil naming the failure; all ok → nil.
+  - `TestSink_ClosePassesContext`: a fake writer records the ctx passed to `Close`; assert it is the caller-supplied cleanup ctx (not a stored/cancelled one).
+- [ ] **Step 2:** Run `go test ./internal/sink/` → FAIL.
+- [ ] **Step 3 (GREEN):**
+  - **Interface** (`internal/sink/sink.go`): change `Close() error` → `Close(ctx context.Context) error`. Drop the stored `ctx context.Context` field from `MetricsSink` and `NewMetricsSink` (Review A NIT / C-LOW) — keep `NewMetricsSink()` taking no ctx (update the `main.go` call). Switch the package's `log` import to `log/slog`.
+  - **`SendReport` / `SendMetrics`** — the current fan-out swallows errors and returns nil. Replace with panic-recovery + mutex-guarded aggregation. `SendReport` becomes (SendMetrics is identical with `WriteMetrics(ctx, metrics)`):
+
+```go
+func (s *MetricsSink) SendReport(ctx context.Context, report tempestudp.Report) error {
+	s.mu.RLock()
+	writers := slices.Clone(s.writers)
+	s.mu.RUnlock()
+
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+	for _, w := range writers {
+		wg.Add(1)
+		go func(writer MetricsWriter) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("writer panic recovered", "panic", r, "writer", fmt.Sprintf("%T", writer))
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("writer %T panicked: %v", writer, r))
+					mu.Unlock()
+				}
+			}()
+			if err := writer.WriteReport(ctx, report); err != nil {
+				mu.Lock() // mutex guards the append — required, else -race flags the concurrent slice write
+				errs = append(errs, fmt.Errorf("writer %T: %w", writer, err))
+				mu.Unlock()
+			}
+		}(w)
+	}
+	wg.Wait()
+	return errors.Join(errs...) // nil when errs is empty
+}
+```
+
+  - **`Close(ctx)`** fans out `Flush(ctx)` then `Close(ctx)` per writer using the **passed** ctx (never a stored one), aggregating errors the same way:
+
+```go
+func (s *MetricsSink) Close(ctx context.Context) error {
+	s.mu.RLock()
+	writers := slices.Clone(s.writers)
+	s.mu.RUnlock()
+
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+	for _, w := range writers {
+		wg.Add(1)
+		go func(writer MetricsWriter) {
+			defer wg.Done()
+			if err := writer.Flush(ctx); err != nil {
+				mu.Lock(); errs = append(errs, err); mu.Unlock()
+			}
+			if err := writer.Close(ctx); err != nil {
+				mu.Lock(); errs = append(errs, err); mu.Unlock()
+			}
+		}(w)
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+```
+
+  - **Implementer signature updates (compile ripple — all in this task):**
+    - `internal/postgres/writer.go`: `func (w *PostgresWriter) Close(ctx context.Context) error` (body still `close`s the four batch channels + `wg.Wait()` + `pool.Close()` for now; the drain rework is Task 0.8, the gate is Task 0.9a).
+    - `internal/prometheus/writer.go` and `internal/prometheus/server.go`: `func (...) Close(ctx context.Context) error` — accept and ignore `ctx` for now (`MetricsServer.Close` already builds its own 5s ctx internally; keep that, the param is unused until 0.9b). Real gate is Task 0.9b.
+  - **`main.go`** (`main`, lines ~28-34): keep the ingest `signal.NotifyContext` (SIGTERM is added in Task 0.8), change the sink construction + deferred close:
+
+```go
+	metricsSink := sink.NewMetricsSink()
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := metricsSink.Close(cleanupCtx); err != nil {
+			slog.Error("sink close", "err", err)
+		}
+	}()
+```
+- [ ] **Step 4:** Run `go test -race ./internal/sink/ ./internal/postgres/ ./internal/prometheus/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `refactor: sink Close(ctx) + panic recovery + error aggregation (A-MEDIUM, A-LOW)`.
+
+**Acceptance:** `go test -race ./internal/sink/...` passes; `go build ./...` clean.
+**Interfaces produced:** `MetricsWriter.Close(ctx context.Context) error`, `MetricsSink.Close(ctx context.Context) error` — WS3/WS6 writers implement this signature.
+**Implements:** design §6; resolves **A-MEDIUM** (panic recovery, cleanup ctx), **A-LOW** (dead nil returns).
+
+### Task 0.8: SIGTERM + drain-on-shutdown for postgres writer (A-H1, cleanup ctx, C-H1) — depends on: Task 0.7
+
+**Files:**
+- Modify: `main.go` (`signal.NotifyContext`)
+- Modify: `internal/postgres/writer.go` (drain the channel buffer under the cleanup ctx)
+- Test: `internal/postgres/writer_test.go`
+
+> **Test seam decision (resolves the cold-review ambiguity):** do NOT try to test `main` sending itself a signal. Instead extract `signalContext` with an **injectable `notify` function** so the test asserts the exact signal set passed to `signal.NotifyContext` without any real signals. This is the acceptance criterion for A-H1 (the design's #1 HIGH).
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `main_test.go`:
+
+```go
+func TestSignalContext_RegistersInterruptAndSIGTERM(t *testing.T) {
+	var gotSigs []os.Signal
+	fakeNotify := func(parent context.Context, sig ...os.Signal) (context.Context, context.CancelFunc) {
+		gotSigs = sig
+		return context.WithCancel(parent)
+	}
+	_, cancel := signalContext(context.Background(), fakeNotify)
+	defer cancel()
+	if !slices.Contains(gotSigs, os.Interrupt) || !slices.Contains(gotSigs, syscall.SIGTERM) {
+		t.Fatalf("signalContext must register SIGINT+SIGTERM, got %v", gotSigs)
+	}
+}
+```
+
+  Also add `TestPostgresWriter_DrainOnClose` in `internal/postgres/writer_test.go`: enqueue N observation rows into `w.obsBatch`, call `Close(ctx)` with a fresh `context.Background()`-derived ctx, assert all N reach the insert path (buffered channel drained, not just a local slice). Because the current writer needs a live pool, extract the drain loop over an injectable `inserter` interface (`interface{ insertObservations(ctx, []observationRow) error }`) so a fake inserter counts rows; keep a `//go:build integration` real-DB variant that exercises the pool.
+- [ ] **Step 2:** Run `go test ./ -run TestSignalContext` and `go test ./internal/postgres/ -run TestPostgresWriter_DrainOnClose` → FAIL (helper/behavior missing).
+- [ ] **Step 3 (GREEN):**
+  - **`main.go`** — extract the injectable helper and call it from `main`:
+
+```go
+// notifyFunc matches signal.NotifyContext so tests can inject a fake.
+type notifyFunc func(parent context.Context, sig ...os.Signal) (context.Context, context.CancelFunc)
+
+func signalContext(parent context.Context, notify notifyFunc) (context.Context, context.CancelFunc) {
+	return notify(parent, os.Interrupt, syscall.SIGTERM)
+}
+
+func main() {
+	ctx, done := signalContext(context.Background(), signal.NotifyContext)
+	defer done()
+	// ... rest of main unchanged (sink construction from Task 0.7) ...
+}
+```
+
+  (Add `"syscall"` and `"slices"` to imports; `signal.NotifyContext` satisfies `notifyFunc` directly.) This replaces the current `signal.NotifyContext(context.Background(), os.Interrupt)` at `main.go:29` — SIGTERM is the fix for A-H1.
+  - **`internal/postgres/writer.go`** — on `Close(ctx)`, **drain the full buffered channels and flush using the passed `ctx`**, not the constructor `w.ctx`. (The idempotent send-blocking `done` gate is added *next*, in Task 0.9a; in 0.8 the drain simply reads whatever is already buffered — do not reference a `done` field here, it does not exist yet.) Concretely, the batch workers' `case <-w.ctx.Done():` branches (e.g. `writer.go:162`, `:249`) currently flush only the local `batch` slice and return — change the shutdown path so `Close(ctx)` drains any rows still queued in `w.obsBatch`/`w.windBatch`/`w.hubBatch`/`w.eventBatch` before returning, e.g. a final non-blocking drain loop per channel that calls the batch insert with the cleanup `ctx`.
+    **Signature ripple (explicit):** the four insert helpers `insertObservations`/`insertRapidWind`/`insertHubStatus`/`insertEvents` are currently param-less w.r.t. context (they derive a 5s timeout from `w.ctx` at `writer.go:179` et al., ~`writer.go:174/216/258/300`). Add an explicit `ctx context.Context` first parameter to **all four** and update their existing call sites in the batch workers to pass the worker/normal ctx, and the new drain path to pass the `Close` ctx. This is a mechanical but file-wide change within `internal/postgres/writer.go`; `go build ./internal/postgres/` must stay green after it.
+- [ ] **Step 4:** Run `go test -race ./internal/postgres/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `fix: SIGTERM + drain buffered postgres rows on shutdown (A-H1, C-H1)`.
+
+**Acceptance:** `go test -race ./internal/postgres/` passes; `go build ./...` clean.
+**Implements:** design §6; resolves **A-H1**, **C-H1** (context+drain).
+
+> **Why 0.9 is split into 0.9a / 0.9b:** the two writers have **structurally different channel shapes** — postgres has FOUR producer channels (`obsBatch/windBatch/hubBatch/eventBatch`) whose workers close-signal by `close(channel)`; prometheus has ONE `outbox` chan plus a `more` signal chan and closes both in `Close`. The send-on-closed gate is the *same idea* but *different code* per writer. Do NOT "apply an identical pattern" — each subtask shows its own concrete code.
+
+### Task 0.9a: Idempotent, panic-free `Close` for the **postgres** writer (C-H3, D-H1) — depends on: Task 0.8
+
+> Sequenced after Task 0.8 because both touch the postgres writer's shutdown path: 0.8 adds the buffered-channel drain, 0.9a adds the `done` gate + idempotent `Close` around it. Doing them in one order avoids a merge conflict on `Close`.
+
+**Files:**
+- Modify: `internal/postgres/writer.go`
+- Test: `internal/postgres/writer_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** In `internal/postgres/writer_test.go`:
+  - `TestPostgresClose_Idempotent`: calling `Close(ctx)` twice does not panic and returns nil both times.
+  - `TestPostgresWriteDuringClose_NoPanic`: spawn goroutines calling `WriteReport` (which sends into `obsBatch` etc.) while `Close(ctx)` runs; run under `-race`; assert no send-on-closed-channel panic and `Close` returns.
+- [ ] **Step 2:** Run `go test -race ./internal/postgres/` → FAIL (double-close at `writer.go:857-860` / send-on-closed from the `default:` producer branches).
+- [ ] **Step 3 (GREEN):** The current `Close` (`writer.go:855`) unconditionally `close()`s the four batch channels — a second `Close` double-closes (panic), and a producer's `select { case w.obsBatch <- row: ... default: ... }` (e.g. `writer.go:~545`) can send on an already-closed channel (panic). Add a `done` gate + `sync.Once`, stop closing the batch channels from `Close`, and make workers exit on `<-w.done`:
+
+```go
+// add to the PostgresWriter struct:
+	done      chan struct{}
+	closeOnce sync.Once
+
+// in NewPostgresWriter, initialize:
+	done: make(chan struct{}),
+
+// every producer send changes from `default: log-drop` to gate on done, e.g.:
+	select {
+	case w.obsBatch <- row:
+	case <-w.done: // Close in progress — stop producing, no send-on-closed
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+// each batch worker's shutdown branch selects on w.done instead of a closed channel:
+	case <-w.done:
+		// drain whatever is buffered, then return (see Task 0.8 drain)
+		return
+
+// Close becomes idempotent and never closes the producer channels:
+func (w *PostgresWriter) Close(ctx context.Context) error {
+	w.closeOnce.Do(func() {
+		close(w.done)      // single close — signals producers AND workers
+		w.wg.Wait()        // workers drain (Task 0.8) then return
+		w.pool.Close()
+	})
+	return nil
+}
+```
+
+  Remove the four `close(w.xBatch)` calls. The batch channels are now never closed (GC reclaims them); `done` is the sole shutdown signal.
+- [ ] **Step 4:** Run `go test -race ./internal/postgres/` → PASS.
+- [ ] **Step 5:** Commit `fix: idempotent panic-free Close in postgres writer via done-gate (C-H3, D-H1)`.
+
+**Acceptance:** `go test -race ./internal/postgres/` passes.
+**Implements:** design §6; resolves **C-H3**, **D-H1** (postgres).
+
+### Task 0.9b: Idempotent, panic-free `Close` for the **prometheus** writer (C-H3, D-H1) — depends on: Task 0.7
+
+**Files:**
+- Modify: `internal/prometheus/writer.go`
+- Test: `internal/prometheus/writer_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** In `internal/prometheus/writer_test.go`:
+  - `TestPrometheusClose_Idempotent`: calling `Close(ctx)` twice does not panic and returns nil both times.
+  - `TestPrometheusWriteDuringClose_NoPanic`: spawn goroutines calling `WriteMetrics` (sends into `outbox`, signals `more`) while `Close(ctx)` runs; run under `-race`; assert no send-on-closed panic and `Close` returns.
+- [ ] **Step 2:** Run `go test -race ./internal/prometheus/` → FAIL (double-close of `outbox`/`more` at `writer.go:91-92`; send-on-closed from `WriteMetrics` `writer.go:61` and `Flush`/`WriteMetrics` `more` sends).
+- [ ] **Step 3 (GREEN):** Replace the close-the-channels shutdown with a `done` gate + `sync.Once`. The `pushWorker` currently loops `for range w.more`; change it to select on `done`. Concrete diff:
+
+```go
+// add to the PrometheusWriter struct:
+	done      chan struct{}
+	closeOnce sync.Once
+
+// in NewPrometheusWriter, initialize:
+	done: make(chan struct{}),
+
+// WriteMetrics — the metric send and the `more` signal both gate on done:
+func (w *PrometheusWriter) WriteMetrics(ctx context.Context, metrics []prometheus.Metric) error {
+	for _, m := range metrics {
+		select {
+		case w.outbox <- m:
+		case <-w.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			log.Printf("prometheus: outbox full, dropping metric")
+		}
+	}
+	select {
+	case w.more <- true:
+	case <-w.done:
+	default:
+	}
+	return nil
+}
+
+// pushWorker drains until done, then does one final drain:
+func (w *PrometheusWriter) pushWorker() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.more:
+			if err := w.pusher.Add(); err != nil {
+				log.Printf("prometheus: push error: %v", err)
+			}
+		case <-w.done:
+			_ = w.pusher.Add() // final flush of whatever the collector can drain
+			return
+		}
+	}
+}
+
+// Close is idempotent and closes NO producer channel:
+func (w *PrometheusWriter) Close(ctx context.Context) error {
+	w.closeOnce.Do(func() {
+		close(w.done)
+		w.wg.Wait()
+	})
+	log.Printf("prometheus: closed")
+	return nil
+}
+```
+
+  Remove `close(w.outbox)` and `close(w.more)`. `Flush` keeps its non-blocking `more` send but also gates on `done` (mirror the `select` above).
+- [ ] **Step 4:** Run `go test -race ./internal/prometheus/` → PASS.
+- [ ] **Step 5:** Commit `fix: idempotent panic-free Close in prometheus writer via done-gate (C-H3, D-H1)`.
+
+**Acceptance:** `go test -race ./internal/prometheus/` passes.
+**Implements:** design §6; resolves **C-H3**, **D-H1** (prometheus).
+
+### Task 0.10: Metrics server returns bind errors synchronously (D-H2, A-H3) — depends on: Task 0.7
+
+**Files:**
+- Modify: `internal/prometheus/server.go` (`MetricsServer.Start`)
+- Test: `internal/prometheus/server_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add `TestMetricsServer_StartReturnsBindError`: start one server on a port, then start a second `MetricsServer` on the same port → `Start()` returns a non-nil error (currently always nil).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** In `Start()`, call `net.Listen("tcp", addr)` synchronously; on error return it; on success `go srv.Serve(ln)`. Add `ReadHeaderTimeout`/`IdleTimeout` to the `http.Server` (Global Constraints; also review LOW).
+- [ ] **Step 4:** Run `go test -race ./internal/prometheus/` → PASS. Confirm `main.go`'s existing `if err := metricsServer.Start(); err != nil` is now live.
+- [ ] **Step 5:** Commit `fix: metrics server surfaces bind errors synchronously (D-H2, A-H3)`.
+
+**Acceptance:** `go test -race ./internal/prometheus/` passes.
+**Implements:** design §6; resolves **D-H2**, **A-H3**.
+
+### Task 0.11: Fix API-export "at least one writer" invariant + gzip `O_TRUNC` (A-H2, A-MEDIUM) — depends on: Task 0.6
+
+**Files:**
+- Modify: `main.go` (writer-count check; `writeMetricsToFile` open flags)
+- Test: `main_test.go` (create)
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add to `main_test.go`:
+
+```go
+func TestRequireWriters(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        Mode
+		writerCount int
+		keepFiles   bool
+		wantErr     bool
+	}{
+		{"udp no writers", ModeUDP, 0, false, true},
+		{"udp one writer", ModeUDP, 1, false, false},
+		{"api no writers no files", ModeAPIExport, 0, false, true},
+		{"api no writers keep files", ModeAPIExport, 0, true, false},
+		{"api db writer", ModeAPIExport, 1, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireWriters(tc.mode, tc.writerCount, tc.keepFiles)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("requireWriters(%v,%d,%v) err=%v want err=%v", tc.mode, tc.writerCount, tc.keepFiles, err, tc.wantErr)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2:** Run `go test ./ -run TestRequireWriters` → FAIL (`Mode`/`requireWriters` undefined).
+- [ ] **Step 3 (GREEN):** Add the `Mode` type and helper to `main.go`, and call it in place of the current `if metricsSink.WriterCount() == 0` block (`main.go:86-88`):
+
+```go
+type Mode int
+
+const (
+	ModeUDP Mode = iota // UDP listener (no TOKEN)
+	ModeAPIExport       // historical export (TOKEN set)
+)
+
+// requireWriters enforces the "at least one writer" invariant, but only where
+// it applies: UDP mode always needs a writer; API-export mode is satisfied by a
+// DB writer OR KEEP_EXPORT_FILES (fixes A-H2 — gzip-only export was unreachable).
+func requireWriters(mode Mode, writerCount int, keepFiles bool) error {
+	if writerCount > 0 {
+		return nil
+	}
+	if mode == ModeAPIExport && keepFiles {
+		return nil
+	}
+	return fmt.Errorf("no writers configured: set ENABLE_POSTGRES / ENABLE_OTEL / ENABLE_PROMETHEUS_* (or KEEP_EXPORT_FILES in API-export mode)")
+}
+```
+
+  In `main`, compute `mode` from `token` (`ModeAPIExport` when `token != ""`, else `ModeUDP`), read `keepFiles` via `config.ParseBoolEnv("KEEP_EXPORT_FILES")` (from Task 0.6), and `if err := requireWriters(mode, metricsSink.WriterCount(), keepFiles); err != nil { log.Fatal(err) }`. Also add `os.O_TRUNC` to the gzip open flags at `main.go:243`: `os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)` (A-MEDIUM corrupt-overwrite when a shorter export overwrites a longer file).
+- [ ] **Step 4:** Run `go test ./... -run TestWriterInvariant`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `fix: reachable gzip-only export mode + O_TRUNC (A-H2, A-MEDIUM)`.
+
+**Acceptance:** `go test ./ -run TestWriterInvariant` passes; `go build ./...` clean.
+**Implements:** design §6/§16; resolves **A-H2**, **A-MEDIUM** (file truncation).
+
+### Task 0.12: CI/supply-chain fixes (G-H1..H3) — no deps
+
+**Files:**
+- Modify: `.github/actions/docker/action.yml` (undeclared `inputs.push`)
+- Modify: `.github/workflows/*.yml` (add `permissions:` blocks; pin actions to SHAs; align Go to 1.24)
+- Create: `.goreleaser.yaml`
+- Modify: `.dockerignore` (add local binary + `docs/`)
+
+**Steps:**
+- [ ] **Step 1:** Fix the input mismatch. Verified against the tree: `.github/actions/docker/action.yml` declares only `inputs.token` but its last step uses `push: ${{ fromJSON(inputs.push) }}`, while `.github/workflows/on-push-main.yml` passes `latest: true`, `push: true`, `tag-strategy: "latest"` — three undeclared inputs. Add the missing declarations to `action.yml`'s `inputs:` block so the caller's inputs resolve:
+
+```yaml
+inputs:
+  token:
+    description: Github token
+    required: true
+  push:
+    description: Whether to push the built image
+    required: false
+    default: "false"
+  latest:
+    description: Also tag the image as latest
+    required: false
+    default: "false"
+  tag-strategy:
+    description: Tag strategy (e.g. latest, semver)
+    required: false
+    default: "latest"
+```
+
+  (`fromJSON("true")`/`fromJSON("false")` yields the boolean the `if:`/`push:` fields need.) Confirm `on-release.yml` and `on-pull-request.yml` callers pass a matching subset.
+- [ ] **Step 2:** Add least-privilege `permissions:` to every workflow; pin third-party actions to commit SHAs; set CI Go to `1.24`; commit a minimal `.goreleaser.yaml`; add `actionlint` to CI.
+- [ ] **Step 3 (verify):** `actionlint` clean; `docker buildx bake image-local` still builds (Task depends on Dockerfile as-is; WS1 rewrites it later).
+- [ ] **Step 4:** Commit `ci: fix docker action inputs, add permissions + goreleaser (G-H1..H3)`.
+
+**Acceptance:** `actionlint` reports no errors; existing image build succeeds.
+**Implements:** design §15; resolves **G-H1, G-H2 (partial — README in Task DOC.1), G-H3**.
+
+### Task 0.13: Wire the legacy Postgres tunables from env (C-H2 for the Postgres path) — no deps
+
+> **User decision B1.** `POSTGRES_BATCH_SIZE` / `POSTGRES_FLUSH_INTERVAL` / `POSTGRES_MAX_RETRIES` are documented (CLAUDE.md) but currently **hardcoded and inert** in `NewPostgresWriter` (`writer.go:133-135` — `batchSize:100, flushInterval:10*time.Second, maxRetries:3`). This is C-H2 for the legacy Postgres writer (the design previously applied the C-H2 *lesson* only to the new SQLite store). Wire them so a set env value takes effect.
+
+**Files:**
+- Create: `internal/postgres/tunables.go`
+- Modify: `internal/postgres/writer.go` (`NewPostgresWriter` reads tunables)
+- Test: `internal/postgres/tunables_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `internal/postgres/tunables_test.go`:
+
+```go
+func TestPostgresTunables(t *testing.T) {
+	getenv := func(k string) string {
+		return map[string]string{
+			"POSTGRES_BATCH_SIZE":     "7",
+			"POSTGRES_FLUSH_INTERVAL": "2s",
+			"POSTGRES_MAX_RETRIES":    "5",
+		}[k]
+	}
+	tn := postgresTunables(getenv)
+	if tn.batchSize != 7 || tn.flushInterval != 2*time.Second || tn.maxRetries != 5 {
+		t.Fatalf("tunables not applied: %+v", tn)
+	}
+	// defaults when unset:
+	def := postgresTunables(func(string) string { return "" })
+	if def.batchSize != 100 || def.flushInterval != 10*time.Second || def.maxRetries != 3 {
+		t.Fatalf("defaults wrong: %+v", def)
+	}
+}
+```
+
+- [ ] **Step 2:** Run `go test ./internal/postgres/ -run TestPostgresTunables` → FAIL (`postgresTunables` undefined).
+- [ ] **Step 3 (GREEN):** Add the pure helper (testable without a live DB), then call it in `NewPostgresWriter`:
+
+```go
+type tunables struct {
+	batchSize     int
+	flushInterval time.Duration
+	maxRetries    int
+}
+
+func postgresTunables(getenv func(string) string) tunables {
+	atoiOr := func(s string, def int) int {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return n
+		}
+		return def
+	}
+	durOr := func(s string, def time.Duration) time.Duration {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+		return def
+	}
+	return tunables{
+		batchSize:     atoiOr(getenv("POSTGRES_BATCH_SIZE"), 100),
+		flushInterval: durOr(getenv("POSTGRES_FLUSH_INTERVAL"), 10*time.Second),
+		maxRetries:    atoiOr(getenv("POSTGRES_MAX_RETRIES"), 3),
+	}
+}
+```
+
+  In `NewPostgresWriter`, replace the hardcoded literals with `tn := postgresTunables(os.Getenv)` and set `batchSize: tn.batchSize, flushInterval: tn.flushInterval, maxRetries: tn.maxRetries`.
+- [ ] **Step 4:** Run `go test ./internal/postgres/ -run TestPostgresTunables`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `fix: honor POSTGRES_BATCH_SIZE/FLUSH_INTERVAL/MAX_RETRIES env (C-H2, B1)`.
+
+**Acceptance:** `go test ./internal/postgres/ -run TestPostgresTunables` passes; `go build ./...` clean.
+**Implements:** design §6/§16; resolves **C-H2** for the Postgres path (B1).
+
+---
+
+## Workstream 3 — SQLite + Litestream (default store)
+
+> Design §10, §12. Depends on WS0 (needs `Close(ctx)` + drain pattern). The UI (WS1) reads this DB, so it lands before WS1.
+
+### Task 3.1: SQLite schema + migrations package (embedded DDL, `schema_version`) — depends on: Task 0.7
+
+**Files:**
+- Create: `internal/sqlite/schema.go`, `internal/sqlite/migrations/0001_init.sql`
+- Test: `internal/sqlite/schema_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestMigrate_CreatesTablesAndVersion`: open a temp `modernc.org/sqlite` DB (`t.TempDir()`), run `Migrate(ctx, db)`, assert the four tables + index exist (query `sqlite_master`) and `schema_version` == 1; run `Migrate` again → idempotent, still version 1.
+- [ ] **Step 2:** Run `go test ./internal/sqlite/` → FAIL (package/functions missing). First `go get modernc.org/sqlite@v1.34.4` + `go mod tidy`.
+- [ ] **Step 3 (GREEN):** `//go:embed migrations/*.sql` the DDL (exactly the design §12 DDL — `tempest_observations`, `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events`, `idx_obs_serial_time`, `schema_version`; integer counts as `INTEGER` not float — fixes B-LOW). Implement `Migrate(ctx, *sql.DB) error` applying unapplied versions in a transaction and recording `schema_version`.
+- [ ] **Step 4:** Run `go test ./internal/sqlite/` → PASS.
+- [ ] **Step 5:** Commit `feat: sqlite schema + embedded migrations (B-MEDIUM)`.
+
+**Acceptance:** `go test ./internal/sqlite/` passes; `go build ./...` clean.
+**Interfaces produced:** `sqlite.Migrate(ctx, *sql.DB) error`; table/column names per design §12.
+**Implements:** design §10/§12; resolves **B-MEDIUM** (migration path), **B-LOW** (integer types).
+
+### Task 3.2: SQLite connection + PRAGMAs — depends on: Task 3.1
+
+**Files:**
+- Create: `internal/sqlite/db.go`
+- Test: `internal/sqlite/db_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestOpen_SetsPragmas`: `Open(ctx, path, cfg)` then query `PRAGMA journal_mode` == `wal`, `PRAGMA busy_timeout` == `5000`, `PRAGMA synchronous` == `1` (NORMAL), `PRAGMA foreign_keys` == `1`. Assert `wal_autocheckpoint` is left at the SQLite default (do NOT set it aggressively — Litestream owns checkpointing).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** `func Open(ctx context.Context, path string, cfg Config) (*sql.DB, error)` using driver name `"sqlite"` (modernc registers under that name). **Confirmed modernc DSN pragma syntax** (Context7, `gitlab.com/cznic/sqlite`): each pragma is a separate `_pragma=` query param, value in `name(value)` form, joined by `&`. Build the DSN as:
+
+```go
+const driverName = "sqlite" // modernc.org/sqlite registers this name
+
+func Open(ctx context.Context, path string, cfg Config) (*sql.DB, error) {
+	dsn := fmt.Sprintf(
+		"file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(%d)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(1)",
+		path, cfg.BusyTimeout.Milliseconds(),
+	)
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1) // single writer — serializes writes, avoids SQLITE_BUSY (design §10)
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("ping sqlite: %w", err)
+	}
+	if err := Migrate(ctx, db); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+```
+
+  Note `foreign_keys(1)` (not `ON`) per the confirmed modernc example, and **do NOT** append a `_pragma=wal_autocheckpoint(...)` — leave it at the SQLite default so Litestream owns checkpointing (design §10). `Config` carries `BatchSize`, `FlushInterval`, `BusyTimeout` from env (`SQLITE_BATCH_SIZE` default 100, `SQLITE_FLUSH_INTERVAL` default 10s, `SQLITE_BUSY_TIMEOUT` default 5000ms) via `cmp.Or`/parse-with-default.
+- [ ] **Step 4:** Run `go test ./internal/sqlite/` → PASS.
+- [ ] **Step 5:** Commit `feat: sqlite Open with exact PRAGMAs (design §10)`.
+
+**Acceptance:** `go test ./internal/sqlite/` passes.
+**Interfaces produced:** `sqlite.Open(ctx, path, cfg)`, `sqlite.Config{BatchSize, FlushInterval, BusyTimeout}`.
+**Implements:** design §10 (PRAGMAs, Litestream-owned checkpointing, honored tunables — avoids C-H2).
+
+### Task 3.3: SQLite writer — single serialized goroutine, `ON CONFLICT DO NOTHING`, UUIDv7 — depends on: Task 3.2
+
+**Files:**
+- Create: `internal/sqlite/writer.go`
+- Test: `internal/sqlite/writer_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Against a real temp DB:
+  - `TestWriter_InsertsObservation`: `WriteReport` an observation → row present with exact column values (field-by-field), UUIDv7 PK.
+  - `TestWriter_OnConflictIdempotent`: write the same `(serial, timestamp)` twice → exactly one row (`ON CONFLICT DO NOTHING`).
+  - `TestWriter_RoutesReportTypes`: obs → observations, rapid_wind → rapid_wind, hub_status → hub_status, precip/strike events → events.
+  - `TestWriter_EventsNotDroppedUnderBackpressure`: fill the channel to capacity, then submit a discrete lightning/rain-start row; assert it is **not** silently dropped — it blocks up to `eventBlockTimeout` and succeeds once the writer drains (avoids C-MEDIUM). Assert the pinned constants exist: `rowChanCap == 1000`, `eventBlockTimeout == 5*time.Second`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Implement `Writer` satisfying `sink.MetricsWriter`. **Pinned constants** (asserted in RED):
+
+```go
+const (
+	// rowChanCap bounds the single writer's inbound queue. 1000 mirrors the
+	// postgres writer's per-channel buffer — at ~1 obs/min plus 3s rapid-wind,
+	// 1000 is minutes of headroom before backpressure engages.
+	rowChanCap = 1000
+	// eventBlockTimeout is how long a DISCRETE event (lightning/rain-start)
+	// will block when the channel is full before it is logged-and-dropped.
+	// Chosen shorter than the 30s shutdown budget yet long enough for the
+	// single writer to complete at least one batch flush; a discrete event is
+	// rare, so blocking briefly is correct, not silent loss.
+	eventBlockTimeout = 5 * time.Second
+)
+```
+
+  Structure: a **single** writer goroutine consumes one buffered `chan rowEnvelope` (cap `rowChanCap`) and batch-inserts per `BatchSize`/`FlushInterval`. Continuous rows (observation/rapid_wind/hub) use a non-blocking send with `done`-gate (WS0 pattern); **discrete events** use a bounded-block send so they are not dropped:
+
+```go
+// continuous rows — non-blocking, drop-with-log only when truly saturated:
+func (w *Writer) enqueue(ctx context.Context, r rowEnvelope) error {
+	select {
+	case w.rows <- r:
+		return nil
+	case <-w.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		slog.Warn("sqlite: row channel full, dropping continuous row", "kind", r.kind)
+		return nil
+	}
+}
+
+// discrete events (lightning, rain-start) — block up to eventBlockTimeout:
+func (w *Writer) enqueueEvent(ctx context.Context, r rowEnvelope) error {
+	t := time.NewTimer(eventBlockTimeout)
+	defer t.Stop()
+	select {
+	case w.rows <- r:
+		return nil
+	case <-w.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		slog.Warn("sqlite: event channel full after block timeout, dropping event", "kind", r.kind)
+		return nil
+	}
+}
+```
+
+  Generate one UUIDv7 per row (`uuid.Must(uuid.NewV7())`). Parameterized inserts, `INSERT ... ON CONFLICT DO NOTHING` on the `(serial_number, timestamp)` unique key (events on `(serial_number, timestamp, event_type)`). `sync.Once`+`done` gate for `Close` (mirror Task 0.9a's postgres shape — never close `w.rows`). Column mappings mirror the postgres writer's verified field indices (`internal/postgres/writer.go` `handleObservationReport` at `writer.go:453` — `ob[0]`=timestamp, `ob[1]`=windLull, `ob[2]`=windAvg, `ob[3]`=windGust, `ob[4]`=windDirection, `ob[5]`=windSampleInterval, `ob[6]`=pressure, `ob[7]`=tempAir, `ob[8]`=humidity, `ob[9]`=illuminance, `ob[10]`=uvIndex, `ob[11]`=irradiance, `ob[12]`=rainRate, `ob[13]`=precipType, `ob[14]`=lightningDistance, `ob[15]`=lightningStrikeCount, `ob[16]`=battery, `ob[17]`=reportInterval; wet-bulb via `tempestudp.WetBulbTemperatureC(ob[7], ob[8], ob[6])`). Timestamps stored as unix-epoch INTEGER (design §12).
+- [ ] **Step 4:** Run `go test -race ./internal/sqlite/` → PASS.
+- [ ] **Step 5:** Commit `feat: sqlite writer (single-writer, idempotent, backpressure-safe)`.
+
+**Acceptance:** `go test -race ./internal/sqlite/` passes.
+**Interfaces produced:** `sqlite.NewWriter(ctx, db, cfg) *Writer` implementing `sink.MetricsWriter`.
+**Implements:** design §10; applies lessons of **C-H1/C-H3/C-MEDIUM**.
+
+### Task 3.4: SQLite drain-on-Close test + history query method — depends on: Task 3.3
+
+**Files:**
+- Modify: `internal/sqlite/writer.go` (add `LatestObservation`, `HistoryPoints` read methods)
+- Test: `internal/sqlite/writer_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):**
+  - `TestWriter_DrainOnClose`: enqueue N reports, `Close(ctx)` with fresh ctx, reopen DB, assert all N persisted.
+  - `TestReader_LatestObservation`: insert 3 obs, `LatestObservation(ctx, serial)` returns the newest.
+  - `TestReader_HistoryPoints`: `HistoryPoints(ctx, field, from, to)` returns `[]Point{T,V}` in range for a field (e.g. `temp_air`), with an allowlist of queryable field names (no SQL injection from `field`).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Add drain in `Close(ctx)`; add read methods. `field` is validated against a static allowlist mapping API field → column.
+- [ ] **Step 4:** Run `go test -race ./internal/sqlite/` → PASS.
+- [ ] **Step 5:** Commit `feat: sqlite drain-on-close + read methods for the JSON API`.
+
+**Acceptance:** `go test -race ./internal/sqlite/` passes.
+**Interfaces produced:** `(*Writer).LatestObservation(ctx, serial)`, `(*Writer).HistoryPoints(ctx, field, from, to)` — consumed by Contract C handlers (WS1).
+**Implements:** design §10/§11; resolves class of **C-H1**.
+
+### Task 3.5: Wire SQLite as default store in `main.go` — depends on: Task 3.4, Task 0.11
+
+**Files:**
+- Modify: `main.go`
+- Test: `main_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestSelectStore` in `main_test.go`:
+
+```go
+func TestSelectStore(t *testing.T) {
+	tests := []struct {
+		name         string
+		enablePG     bool
+		sqlitePath   string
+		wantPostgres bool
+		wantSQLite   bool
+		wantPath     string
+	}{
+		{"default sqlite", false, "", false, true, "/data/tempest.db"},
+		{"postgres only", true, "", true, false, ""},
+		{"both fan-out", true, "/tmp/x.db", true, true, "/tmp/x.db"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := selectStore(tc.enablePG, tc.sqlitePath)
+			if c.postgres != tc.wantPostgres || c.sqlite != tc.wantSQLite {
+				t.Fatalf("got %+v", c)
+			}
+			if tc.wantSQLite && c.sqlitePath != tc.wantPath {
+				t.Fatalf("path %q want %q", c.sqlitePath, tc.wantPath)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2:** Run `go test ./ -run TestSelectStore` → FAIL (`selectStore`/`storeChoice` undefined).
+- [ ] **Step 3 (GREEN):** Add the pure decision helper to `main.go` and use it to register writers:
+
+```go
+type storeChoice struct {
+	postgres   bool
+	sqlite     bool
+	sqlitePath string
+}
+
+// selectStore: SQLite is the default store (R2); Postgres is opt-in via
+// ENABLE_POSTGRES. Both may run concurrently (fan-out). SQLite is disabled only
+// when Postgres is the sole configured store AND no SQLITE_PATH override is set.
+func selectStore(enablePostgres bool, sqlitePathEnv string) storeChoice {
+	c := storeChoice{postgres: enablePostgres}
+	if !enablePostgres || sqlitePathEnv != "" {
+		c.sqlite = true
+		c.sqlitePath = cmp.Or(sqlitePathEnv, "/data/tempest.db")
+	}
+	return c
+}
+```
+
+  In `main`, call `choice := selectStore(enablePostgres, os.Getenv("SQLITE_PATH"))`; when `choice.sqlite`, `sqlite.Open` + register `sqlite.NewWriter`; when `choice.postgres`, register the postgres writer (existing path). Both register → fan-out. The SQLite writer/reader handle is retained for the WS1 observation handlers.
+- [ ] **Step 4:** Run `go test ./ -run TestSelectStore`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `feat: default to sqlite store, postgres opt-in (R2)`.
+
+**Acceptance:** `go test ./ -run TestSelectStore` passes; `go build ./...` clean.
+**Implements:** design §10 (R2).
+
+### Task 3.6: Litestream replicate+restore round-trip test (default: filesystem replica) — depends on: Task 3.5
+
+> **Replica choice is concrete (resolves the cold-review ambiguity): the DEFAULT test uses a Litestream `file:` replica to a `t.TempDir()` path — NOT integration-gated — so the PRAGMA/WAL/restore contract is proven on every `go test` run** (design §10 names "misconfigured PRAGMAs silently lose Litestream data" as the top risk; a routinely-skipped integration test would leave it unproven). The test requires the `litestream` binary on PATH; if absent, `t.Skip` with a clear message (CI installs it). A separate `//go:build integration` MinIO/S3 variant is optional and exercises the object-storage path.
+
+**Files:**
+- Create: `internal/sqlite/litestream_test.go` (default build, filesystem replica)
+- Create: `internal/sqlite/litestream_integration_test.go` (`//go:build integration`, MinIO/S3 — optional)
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestLitestreamRestore_FileReplica` (default build):
+  - open a SQLite DB at `db := t.TempDir()+"/tempest.db"` via `sqlite.Open`, write N observation rows through the WS3 writer, `Close`.
+  - write a Litestream config with a `file:` replica pointing at `replica := t.TempDir()+"/replica"`; run `litestream replicate -config <cfg>` briefly (or `litestream replicate -exec` / a one-shot `litestream snapshot`), then `litestream restore -config <cfg> -o <fresh.db> <db>`.
+  - open `fresh.db`, assert the N rows match the original field-for-field.
+  - Guard with `if _, err := exec.LookPath("litestream"); err != nil { t.Skip("litestream not installed") }`.
+- [ ] **Step 2:** Run `go test ./internal/sqlite/ -run TestLitestreamRestore_FileReplica` → FAIL (harness missing) or SKIP (binary absent).
+- [ ] **Step 3 (GREEN):** Implement the harness: template the Litestream YAML config (`dbs: [{path: <db>, replicas: [{type: file, path: <replica>}]}]`), spawn `litestream` via `os/exec` with the test's context, assert restore equality. Keep the optional `//go:build integration` MinIO variant thin (swap the replica block for `type: s3` + testcontainer endpoint).
+- [ ] **Step 4:** Run `go test ./internal/sqlite/ -run TestLitestreamRestore_FileReplica` (litestream installed) → PASS.
+- [ ] **Step 5:** Commit `test: litestream file-replica replicate+restore round-trip (default) + optional S3 (integration)`.
+
+**Acceptance:** `go test ./internal/sqlite/ -run TestLitestreamRestore_FileReplica` passes locally with `litestream` installed (skips cleanly without it).
+**Implements:** design §10/§18 (restore-from-replica test proven on every run; PRAGMA-safety guard).
+
+---
+
+## Workstream 6 — Unified OpenTelemetry (OTLP) backbone
+
+> Design §8, §12. Depends on WS0. WS4 (Grafana) depends on this. **Confirm all OTel APIs via Context7 before coding — logs signal is experimental.**
+
+### Task 6.1: `internal/otel` setup — providers + OTLP exporters + resource — depends on: Task 0.7
+
+**Files:**
+- Create: `internal/otel/setup.go`
+- Test: `internal/otel/setup_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestSetup_ReturnsShutdown`: `Setup(ctx, cfg)` with a fake/no-op endpoint returns a non-nil `shutdown func(context.Context) error` and no error; calling `shutdown(ctx)` is clean and idempotent. `TestResourceAttributes`: the built `Resource` carries `service.name=tempestwx`, `service.version`, `tempest.serial`.
+- [ ] **Step 2:** Run → FAIL. First `go get` the OTel modules (versions in Dependencies table) + `go mod tidy`.
+- [ ] **Step 3 (GREEN):** `func Setup(ctx context.Context, cfg Config) (func(context.Context) error, error)` building a `Resource`, `MeterProvider`, `TracerProvider`, and `LoggerProvider`, each with an OTLP gRPC exporter → `OTEL_EXPORTER_OTLP_ENDPOINT`. Keep the log signal isolated in this file (No-Wall — an API bump is one-file). Return a `shutdown` that flushes+stops all three.
+- [ ] **Step 4:** Run `go test ./internal/otel/` → PASS.
+- [ ] **Step 5:** Commit `feat: internal/otel setup — meter/tracer/logger providers + OTLP (R1)`.
+
+**Acceptance:** `go test ./internal/otel/` passes; `go build ./...` clean.
+**Interfaces produced:** `otel.Setup(ctx, cfg) (shutdown, error)`, `otel.Config{Endpoint, ServiceVersion}`.
+**Implements:** design §8 (R1).
+
+### Task 6.2: OTel sink writer — instruments per Contract B — depends on: Task 6.1
+
+**Files:**
+- Create: `internal/otel/writer.go`
+- Test: `internal/otel/writer_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestWriter_RecordsInstruments`: use an in-memory metric reader (`sdk/metric` manual reader / `metricdata`); `WriteReport` an observation → assert the recorded instrument names/kinds/values EXACTLY match Contract B (e.g. `tempest.temperature.c` Gauge with `kind="air"`, `tempest.wind.meters_per_second` Gauge, `tempest.uptime.seconds` Gauge, `tempest.reboots` Counter). Assert wet-bulb NaN is skipped. Assert `serial` is an attribute, not `instance`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Implement `otel.Writer` satisfying `sink.MetricsWriter`; pre-register every instrument in Contract B; on `WriteReport` record each field to its instrument with the `serial`/`kind` attributes; derived dewpoint/heat-index/wetbulb as Gauges. `WriteMetrics` maps the API-mode prom metrics similarly. `Close(ctx)`/`Flush(ctx)` no-op (provider shutdown handled by Setup).
+- [ ] **Step 4:** Run `go test -race ./internal/otel/` → PASS.
+- [ ] **Step 5:** Commit `feat: otel sink writer with tempest_* instrument names (D-MEDIUM hygiene)`.
+
+**Acceptance:** `go test -race ./internal/otel/` passes.
+**Interfaces produced:** `otel.NewWriter(mp) *Writer` implementing `sink.MetricsWriter`.
+**Implements:** design §8/§12; resolves **D-MEDIUM** metric-hygiene set (instance→serial, `_ms`, `_total`, dead RainTotal).
+
+### Task 6.3: Tracing spans around ingest + HTTP — depends on: Task 6.2
+
+**Files:**
+- Modify: `main.go` (ingest spans), `internal/otel/tracing.go` (helpers)
+- Test: `internal/otel/tracing_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestSpans_UDPIngestChain`: with a `tracetest.SpanRecorder`, run a report through the traced ingest path; assert spans `udp.receive` → `report.parse` → `sink.write` exist with parent/child links.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Add span helpers; wrap UDP ingest and the API export loop. (HTTP `otelhttp` middleware is added in WS1 where the server lives.)
+- [ ] **Step 4:** Run `go test ./internal/otel/` → PASS; `go build ./...` clean.
+- [ ] **Step 5:** Commit `feat: tracing spans for udp ingest + export loop`.
+
+**Acceptance:** `go test ./internal/otel/` passes.
+**Implements:** design §8/§12 (spans).
+
+### Task 6.4: slog→OTel log bridge + wire OTel into main — depends on: Task 6.3, Task 3.5
+
+**Files:**
+- Modify: `main.go` (call `otel.Setup`, register writer, install log bridge, defer shutdown)
+- Create: `internal/otel/logbridge.go`
+- Test: `internal/otel/logbridge_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestLogBridge_EmitsRecords`: emit a `slog` record through the bridge handler → assert it reaches an in-memory OTel log exporter with the message + attributes (and trace/span IDs when a span is active).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Use the **official OTel slog bridge** rather than hand-writing a handler: `go.opentelemetry.io/contrib/bridges/otelslog` provides `otelslog.NewHandler(name string, opts ...Option) *otelslog.Handler` that emits `slog.Record`s to a `LoggerProvider` (pass `otelslog.WithLoggerProvider(lp)`); it carries the active span's trace/span IDs automatically. `internal/otel/logbridge.go` is a thin wrapper: `func NewSlogHandler(lp log.LoggerProvider) slog.Handler { return otelslog.NewHandler("tempestwx", otelslog.WithLoggerProvider(lp)) }` (keep it one file so an experimental-API bump is contained — No-Wall). Add `go.opentelemetry.io/contrib/bridges/otelslog` to the deps table (`v0.8.0`). In `main.go`: when `ENABLE_OTEL=true` + `OTEL_EXPORTER_OTLP_ENDPOINT` set, call `otel.Setup`, register `otel.NewWriter`, `slog.SetDefault(slog.New(otel.NewSlogHandler(lp)))`, and `defer shutdown(cleanupCtx)`. Confirm the `otelslog`/`log` API via Context7 before coding (experimental).
+- [ ] **Step 4:** Run `go test ./internal/otel/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `feat: slog→OTel log bridge + wire OTel sink (ENABLE_OTEL)`.
+
+**Acceptance:** `go test ./internal/otel/` passes; `go build ./...` clean.
+**Implements:** design §8 (structured logs with trace correlation).
+
+### Task 6.5: Deprecate the bespoke Prometheus path (deprecate-then-remove, O4) — depends on: Task 6.4
+
+**Files:**
+- Modify: `internal/prometheus/writer.go`, `internal/prometheus/server.go`, `main.go`
+
+**Steps:**
+- [ ] **Step 1:** Add a one-time `slog.Warn("ENABLE_PROMETHEUS_* is deprecated; migrate to ENABLE_OTEL — removal in the next release")` when either prometheus writer is registered. (No behavior change — kept one release per O4.)
+- [ ] **Step 2 (verify):** `go build ./...` clean; existing prometheus tests still pass.
+- [ ] **Step 3:** Commit `chore: deprecation warning on bespoke prometheus path (O4)`.
+
+**Acceptance:** `go build ./...` clean; `go test ./internal/prometheus/` passes.
+**Implements:** design §8/§16 (O4 deprecate-then-remove).
+
+---
+
+## Workstream 1 — Embedded UI + backend JSON API (folds in WS5 UX P0/P1)
+
+> Design §7, §11, §14. Depends on WS3 (data) + WS0 (token proxy). UX P0/P1 items (design §14) are folded into these tasks as noted; P2 polish is Task UX.1 at the end.
+
+### Task 1.1: Vendor the `tempest-display` UI into `web/` + build wiring + emit UI manifest — depends on: Task 0.1
+
+> **UI manifest (below) is authoritative for all downstream UI tasks (1.2, 1.3, 1.4, 1.7a–c, 2.6, UX.1).** It is captured here from the pinned upstream commit `49892063` so those tasks reference **present, real symbol names** instead of forward-referencing an external repo. Verify the tree matches after the clone; if upstream differs, STOP and reconcile before proceeding.
+
+**Files:**
+- Create: `web/` (vendored from `tempest-display@49892063`, retaining `LICENSE` + provenance header), `web/dist/.gitkeep`, `web/PROVENANCE.md`
+- Modify: `taskfile.yml` (add `ui-build` target)
+
+**UI manifest — file tree under `web/` after vendoring (upstream `server/` removed):**
+
+```
+web/
+  index.html
+  package.json           # React 19 + TS 5.9 + Vite 7; add: maplibre-gl, pmtiles, vitest, @testing-library/react
+  vite.config.ts
+  eslint.config.js
+  tsconfig.json  tsconfig.app.json  tsconfig.node.json
+  public/vite.svg
+  src/
+    main.tsx
+    App.tsx                       # top-level dashboard; wrap in ErrorBoundary (1.7b), mount RadarCard (2.6)
+    App.css  index.css            # missing .loading-screen/.loading-spinner/.error-screen/.glass-btn defined in 1.7b
+    api/
+      tempestApi.ts               # STUB client — fetchStationMeta, fetchCurrentObservation, fetchForecast,
+                                   #   fetchHourlyForecast, fetchStationStatus, fetchStationAlmanac,
+                                   #   setApiToken/getApiToken, connectWebSocket (replace stubs → real /api/* in 1.7a)
+      stubData.ts                 # deleted in 1.7a
+    hooks/
+      useUnits.ts                 # convertTemp/convertWind/convertPressure/convertRain + format* + useUnits() (CORRECT — cover in 1.2)
+      useWeatherData.ts           # useWeatherData(stationId?) → WeatherData; add AbortController in 1.7a
+    components/
+      AlmanacCard.tsx             # MoonPhase(), formatTime(), RecordColumn(), daylightDuration(), AlmanacCard() (moon geometry CORRECT)
+      ForecastStrip.tsx           # getDayName(dayNum, monthNum) — Dec→Jan boundary BUG, fix in 1.2
+      GlassCard.tsx  Header.tsx   # Header.tsx line 28: hardcoded "°N … °W" hemisphere BUG, fix in 1.2
+      HumidityCard.tsx  LightningCard.tsx  PressureCard.tsx  RainCard.tsx
+      SettingsPanel.tsx           # dead Station ID (line 103) + API Token (line 112) inputs — REMOVE in 1.7c
+      SolarUVCard.tsx  StationHealth.tsx  TemperatureHero.tsx  WeatherIcon.tsx  WindCard.tsx
+    themes/themes.ts              # themes: Record<ThemeName,…>; applyTheme(name); getThemeList() — theme-var leak fix in UX.1
+    types/weather.ts              # SINGLE SOURCE for Contract C shapes — reproduced verbatim below
+```
+
+**UI manifest — `web/src/types/weather.ts` (verbatim, the Contract C source of truth):**
+
+```ts
+export interface StationMeta {
+  station_id: number; name: string; latitude: number; longitude: number;
+  elevation: number; timezone: string; firmware_revision: string;
+  serial_number: string; device_id: number;
+}
+export interface CurrentObservation {
+  timestamp: number;
+  windLull: number; windAvg: number; windGust: number; windDirection: number;
+  windSampleInterval: number; stationPressure: number; airTemperature: number;
+  relativeHumidity: number; illuminance: number; uvIndex: number;
+  solarRadiation: number; rainAccumulated: number;
+  precipitationType: PrecipitationType;
+  lightningStrikeAvgDistance: number; lightningStrikeCount: number;
+  battery: number; reportInterval: number; localDayRainAccumulation: number;
+  feelsLike: number; dewPoint: number; wetBulbTemperature: number;
+  heatIndex: number; windChill: number; pressureTrend: PressureTrend;
+}
+export const PrecipitationType = { None:0, Rain:1, Hail:2, RainAndHail:3 } as const;
+export type PrecipitationType = typeof PrecipitationType[keyof typeof PrecipitationType];
+export const PressureTrend = { Falling:'falling', Steady:'steady', Rising:'rising' } as const;
+export type PressureTrend = typeof PressureTrend[keyof typeof PressureTrend];
+export interface ForecastDay {
+  dayNum: number; monthNum: number; conditions: string; icon: string;
+  airTempHigh: number; airTempLow: number; precipProbability: number;
+  precipType: string; sunrise: number; sunset: number;
+}
+export interface HourlyForecast {
+  timestamp: number; conditions: string; icon: string; airTemperature: number;
+  feelsLike: number; relativeHumidity: number; windAvg: number;
+  windDirection: number; windGust: number; precipProbability: number; uvIndex: number;
+}
+export interface StationStatus {
+  isOnline: boolean; lastReport: number; batteryLevel: number;
+  signalStrength: number; firmwareVersion: string;
+}
+export type TemperatureUnit = 'C' | 'F';
+export type WindUnit = 'ms' | 'mph' | 'kph' | 'kts';
+export type PressureUnit = 'mb' | 'inHg' | 'hPa';
+export type RainUnit = 'mm' | 'in';
+export interface TempRecord { high: number; highDate: string; low: number; lowDate: string; }
+export interface StationAlmanac {
+  today: TempRecord; week: TempRecord; month: TempRecord; year: TempRecord;
+  sunrise: number; sunset: number; moonPhase: number;
+  moonPhaseName: string; moonIllumination: number;
+}
+export interface UserPreferences {
+  temperatureUnit: TemperatureUnit; windUnit: WindUnit;
+  pressureUnit: PressureUnit; rainUnit: RainUnit; theme: string;
+}
+export type ThemeName = 'liquid-glass' | 'midnight-aurora' | 'desert-sunset' | 'nord' | 'tokyo-night' | 'catppuccin-mocha' | 'the-grid';
+```
+
+**Steps:**
+- [ ] **Step 1:** Clone the pinned upstream and copy it in: `git clone https://github.com/jacaudi/tempest-display && (cd tempest-display && git checkout 49892063)` then copy its tree into `web/`. Record the exact source commit `49892063` in `web/PROVENANCE.md`. **Delete the upstream `web/server/`** (its 63-line static server is absorbed by the Go server in Task 1.3). Keep `src/`, `package.json`, `vite.config.ts`, tsconfigs, ESLint.
+- [ ] **Step 2 (verify manifest):** confirm the vendored tree matches the manifest above and that `web/src/types/weather.ts` is byte-identical to the reproduction (it is Contract C's source). If not, STOP and reconcile.
+- [ ] **Step 3:** Add `task ui-build` → `cd web && npm ci --ignore-scripts && npm run build` producing `web/dist`. Add `web/dist/.gitkeep` and document the `go:embed`-needs-non-empty-dir build-order requirement in `web/README.md`.
+- [ ] **Step 4 (verify):** `task ui-build` produces `web/dist/index.html`.
+- [ ] **Step 5:** Commit `feat: vendor tempest-display UI into web/ (owned fork @49892063) + UI manifest`.
+
+**Acceptance:** `task ui-build` succeeds; `web/dist/index.html` exists; vendored tree matches the manifest.
+**Implements:** design §7. The manifest above is the reference for all downstream UI tasks.
+
+### Task 1.2: Vitest harness + cover the pure math (UI-F test gap) — depends on: Task 1.1
+
+**Files:**
+- Modify: `web/package.json` (add `vitest`, `@testing-library/react`, `test` script)
+- Create: `web/src/hooks/useUnits.test.ts`, `web/src/components/AlmanacCard.test.tsx`, `web/src/components/ForecastStrip.test.tsx`
+
+**Steps:**
+- [ ] **Step 1 (RED):** Write tests for the already-correct pure functions (10 unit conversions, moon-phase, day-name) AND for the bugs to be fixed: `getDayName` across a Dec→Jan boundary (currently wrong — UI D-MEDIUM), hemisphere suffix `°S/°E` (UI C-MEDIUM). The boundary/hemisphere tests FAIL against current code.
+- [ ] **Step 2:** Run `cd web && npm test` → conversions/moon PASS, boundary/hemisphere FAIL.
+- [ ] **Step 3 (GREEN):** Fix `ForecastStrip.getDayName` to use the entry's own `sunrise` epoch; fix hemisphere suffix logic to honor sign of lat/lon.
+- [ ] **Step 4:** Run `npm test` → all PASS.
+- [ ] **Step 5:** Commit `test: add vitest + fix day-name and hemisphere bugs (UI D/C-MEDIUM)`.
+
+**Acceptance:** `cd web && npm test` passes; `npm run build` clean.
+**Implements:** design §14 P1.9, §18; resolves **UI D-MEDIUM**, **UI C-MEDIUM**.
+
+### Task 1.3: Go HTTP server — embed UI, SPA fallback, timeouts, headers, graceful shutdown — depends on: Task 1.1, Task 0.7
+
+**Files:**
+- Create: `internal/httpserver/server.go`, `internal/httpserver/embed.go` (`//go:embed web/dist` — note: embed path must be relative; place the embed directive appropriately or use an embed sub-package under `web/`)
+- Test: `internal/httpserver/server_test.go`
+
+> Embed note: `//go:embed` cannot cross out of a package dir upward. Put the embed directive in a small `web/embed.go` (`package web`, `//go:embed dist`) and import it, OR generate into the httpserver package. Choose the `web` sub-package approach and document it.
+
+**Steps:**
+- [ ] **Step 1 (RED):**
+  - `TestServer_ServesIndex`: `GET /` → 200 + the embedded index.html.
+  - `TestServer_SPAFallback`: `GET /some/spa/route` → 200 index.html; `GET /assets/missing.js` → 404 (NOT index — fixes UI immutable-cache bug).
+  - `TestServer_SecurityHeaders`: responses carry `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and the **self-only CSP** (B2) exactly: `default-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self'; object-src 'none'; base-uri 'self'`. Assert the CSP contains **no** external host (no `http`/`https` scheme with a domain) — the basemap is same-origin `.pmtiles`.
+  - `TestServer_Timeouts`: the `http.Server` has non-zero Read/ReadHeader/Write/Idle timeouts.
+  - `TestServer_Healthz`: `GET /healthz` → 200 `{"status":"ok"}`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Build a `net/http.ServeMux`-based server (Go 1.22 method+path patterns) serving the embedded FS with `fs.ValidPath` traversal safety (preserve the praised safety), SPA fallback, security-headers middleware emitting the self-only CSP above (single `const cspPolicy = "..."`), explicit timeouts, `/healthz`, and `Shutdown(ctx)` on the cleanup ctx. Only set `Cache-Control: immutable` after a successful asset stat. The OSM `.pmtiles` basemap is served **same-origin** as a static asset (e.g. `web/dist/basemap/osm.pmtiles`, embedded or bind-mounted — the asset itself is produced in Task 2.6's basemap step); MapLibre reads it via byte-range requests to `'self'`, so no external tile host and no CSP host entry.
+- [ ] **Step 4:** Run `go test -race ./internal/httpserver/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `feat: embedded UI HTTP server (timeouts, headers, SPA fallback, /healthz)`.
+
+**Acceptance:** `go test -race ./internal/httpserver/` passes.
+**Interfaces produced:** `httpserver.New(cfg, deps) *http.Server`; mux registration seam for API handlers.
+**Implements:** design §7/§11/§15; resolves **UI E-H1**, **UI E-MEDIUM** (cache/headers/shutdown), UI F-LOW (health).
+
+### Task 1.4: Observation API handlers (current/history) reading sqlite — depends on: Task 1.3, Task 3.4
+
+**Files:**
+- Create: `internal/httpserver/observations.go`
+- Test: `internal/httpserver/observations_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** With a temp sqlite DB seeded via the WS3 writer:
+  - `TestAPI_CurrentObservation`: `GET /api/observations/current` → 200 JSON matching Contract C `CurrentObservation` (SI units, field names from `web/src/types/weather.ts`).
+  - `TestAPI_History`: `GET /api/observations/history?field=temp_air&from=&to=` → `{"points":[{"t":..,"v":..}]}`; an invalid `field` → 400 (allowlist).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Handlers call `(*sqlite.Writer).LatestObservation`/`HistoryPoints`; marshal to Contract C shapes; register on the mux.
+- [ ] **Step 4:** Run `go test -race ./internal/httpserver/` → PASS.
+- [ ] **Step 5:** Commit `feat: /api/observations current+history from sqlite (UI B-H2)`.
+
+**Acceptance:** `go test -race ./internal/httpserver/` passes.
+**Implements:** design §11 (Contract C); resolves **UI B-H2** (real data path).
+
+### Task 1.5: WeatherFlow proxy handlers (station/forecast/almanac) with server-side token — depends on: Task 1.3, Task 0.5
+
+**Files:**
+- Create: `internal/httpserver/proxy.go`
+- Test: `internal/httpserver/proxy_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** With an `httptest.Server` standing in for WeatherFlow:
+  - `TestProxy_InjectsBearerToken`: `GET /api/station` → the upstream request carries `Authorization: Bearer <TOKEN>` and the browser-facing request needs no token.
+  - `TestProxy_NoTokenInResponseOrLogs`: the token never appears in the response body.
+  - `TestProxy_ForecastAndAlmanac`: both endpoints proxy and pass through JSON.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Implement handlers that call the WeatherFlow REST endpoints with the server-held `TOKEN` via `Authorization: Bearer` (reuse the hardened client from Task 0.5), timeouts, status checks; register on the mux.
+- [ ] **Step 4:** Run `go test -race ./internal/httpserver/` → PASS.
+- [ ] **Step 5:** Commit `feat: server-side WeatherFlow proxy (UI B-H1, exporter F-H1)`.
+
+**Acceptance:** `go test -race ./internal/httpserver/` passes.
+**Implements:** design §7/§11/§15; resolves **UI B-H1**, exporter **F-H1** (token off the wire).
+
+### Task 1.6: `otelhttp` middleware + wire the server into main — depends on: Task 1.5, Task 6.4
+
+**Files:**
+- Modify: `internal/httpserver/server.go` (wrap handler in `otelhttp.NewHandler`), `main.go` (start server, run in both modes)
+- Test: `internal/httpserver/server_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestServer_EmitsHTTPSpan`: with a `tracetest.SpanRecorder`, a request produces an `http.server.request` span.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Wrap the mux in `otelhttp.NewHandler(mux, "http.server")`. In `main.go`, start the HTTP server (default addr `:8080`, `HTTP_ADDR` override) in UDP mode alongside ingest; graceful shutdown via cleanup ctx.
+- [ ] **Step 4:** Run `go test -race ./internal/httpserver/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `feat: otelhttp middleware + start UI/API server from main`.
+
+**Acceptance:** `go test -race ./internal/httpserver/` passes; `go build ./...` clean.
+**Implements:** design §8/§11.
+
+> **Task 1.7 was split into 1.7a/1.7b/1.7c** (cold review: the original bundled five independent concerns and a reviewer could not accept one while rejecting another). Each subtask is independently testable. All three depend on the UI manifest in Task 1.1 for symbol names.
+
+### Task 1.7a: UI data layer — replace stubs with backend fetches + AbortController + stale indicator — depends on: Task 1.4, Task 1.5
+
+**Files:**
+- Modify: `web/src/api/tempestApi.ts` (real fetches to relative `/api/*`; delete `stubData` import), `web/src/hooks/useWeatherData.ts` (AbortController + stale tracking)
+- Delete: `web/src/api/stubData.ts`
+- Create: `web/src/api/tempestApi.test.ts`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `tempestApi.test.ts`: mock global `fetch`; assert `fetchCurrentObservation()` GETs the tokenless relative URL `/api/observations/current` and returns a typed `CurrentObservation` (from the manifest's `weather.ts`), with no `stubData` import. Add a `useWeatherData` test: a failed refetch retains the prior `WeatherData` and flips a `isStale`/`lastUpdated` field (§14 P1.6). Both FAIL.
+- [ ] **Step 2:** Run `cd web && npm test` → FAIL.
+- [ ] **Step 3 (GREEN):** In `tempestApi.ts`, replace every stub return in `fetchStationMeta`/`fetchCurrentObservation`/`fetchForecast`/`fetchHourlyForecast`/`fetchStationStatus`/`fetchStationAlmanac` with `fetch` to the tokenless relative Contract C endpoints (`/api/station`, `/api/observations/current`, `/api/forecast`, `/api/almanac`, …); drop `setApiToken`/`getApiToken` (token is server-side). Add an `AbortController` to `useWeatherData` (cancel in-flight on unmount/refetch — UI B-MEDIUM race); retain prior data on failure and expose `isStale` + `lastUpdated` age.
+- [ ] **Step 4:** Run `npm test && npm run build && npx tsc --noEmit` → clean.
+- [ ] **Step 5:** Commit `feat: real UI data layer (Contract C) + AbortController + stale indicator (UI B-H2, B-MEDIUM, §14 P1.6)`.
+
+**Acceptance:** `cd web && npm test && npm run build && npx tsc --noEmit` clean.
+**Implements:** design §11/§14 P1.6; resolves **UI B-H2**, **UI B-MEDIUM**.
+
+### Task 1.7b: Error boundary + missing CSS + responsive/a11y (UX P0) — depends on: Task 1.1
+
+**Files:**
+- Create: `web/src/components/ErrorBoundary.tsx`, `web/src/components/ErrorBoundary.test.tsx`
+- Modify: `web/src/App.tsx` (wrap dashboard), `web/src/App.css` / `web/src/index.css` (define `.loading-screen/.loading-spinner/.error-screen/.glass-btn`, `@media` breakpoints, `prefers-reduced-motion`, `:focus-visible`), the UV card (`SolarUVCard.tsx`) for the `formatX` NaN guard
+
+**Steps:**
+- [ ] **Step 1 (RED):** `ErrorBoundary.test.tsx`: a child that throws renders the fallback UI, not a blank page. Add a small test that a UV value of `undefined` routed through the `formatX` helper renders `"NaN"` (or an em-dash) rather than throwing. Both FAIL.
+- [ ] **Step 2:** Run `cd web && npm test` → FAIL.
+- [ ] **Step 3 (GREEN):**
+  - Add `ErrorBoundary` (class component with `componentDidCatch`) and wrap the dashboard in `App.tsx` (§14 P0.1 / UI A-H1) — one bad card must not blank a 24/7 display.
+  - Define the missing `.loading-screen/.loading-spinner/.error-screen/.glass-btn` CSS (§14 P0.2 / UI A-H2 — the literal first screen).
+  - Add responsive `@media` breakpoints collapsing the 3-col grid to 2/1 (P0.3 / UI A-H3); add `@media (prefers-reduced-motion: reduce)` disabling animations and a global `:focus-visible` outline (P0.4 / UI A-H4).
+  - Route UV (and other optional fields) through a `formatX(value, fmt)` helper so a missing field renders `NaN`/`—` not a hard crash (P0.5 / UI C-MEDIUM).
+- [ ] **Step 4:** Run `npm test && npm run build && npx tsc --noEmit` → clean.
+- [ ] **Step 5:** Commit `feat: error boundary + missing CSS + responsive/a11y + NaN-safe formatX (UI A-H1..H4, C-MEDIUM)`.
+
+**Acceptance:** `cd web && npm test && npm run build && npx tsc --noEmit` clean.
+**Implements:** design §14 P0; resolves **UI A-H1, A-H2, A-H3, A-H4, C-MEDIUM**.
+
+### Task 1.7c: Remove dead SettingsPanel token inputs + self-host fonts — depends on: Task 1.7a
+
+**Files:**
+- Modify: `web/src/components/SettingsPanel.tsx` (remove Station-ID/Token inputs), `web/index.html` / `web/src/index.css` (self-host Inter, drop Google Fonts CDN)
+- Create: `web/src/components/SettingsPanel.test.tsx`; add the Inter font files under `web/src/assets/fonts/` (or `web/public/fonts/`)
+
+**Steps:**
+- [ ] **Step 1 (RED):** `SettingsPanel.test.tsx`: render `SettingsPanel`; assert there is **no** "Station ID" text input and **no** "API Token" password input (they are dead now the token is server-side — §14 P1.10 / UI D-MEDIUM). FAILs against current code (inputs at `SettingsPanel.tsx:103` and `:112`).
+- [ ] **Step 2:** Run `cd web && npm test` → FAIL.
+- [ ] **Step 3 (GREEN):** Remove the Station-ID and API-Token inputs and their handlers/state from `SettingsPanel.tsx` (keep the real settings: units, theme, kiosk toggle). Self-host the Inter font (§14 P1.12 / UI A-MEDIUM): add the woff2 files, `@font-face` in `index.css`, and **remove the Google Fonts `<link>`** from `index.html` — the self-only CSP (Task 1.3) has no font CDN, so the CDN link would otherwise be blocked and the appliance must work offline/air-gapped.
+- [ ] **Step 4:** Run `npm test && npm run build && npx tsc --noEmit` → clean.
+- [ ] **Step 5:** Commit `feat: remove dead token inputs + self-host Inter font (UI D-MEDIUM, A-MEDIUM)`.
+
+**Acceptance:** `cd web && npm test && npm run build && npx tsc --noEmit` clean; no external font/host references remain.
+**Implements:** design §7/§14 P1.10/P1.12; resolves **UI D-MEDIUM**, **UI A-MEDIUM**.
+
+### Task 1.8: Multi-stage Dockerfile — Vite build → Go embed → non-root static image — depends on: Task 1.6, Task 1.7a, Task 1.7b, Task 1.7c
+
+**Files:**
+- Modify: `Dockerfile`, `docker-bake.hcl`, `.dockerignore`
+
+**Steps:**
+- [ ] **Step 1:** Rewrite `Dockerfile` as multi-stage: (1) `node:22-alpine` → `npm ci --ignore-scripts` + `vite build` → `web/dist`; (2) `golang:1.25-alpine` → `CGO_ENABLED=0 go build` embedding `web/dist`; (3) `cgr.dev/chainguard/static` non-root `USER 65532`, `-trimpath -ldflags="-s -w"`, version injection (`-X main.version=...`). Digest-pin base images. Add `EXPOSE 8080` + `HEALTHCHECK` hitting `/healthz`.
+- [ ] **Step 2 (verify):** `docker buildx bake image-local` builds; `docker run` the image → `GET /healthz` returns 200; container runs as UID 65532.
+- [ ] **Step 3:** Commit `build: multi-stage Dockerfile embedding UI, non-root static image (UI F-H1)`.
+
+**Acceptance:** `docker buildx bake image-local` succeeds; healthcheck passes; non-root confirmed.
+**Implements:** design §7/§15; resolves **UI F-H1** (root→non-root).
+
+---
+
+## Workstream 2 — NEXRAD Level 3 radar overlay (opt-in Python sidecar + Go proxy)
+
+> Design §9. Depends on WS1 (HTTP surface + UI map card). Radar is opt-in (`ENABLE_RADAR`). Contract A governs the Go↔sidecar boundary.
+
+### Task 2.1: Python radar sidecar — FastAPI + Py-ART decode → contoured GeoJSON — no deps (parallel-safe; separable dir)
+
+> **Fixture BLOCKER resolved (cold review #1).** The binary NIDS fixture cannot be authored from text, so the TDD loop starts with a **deterministic malformed-bytes RED case that needs no binary** (`test_decode_bad_bytes_raises`). The binary golden-file test comes second and its fixture is obtained by a **pinned acquire-then-commit step** (Step 0) — fetched once from the real-time S3 bucket and committed, so it is stable thereafter (the bucket is real-time with rotating flat keys `SSS_PPP_YYYY_MM_DD_HH_MM_SS`, so a hardcoded key would 404 later; committing the fetched bytes pins it by git, not by S3).
+
+**Files:**
+- Create: `radar/app.py`, `radar/decode.py`, `radar/requirements.txt`, `radar/Dockerfile`, `radar/tests/test_decode.py`, `radar/tests/fixtures/TLX_N0B.nids` (committed binary), `radar/tests/fixtures/PROVENANCE.md`
+
+**Steps:**
+- [ ] **Step 0 (acquire + commit the fixture — one-time, documented):** requires `aws` CLI (anonymous S3 works with `--no-sign-request`). The bucket is real-time, so **list the newest object then copy it**, and commit the bytes:
+
+```bash
+# newest TLX super-res base-reflectivity object (bucket is us-east-1, anonymous):
+KEY=$(aws s3 ls --no-sign-request s3://unidata-nexrad-level3/ \
+      | grep -E 'TLX_N0B_' | sort | tail -1 | awk '{print $4}')
+aws s3 cp --no-sign-request "s3://unidata-nexrad-level3/${KEY}" \
+      radar/tests/fixtures/TLX_N0B.nids
+# record what we fetched so the golden file is traceable:
+printf 'source: s3://unidata-nexrad-level3/%s\nfetched: %s\n' "$KEY" "$(date -u +%FT%TZ)" \
+      > radar/tests/fixtures/PROVENANCE.md
+git add radar/tests/fixtures/TLX_N0B.nids radar/tests/fixtures/PROVENANCE.md
+```
+
+  The committed `TLX_N0B.nids` is now the stable golden input; CI never touches S3 for tests.
+- [ ] **Step 1 (RED, pytest — deterministic, no binary needed first):**
+  - `test_decode.py::test_decode_bad_bytes_raises`: `decode.to_geojson(b"not-nids", "N0B")` raises a typed `decode.DecodeError`. This can be written and watched-fail immediately (module → function → wrong-exception), unblocking TDD.
+  - `test_decode.py::test_decode_nids_to_isobands` (uses the committed fixture from Step 0): `decode.to_geojson(Path("tests/fixtures/TLX_N0B.nids").read_bytes(), "N0B")` returns a FeatureCollection whose features carry `dbz_min`/`dbz_max` band properties and a `metadata` block with `site`/`product`/`scan_time`/`bbox` (Contract A). Assert `>0` features and that `dbz_min`/`dbz_max` are 5-dBZ-aligned.
+- [ ] **Step 2:** Run `cd radar && pytest` → FAIL (module missing). Set matplotlib to headless `Agg` (`MPLBACKEND=Agg` / `matplotlib.use("Agg")`).
+- [ ] **Step 3 (GREEN):** `decode.py`: define `class DecodeError(Exception)`; `to_geojson(nids: bytes, product: str)` writes the bytes to a temp file, `pyart.io.read_nexrad_level3` it (wrap any exception → `DecodeError`), grid base reflectivity, `geojsoncontour`/`contourf` into 5-dBZ isobands over the NWS reflectivity scale, emit Contract A GeoJSON (each `Feature.properties` has `dbz_min`/`dbz_max`; top-level `metadata`). `app.py`: FastAPI `GET /radar?site=&product=` — fetch newest NIDS from `s3://unidata-nexrad-level3` via anonymous `boto3` (`ListObjectsV2` prefix `SSS_PPP_`, pick largest `YYYY_MM_DD_HH_MM_SS`, `GetObject`), decode, return GeoJSON; on failure return the Contract A **non-200 + error envelope** (`503 no_recent_scan` / `502 decode_failed` / `500 internal`). `GET /healthz` → 200.
+- [ ] **Step 4:** Run `cd radar && pytest` → PASS.
+- [ ] **Step 5:** Commit `feat: python radar sidecar (Py-ART → contoured GeoJSON, Contract A) + committed NIDS fixture`.
+
+**Acceptance:** `cd radar && pytest` passes (both the no-binary malformed case and the committed-fixture isoband case).
+**Implements:** design §9 (O1 Py-ART sidecar, O3 contoured GeoJSON, Contract A).
+
+### Task 2.2: Sidecar Dockerfile + healthcheck — depends on: Task 2.1
+
+**Files:**
+- Modify: `radar/Dockerfile`
+
+**Steps:**
+- [ ] **Step 1:** Multi-stage/ slim Python image installing Py-ART/SciPy/matplotlib/boto3/geojsoncontour/FastAPI/uvicorn; run uvicorn on `:8081`; non-root user; `HEALTHCHECK` → `/healthz`; headless matplotlib `MPLBACKEND=Agg`.
+- [ ] **Step 2 (verify):** `docker build radar/` succeeds; `docker run` → `GET /healthz` 200.
+- [ ] **Step 3:** Commit `build: radar sidecar Dockerfile`.
+
+**Acceptance:** `docker build radar/` succeeds; healthcheck passes.
+**Implements:** design §9/§15a.
+
+### Task 2.3: Go `internal/radar` — site table + nearest-site selection + `{site}` allowlist — depends on: Task 0.7
+
+> **Site-table data is concrete (cold review #9).** Do NOT "reuse DRAS." Generate the table from NOAA's authoritative WSR-88D station list (fixed-width text, verified reachable). This is a one-time `go generate` step whose output is committed.
+
+**Files:**
+- Create: `internal/radar/sites.go` (committed static table `var sites = []Site{...}`), `internal/radar/select.go`
+- Test: `internal/radar/select_test.go`
+
+**Steps:**
+- [ ] **Step 0 (data acquisition — pinned, one-time, commit the OUTPUT):** the NOAA HOMR list is fixed-width; verified format: `ICAO` (e.g. `KTLX`), `LAT`/`LON` decimal degrees, `STNTYPE` == `NEXRAD`. The site code is the ICAO **without the leading `K`** (`KTLX`→`TLX`). Produce the committed table with a documented one-liner (no generator program to maintain — the table changes maybe once a decade):
+
+```bash
+{ echo 'package radar'; echo; echo 'var sites = []Site{'; \
+  curl -s "https://www.ncei.noaa.gov/access/homr/file/nexrad-stations.txt" \
+  | awk 'NR>2 && /NEXRAD/ { icao=$2; code=substr(icao,2); printf "\t{%q, %s, %s},\n", code, $(NF-4), $(NF-3) }'; \
+  echo '}'; } > internal/radar/sites.go
+gofmt -w internal/radar/sites.go
+```
+
+  Commit `internal/radar/sites.go` (the ~160-row output). Re-run the one-liner only if NOAA adds a site. (Verify the `awk` column indices against the current file header once — HOMR is stable fixed-width; adjust `$(NF-4)`/`$(NF-3)` if the trailing columns shift.)
+- [ ] **Step 1 (RED):** `TestNearestSite`: for a lat/lon near Oklahoma City (`35.47, -97.51`), `NearestSite(lat, lon)` returns `"TLX"`. `TestValidSite`: `IsValidSite("TLX")` true; `IsValidSite("../etc")`, `IsValidSite("ZZZ")`, `IsValidSite("tlx")` (case) all false (SSRF allowlist guard).
+- [ ] **Step 2:** Run `go test ./internal/radar/` → FAIL (`Site`/`NearestSite`/`IsValidSite` missing).
+- [ ] **Step 3 (GREEN):** `select.go`: `type Site struct{ Code string; Lat, Lon float64 }`; `NearestSite(lat, lon float64) string` via haversine over `sites` (return the min-distance `Code`); `IsValidSite(code string) bool` = exact-match membership in `sites` (uppercase, 3-char).
+- [ ] **Step 4:** Run `go test ./internal/radar/` → PASS.
+- [ ] **Step 5:** Commit `feat: radar site table (generated from NOAA HOMR) + nearest-site + allowlist (SSRF guard)`.
+
+**Acceptance:** `go test ./internal/radar/` passes.
+**Interfaces produced:** `radar.NearestSite(lat, lon) string`, `radar.IsValidSite(code) bool`.
+**Implements:** design §9/§15 (SSRF guard).
+
+### Task 2.4: Go radar proxy + LRU cache (Contract A client) — depends on: Task 2.3
+
+**Files:**
+- Create: `internal/radar/proxy.go` (sidecar HTTP client + `(site,product,scanTime)` LRU)
+- Test: `internal/radar/proxy_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** With an `httptest.Server` mimicking the sidecar (Contract A):
+  - `TestProxy_FetchesAndCaches`: two calls for the same `(site,product,scanTime)` hit the sidecar once (cache hit second time).
+  - `TestProxy_N0BFallsBackToN0Q`: sidecar returns `503 no_recent_scan` for N0B → proxy retries with N0Q (O2 default+fallback).
+  - `TestProxy_ErrorEnvelope`: `502 decode_failed` → proxy surfaces a typed error mapped for the HTTP layer.
+  - `TestProxy_Constants`: assert the pinned cache constants `radarCacheMaxEntries == 64` and `radarCacheTTL == 5*time.Minute`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Implement the sidecar client (stdlib `http.Client` with a 30s timeout) and a bounded LRU keyed on `(site,product,scanTime)`. **Pinned constants** (asserted in RED):
+
+```go
+const (
+	// radarCacheMaxEntries bounds the LRU. ~160 sites but any one deployment
+	// tracks 1 station → a handful of sites × 2 products (N0B/N0Q) × the last
+	// few scan times; 64 is generous headroom and a hard memory bound.
+	radarCacheMaxEntries = 64
+	// radarCacheTTL ≈ one WSR-88D volume-scan cycle (VCP ~4–6 min); 5 min keeps
+	// a scan cached for its useful life without serving stale reflectivity.
+	radarCacheTTL = 5 * time.Minute
+	// radarSidecarTimeout bounds the HTTP call to the Python sidecar.
+	radarSidecarTimeout = 30 * time.Second
+)
+```
+
+  N0B→N0Q fallback (per O2): on a `503 no_recent_scan` for `N0B`, retry once with `N0Q`. Map Contract A non-200 envelopes to typed Go errors (`ErrNoRecentScan`, `ErrDecodeFailed`, `ErrInternal`) for the HTTP layer.
+- [ ] **Step 4:** Run `go test -race ./internal/radar/` → PASS.
+- [ ] **Step 5:** Commit `feat: radar proxy + LRU cache + N0B→N0Q fallback (O2, Contract A)`.
+
+**Acceptance:** `go test -race ./internal/radar/` passes.
+**Interfaces produced:** `radar.NewProxy(sidecarURL, cfg)`; `(*Proxy).Get(ctx, site, product) (GeoJSON, meta, error)`.
+**Implements:** design §9 (O2, Contract A).
+
+### Task 2.5: `/api/radar/{site}` handler (opt-in) — depends on: Task 2.4, Task 1.6
+
+**Files:**
+- Create: `internal/httpserver/radar.go`
+- Test: `internal/httpserver/radar_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):**
+  - `TestRadarHandler_ServesGeoJSON`: `GET /api/radar/TLX?product=N0B` → 200 GeoJSON (via a fake proxy).
+  - `TestRadarHandler_RejectsInvalidSite`: `GET /api/radar/../etc` → 400 (allowlist).
+  - `TestRadarHandler_ErrorMapping`: proxy `no_recent_scan`→503, `decode_failed`→502, `internal`→502 with `{"error":...}` (Contract C).
+  - `TestRadarHandler_DisabledWhenNotEnabled`: with `ENABLE_RADAR` off, the route is not registered / returns 404.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3 (GREEN):** Register the handler only when `ENABLE_RADAR=true`; validate `{site}` via `radar.IsValidSite`; call the proxy; map errors per Contract C.
+- [ ] **Step 4:** Run `go test -race ./internal/httpserver/`; `go build ./...` → clean, PASS.
+- [ ] **Step 5:** Commit `feat: /api/radar/{site} handler, opt-in ENABLE_RADAR (Contract C)`.
+
+**Acceptance:** `go test -race ./internal/httpserver/` passes.
+**Implements:** design §9/§11; resolves **UI F-MEDIUM** (phantom radar → real feature).
+
+### Task 2.6: UI radar map card (MapLibre GL JS + same-origin OSM `.pmtiles` basemap, GeoJSON isoband fill) — depends on: Task 2.5, Task 1.7a, Task 1.7b
+
+> **Basemap = OpenStreetMap via Protomaps `.pmtiles`, served same-origin (user decision B2).** No external tile server, no API key, offline-capable. MapLibre reads the `.pmtiles` file with byte-range requests to `'self'` via the `pmtiles` protocol plugin. **OSM attribution is required** and MUST be visible on the map. The public `tile.openstreetmap.org` raster server is an online-only, light-use fallback only — not the default.
+
+**Files:**
+- Create: `web/src/components/RadarCard.tsx`, `web/src/components/RadarCard.test.tsx`, `web/public/basemap/osm.pmtiles` (built/downloaded — Step 0)
+- Modify: `web/src/App.tsx` (mount the card when radar is available), `web/package.json` (add `maplibre-gl`, `pmtiles`)
+
+**Steps:**
+- [ ] **Step 0 (basemap asset — pinned, one-time, committed or build-fetched):** obtain a single OSM vector-tile `.pmtiles` file and place it at `web/public/basemap/osm.pmtiles` so Vite copies it into `web/dist/basemap/` (served same-origin under `'self'`). Two documented options — pick one and record it in `web/public/basemap/PROVENANCE.md`:
+  - **Regional extract (recommended, small):** build from a region extract with the Protomaps tooling — `pmtiles extract https://build.protomaps.com/<DATE>.pmtiles web/public/basemap/osm.pmtiles --bbox=<minLon,minLat,maxLon,maxLat>` (bbox around the deployment region), or download a prebuilt regional `.pmtiles` from `build.protomaps.com`.
+  - **Whole-planet (large):** download the daily planet build `https://build.protomaps.com/<DATE>.pmtiles` (only if a global basemap is genuinely wanted — it is hundreds of MB; prefer the extract).
+  Attribution string to render: `© OpenStreetMap contributors`.
+- [ ] **Step 1 (RED):** `RadarCard.test.tsx`: renders a map container; registers the `pmtiles://` protocol pointing at the same-origin `/basemap/osm.pmtiles`; on a mocked `/api/radar/...` GeoJSON response it adds a fill layer styled by `dbz_min`/`dbz_max`; on an `{error}` response it renders a graceful "radar unavailable" state (no crash); the OSM attribution control is present. Respects `prefers-reduced-motion` (no auto-pan). (Mock MapLibre GL in jsdom.)
+- [ ] **Step 2:** Run `cd web && npm test` → FAIL.
+- [ ] **Step 3 (GREEN):** Implement `RadarCard` with MapLibre GL JS. Register the pmtiles protocol: `import { Protocol } from 'pmtiles'; const p = new Protocol(); maplibregl.addProtocol('pmtiles', p.tile);` and use a style whose vector source is `url: 'pmtiles:///basemap/osm.pmtiles'` (same-origin — matches the self-only CSP from Task 1.3; no external host, no API key). Add a visible `AttributionControl` showing `© OpenStreetMap contributors`. Center on the station lat/lon; add the radar GeoJSON as a fill layer with a data-driven color ramp keyed on `dbz_min`; auto-refresh on the scan cadence; graceful error state.
+- [ ] **Step 4:** Run `npm test && npm run build && npx tsc --noEmit` → clean.
+- [ ] **Step 5:** Commit `feat: UI radar map card (MapLibre + same-origin OSM pmtiles basemap, dBZ isobands) — §14 P1.8, B2`.
+
+**Acceptance:** `cd web && npm test && npm run build` clean; basemap loads from `'self'`; OSM attribution visible.
+**Implements:** design §9/§14 P1.8 (B2 pmtiles basemap, self-only CSP, OSM attribution).
+
+---
+
+## Workstream 4 — Grafana "Weather Nerd" dashboard
+
+> Design §13. Depends on WS6 (metrics via Collector→Prometheus). PromQL uses ONLY Contract B / design §13 names + `serial` label.
+
+### Task 4.1: OTel→Prometheus name-translation assertion test (real exporter) — depends on: Task 6.2
+
+> **Repaired per cold review:** the previous "OR table-equality" branch compared a hand-written map to a hand-written map and asserted nothing about actual translation — deleted. This test drives the OTel writer through the **real** in-process Prometheus exporter (`go.opentelemetry.io/otel/exporters/prometheus`), which performs the exact OTLP→Prometheus normalization the Collector uses (dotted→underscore, unit suffixes, `_total` for monotonic counters). Gathering the registry and asserting the emitted metric family names is a genuine translation check, deterministic on every `go test` run — no Collector container needed. (An optional `//go:build integration` real-Collector test may be added later but is not required.)
+
+**Files:**
+- Create: `internal/otel/promnames_test.go`
+
+**Steps:**
+- [ ] **Step 1 (RED):** `TestPrometheusExporterEmitsContractBNames`:
+
+```go
+func TestPrometheusExporterEmitsContractBNames(t *testing.T) {
+	reg := prom.NewRegistry() // github.com/prometheus/client_golang/prometheus
+	exporter, err := otelprom.New(otelprom.WithRegisterer(reg)) // otel exporters/prometheus
+	if err != nil { t.Fatal(err) }
+	mp := metric.NewMeterProvider(metric.WithReader(exporter))
+	w := otel.NewWriter(mp)
+
+	// record one of every field so every instrument is emitted:
+	w.WriteReport(t.Context(), fullSampleReport())
+
+	mfs, err := reg.Gather()
+	if err != nil { t.Fatal(err) }
+	got := map[string]bool{}
+	for _, mf := range mfs { got[mf.GetName()] = true }
+
+	// wantNames = Contract B right column (the exact tempest_* names):
+	wantNames := []string{
+		"tempest_temperature_c", "tempest_dewpoint_c", "tempest_heat_index_c",
+		"tempest_wetbulb_c", "tempest_humidity_percent", "tempest_pressure_mb",
+		"tempest_wind_meters_per_second", "tempest_wind_direction_degrees",
+		"tempest_uv_index", "tempest_irradiance_w_m2", "tempest_illuminance_lux",
+		"tempest_rain_rate_mm_min", "tempest_rainfall_mm_total",
+		"tempest_lightning_distance_km", "tempest_lightning_strike_count_total",
+		"tempest_battery_volts", "tempest_rssi_dbm", "tempest_uptime_seconds",
+		"tempest_reboots_total", "tempest_bus_errors_total",
+	}
+	for _, n := range wantNames {
+		if !got[n] { t.Errorf("missing Prometheus metric %q (got %v)", n, slices.Sorted(maps.Keys(got))) }
+	}
+	// negative guards: the OLD names must NOT appear (the intended breaks):
+	for _, old := range []string{"tempest_wind_ms", "tempest_uptime_seconds_total", "tempest_rainfall_total"} {
+		if got[old] { t.Errorf("stale metric name %q still emitted", old) }
+	}
+}
+```
+
+  (The Prometheus exporter may append `_total` to monotonic counters and reconcile units itself — the assertion is on the **emitted** family names, so it catches a wrong instrument name or wrong kind.)
+- [ ] **Step 2:** Run `go test ./internal/otel/ -run TestPrometheusExporterEmitsContractBNames` → FAIL if any instrument name/kind drifts from Contract B. First `go get go.opentelemetry.io/otel/exporters/prometheus@v0.54.0`.
+- [ ] **Step 3 (GREEN):** Reconcile the Task 6.2 instrument names/kinds until the emitted family names match Contract B exactly.
+- [ ] **Step 4:** Run the test → PASS.
+- [ ] **Step 5 (metric-migration diff, item 11):** Add `TestMetricMigrationList`: diff Contract B's right column against the **current** descriptor names in `internal/tempest/metrics.go` (`tempest_uptime_seconds_total`, `tempest_rssi_dbm`, `tempest_reboots_total`, `tempest_bus_errors_total`, `tempest_illuminance_lux`, `tempest_uv_index`, `tempest_rain_rate_mm_min`, `tempest_wind_ms`, `tempest_wind_direction_degrees`, `tempest_battery_volts`, `tempest_report_interval_minutes`, `tempest_irradiance_w_m2`, `tempest_rainfall_total`, `tempest_pressure_mb`, `tempest_temperature_c`, `tempest_humidity_percent`, `tempest_lightning_distance_km`, `tempest_lightning_strike_count`). The test computes and prints (via `t.Log`) the renamed/added/dropped set — `tempest_wind_ms`→`tempest_wind_meters_per_second`, `tempest_uptime_seconds_total`→`tempest_uptime_seconds`, `tempest_rainfall_total`→`tempest_rainfall_mm_total`, `tempest_lightning_strike_count`→`tempest_lightning_strike_count_total`, plus the `instance`→`serial` label rename — and asserts this is the COMPLETE break set (fails if an unlisted name changes). DOC.2 consumes this list for the migration note.
+- [ ] **Step 6:** Commit `test: assert OTel instruments translate to exact tempest_* names via real prom exporter + emit migration list (Contract B)`.
+
+**Acceptance:** `go test ./internal/otel/ -run 'TestPrometheusExporterEmitsContractBNames|TestMetricMigrationList'` passes.
+**Implements:** design §8/§13 (name-translation guard via the real exporter; complete metric-migration list for DOC.2).
+
+### Task 4.2: Grafana dashboard JSON + provisioning — depends on: Task 4.1
+
+**Files:**
+- Create: `deploy/grafana/dashboards/weather-nerd.json`, `deploy/grafana/provisioning/datasources/prometheus.yaml`, `deploy/grafana/provisioning/dashboards/dashboards.yaml`
+- Test: `deploy/grafana/validate_test.go` (or a `Makefile`/`task` target running `jsonnet`/`promtool`)
+
+**Steps:**
+- [ ] **Step 1 (RED):** Add a validation check: a small Go test (or `task grafana-validate`) that (a) `json.Unmarshal`s the dashboard without error, (b) asserts every panel `expr` references only names present in Contract B / design §13, and (c) asserts the `$serial` + `$__range` template variables exist. FAIL before the JSON exists.
+- [ ] **Step 2:** Run the validation → FAIL.
+- [ ] **Step 3 (GREEN):** Author `weather-nerd.json` implementing all 8 rows exactly as design §13 enumerates (Current conditions stats; Trends incl. `deriv(tempest_pressure_mb[3h])`; Wind rose + gust factor; Rain rate/accumulation; Lightning rate/nearest; Solar/UV; Station health; Records/almanac with `max_over_time`/`min_over_time` over `$__range`). Provision the Prometheus datasource + dashboard loader.
+- [ ] **Step 4:** Run the validation → PASS.
+- [ ] **Step 5:** Commit `feat: Grafana Weather Nerd dashboard + provisioning (§13)`.
+
+**Acceptance:** dashboard JSON parses; validation passes; (manual) dashboard loads in the compose stack against live metrics.
+**Implements:** design §13.
+
+---
+
+## Workstream 5 — UX polish (P2) + records the deferred P3 follow-ups
+
+> Design §14. P0/P1 landed inside WS1/WS2. This is the P2 batch. P3 items are NOT built (YAGNI) — recorded as follow-ups in DOC.1.
+
+### Task UX.1: UI P2 polish batch — depends on: Task 1.7b, Task 1.7c
+
+**Files:**
+- Modify: leaf card components (`web/src/components/*`), `web/src/App.css`, `web/src/components/SettingsPanel.tsx`, `web/src/themes/themes.ts`
+- Test: extend `web/src/**/*.test.tsx`
+
+**Steps:**
+- [ ] **Step 1 (RED where testable):** Add tests for the behavior-bearing P2 items: settings modal dialog semantics (`role="dialog"`, Escape closes, focus restore — §14 P2.14), theme-var leak fix (`applyTheme` clears prior vars; `desert-sunset` `--text-shadow` — §14 P2.15). These FAIL initially.
+- [ ] **Step 2:** Run `cd web && npm test` → FAIL.
+- [ ] **Step 3 (GREEN):** Implement the P2 set: `React.memo` leaf cards + `useMemo` RainCard raindrops (§14 P2.13); dialog semantics/focus-trap (P2.14); theme-var leak fix + `aria-hidden` on decorative SVGs (P2.15); `100dvh` over `100vh`, drop `background-attachment: fixed`, enumerate `transition` props (P2.16). (P2.17 Vitest+CI already established in Task 1.2 / DOC.2.)
+- [ ] **Step 4:** Run `npm test && npm run build && npx tsc --noEmit` → clean.
+- [ ] **Step 5:** Commit `feat: UI P2 polish — memoization, dialog a11y, theme leak, viewport (§14 P2)`.
+
+**Acceptance:** `cd web && npm test && npm run build` clean.
+**Implements:** design §14 P2.13–P2.16.
+
+---
+
+## Documentation, Compose, CI
+
+### Task DOC.1: Full-stack docker-compose + `.env.example` — depends on: Task 1.8, Task 2.2, Task 4.2
+
+**Files:**
+- Create: `deploy/docker-compose.yml`, `deploy/.env.example` (gitignored `.env`), `deploy/otel-collector-config.yaml`, `deploy/prometheus.yml`, `deploy/litestream.yml`
+
+**Steps:**
+- [ ] **Step 1:** Author compose per design §15a: `tempestwx` (`network_mode: host`, `OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317`, `SQLITE_PATH=/data/tempest.db`, `TOKEN`, volume `/data`); `litestream` (same `/data` → `minio`); `otel-collector` (OTLP `:4317`, metrics→Prometheus required, traces/logs→debug by default, **Tempo/Loki commented**); `prometheus`; `grafana` (provisioned datasource + WS4 dashboard); `radar-sidecar` **opt-in** (profile/commented, enabled with `ENABLE_RADAR`); `minio`. Document the `ENABLE_POSTGRES` variant (swap litestream+minio for `postgres`).
+- [ ] **Step 2 (verify):** `docker compose -f deploy/docker-compose.yml config` validates; a smoke bring-up reaches Grafana with the dashboard and (with `ENABLE_RADAR`) the radar card.
+- [ ] **Step 3:** Commit `feat: full-stack docker-compose (Collector+Prometheus+Grafana+Litestream+MinIO; radar opt-in) — §15a`.
+
+**Acceptance:** `docker compose config` validates; smoke bring-up healthy.
+**Implements:** design §15a (R1/O5 — no bundled Tempo/Loki as required services).
+
+### Task DOC.2: README/docs rewrite + UI CI — depends on: Task DOC.1
+
+**Files:**
+- Modify: `README.md`, `CLAUDE.md` (env-var matrix), `.github/workflows/` (add UI lint/typecheck/build/`docker build` job)
+- Create: `docs/CHANGELOG` note or follow-up list capturing the P3 items
+
+**Steps:**
+- [ ] **Step 1:** Rewrite README to reality: new env vars (`ENABLE_OTEL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `SQLITE_PATH`, `SQLITE_*`, `ENABLE_RADAR`, `RADAR_SITE`, `LITESTREAM_*`, `HTTP_ADDR`); new default store (SQLite); updated operational-mode matrix (design §16); remove obsolete `PUSH_URL`/`DATABASE_*` (G-H2); note the `ENABLE_PROMETHEUS_*` deprecation and consume the **complete metric-migration list** emitted by Task 4.1's `TestMetricMigrationList` (`instance`→`serial` label break, `tempest_wind_ms`→`tempest_wind_meters_per_second`, `tempest_uptime_seconds_total`→`tempest_uptime_seconds`, `tempest_rainfall_total`→`tempest_rainfall_mm_total`, `tempest_lightning_strike_count`→`tempest_lightning_strike_count_total`). Document that **`POSTGRES_BATCH_SIZE`/`POSTGRES_FLUSH_INTERVAL`/`POSTGRES_MAX_RETRIES` are now honored** (Task 0.13, B1 — previously inert). Document **`/api/almanac` proxies WeatherFlow** (B3) and that the **map basemap is a same-origin OSM `.pmtiles`** with required **OSM attribution** and no external tile server/API key (B2). Record P3 follow-ups (in-UI alerting, multi-station switcher, PWA, unit/theme profiles — design §14 P3) as a clearly-labeled "Future work (not implemented)" list.
+- [ ] **Step 2:** Add a UI CI job: `npm ci --ignore-scripts && npm run lint && npx tsc --noEmit && npm test && npm run build`, plus `docker build` for both images; turn on `noUncheckedIndexedAccess` in `web/tsconfig.app.json`.
+- [ ] **Step 3 (verify):** CI green locally (`actionlint`; run the UI steps).
+- [ ] **Step 4:** Commit `docs: rewrite README for new architecture + add UI CI (G-H2, UI F-MEDIUM)`.
+
+**Acceptance:** `actionlint` clean; UI CI steps pass; README quickstart is runnable.
+**Implements:** design §16; resolves **G-H2**, **UI F-MEDIUM**; records design §14 P3 as follow-ups.
+
+---
+
+## Risks & Rollback
+
+- **Interface-change ripple (Task 0.7):** `Close(ctx)` breaks all writers at once. Mitigation: the task updates every implementer + main in one commit; `go build ./...` gates it. Rollback: revert the single commit.
+- **OTel logs API is experimental:** isolated in `internal/otel` (No-Wall). If a breaking bump lands, fall back to `slog`-only (drop the log bridge, keep metrics/traces). Confirm APIs via Context7 before coding.
+- **Metric-name drift breaks the dashboard:** Task 4.1 asserts Contract B before Task 4.2 authors PromQL. If the Collector's translation differs from assumption, fix the assertion + instrument names before shipping the dashboard.
+- **SQLite PRAGMA misconfig silently loses Litestream data:** Task 3.2 pins exact PRAGMAs and leaves checkpointing to Litestream; Task 3.6 proves restore. Do not set `wal_autocheckpoint`.
+- **Sidecar image size / second moving part:** radar is opt-in; core stays a single static Go binary when `ENABLE_RADAR` is off. Sidecar failures soft-fail per Contract A. Rollback: disable `ENABLE_RADAR`.
+- **Vendored UI drift:** `web/` is an owned fork pinned at `49892063` (recorded in `web/PROVENANCE.md`); upstream changes are cherry-picked deliberately.
+- **`go:embed` empty-dir build failure:** `web/dist/.gitkeep` + documented build order (`task ui-build` before `go build`); the Dockerfile enforces the order.
+
+## Definition of Done (whole effort)
+
+- [ ] `go build ./...` clean; `go vet ./...` clean; `gofmt -l ./...` empty; `golangci-lint run ./...` clean.
+- [ ] `go test -race ./...` passes (this includes the **default** Litestream file-replica restore test, Task 3.6 — proven on every run, not integration-gated); `go test -tags integration ./...` passes locally (optional S3/MinIO Litestream variant).
+- [ ] `cd web && npm ci && npm run lint && npx tsc --noEmit && npm test && npm run build` all clean.
+- [ ] `cd radar && pytest` passes (malformed-bytes case + committed-fixture isoband case).
+- [ ] `docker buildx bake image-local` and `docker build radar/` succeed; both images run non-root; `/healthz` responds on each.
+- [ ] `docker compose -f deploy/docker-compose.yml config` validates; smoke bring-up reaches Grafana with the Weather Nerd dashboard populated from live metrics; radar card renders (same-origin OSM `.pmtiles` basemap, OSM attribution visible) when `ENABLE_RADAR=true`.
+- [ ] Every review CRITICAL/HIGH is resolved or superseded: exporter **C-1, A-H1..H3, C-H1, C-H2 (both SQLite and Postgres paths — Task 0.13/3.2/3.3), C-H3, D-H1..H2, F-H1..H4, G-H1..H3, B-HIGH**; UI **A-H1..H4, B-H1..H2, E-H1, F-H1**. (Each traced to a task above.)
+- [ ] `instance`→`serial` label rename documented; `tempest_*` names preserved and asserted via the **real Prometheus exporter** (Task 4.1, Contract B); the complete metric-migration list emitted for the README.
+- [ ] CSP is **self-only** (no external hosts); the map basemap is a same-origin OSM `.pmtiles` with visible OSM attribution; `/api/almanac` proxies WeatherFlow (B3).
+- [ ] `POSTGRES_BATCH_SIZE`/`POSTGRES_FLUSH_INTERVAL`/`POSTGRES_MAX_RETRIES` take effect (Task 0.13); `SQLITE_*` tunables take effect.
+- [ ] README quickstart is runnable; operational-mode matrix matches reality; P3 items recorded as explicit follow-ups (not built).
+- [ ] Fresh cold-review on the full diff from branch point completed; findings addressed.
+
+**Task count:** 46 tasks (was 42; +4 net). WS0: 14 (0.1–0.8, 0.9a, 0.9b, 0.10, 0.11, 0.12, 0.13 — the 0.9→0.9a/0.9b split and new 0.13); WS3: 6 (3.1–3.6); WS6: 5 (6.1–6.5); WS1: 10 (1.1–1.6, 1.7a, 1.7b, 1.7c, 1.8 — the 1.7→1.7a/b/c split); WS2: 6 (2.1–2.6); WS4: 2 (4.1–4.2); WS5: 1 (UX.1); DOC: 2 (DOC.1–DOC.2). Tasks added/split: **+0.13** (B1 Postgres tunables), **0.9→0.9a/0.9b** (per-writer gate), **1.7→1.7a/1.7b/1.7c** (right-sizing).

--- a/docs/review/2026-07-17-code-review-summary.md
+++ b/docs/review/2026-07-17-code-review-summary.md
@@ -1,0 +1,195 @@
+# Code Review Summary — tempestwx-exporter
+
+**Date:** 2026-07-17
+**Reviewed commit:** `017a852` (branch `main`) + the one uncommitted local change (`.gitignore`)
+**Reviewer:** Claude Code, via 7 parallel senior-engineer review agents (file-by-file, line-by-line)
+**Scope:** Every tracked Go file in the `main` working tree (20 `.go` files, ~2,760 LoC), plus all build/CI/infra/docs, plus the uncommitted `.gitignore` edit.
+
+---
+
+## 1. How this review was done
+
+The repository was partitioned across 7 background review agents, each reading **every line** of its assigned files (no skimming, no sampling), cross-checking symbols in neighbouring packages, and running the critical-thinking verification gate before reporting:
+
+| Agent | Area | Files |
+|---|---|---|
+| A | Entry point + fan-out | `main.go`, `internal/sink/` |
+| B | Config + DB schema | `internal/config/`, `internal/postgres/schema.go` |
+| C | Postgres batch writer | `internal/postgres/writer.go` (+test) |
+| D | Prometheus layer | `internal/tempest/`, `internal/prometheus/` |
+| E | UDP parsing + wet-bulb | `internal/tempestudp/` |
+| F | REST API client | `internal/tempestapi/` |
+| G | Build / CI / infra / docs / deps | Dockerfile, `.github/`, go.mod, README, etc. |
+
+I also gathered independent ground-truth evidence (below) to cross-check agent claims rather than take them on faith.
+
+### Scope notes (verified, not assumed)
+
+- **Uncommitted local change:** the only uncommitted change on `main` is `.gitignore` (adds `# Auto Claude data directory` / `.auto-claude/`). Trivial and correct. **Included in scope as requested.**
+- **The 16.9 MB `tempestwx-utilities` binary** in the repo root is a local build artifact — **not tracked** (confirmed via `git ls-files --error-unmatch` → "not tracked" and `git check-ignore` → matched by `.gitignore`). Not a finding.
+- **Stale worktree:** `.worktrees/uuid-raw-values/` (branch `feature/uuid-raw-values-v1.0.0`, `bd3cf99`) is a *prunable, gitignored, untracked* worktree whose git link is broken and whose code has **diverged** from `main` (it lacks the Prometheus scrape endpoint that `main` has; `main` lacks some of its commits). It is committed work on a pushed branch — **not** "local-only uncommitted code" — so it was **not** deep-reviewed. Recommend `git worktree prune` / `git worktree remove` to remove dead clutter that also pollutes repo-wide greps.
+
+---
+
+## 2. Objective ground-truth (independently verified)
+
+```
+go version   : go1.26.4 (go.mod targets go 1.24.0, toolchain go1.25.5)
+go build ./... : clean ✅
+go vet ./...   : clean ✅
+gofmt        : internal/tempest/metrics.go is NOT gofmt-clean ✗
+```
+
+**Test coverage — total 35.2%** (`go test -cover ./...`):
+
+| Package | Coverage | Notes |
+|---|---:|---|
+| `internal/config` | 100.0% | but tautological (asserts `Sprintf` output; no round-trip) |
+| `internal/sink` | 93.8% | happy paths only; no `-race`, no panic/partial-failure |
+| `internal/tempestapi` | 90.5% | broad on filtering; **blind to status/timeout paths** |
+| `internal/prometheus` | 90.1% | smoke-level; misses bind-fail + concurrency |
+| `internal/tempestudp` | 82.5% | good obs coverage; **the CRITICAL panic path untested** |
+| **`internal/postgres`** | **9.2%** | 4 of 5 tests are `t.Skip`; SQL/retry/drain untested |
+| `internal/tempest` | 0.0% | descriptors only |
+| `main.go` | 0.0% | untested (mode-selection logic, where a HIGH bug lives) |
+
+The postgres writer's highest-risk functions — **every** `batch*`/`flush*`/`insert*` path for rapid_wind, hub_status, and events, plus `flushWithRetry`, `isRetryable`, `Close`, and the shutdown drain — are at **0%**. Only `handleObservationReport` (88.9%) is meaningfully exercised.
+
+---
+
+## 3. Findings roll-up
+
+| Severity | Count |
+|---|---:|
+| 🔴 CRITICAL | 1 |
+| 🟠 HIGH | 17 |
+| 🟡 MEDIUM | 31 |
+| 🔵 LOW | 23 |
+| ⚪ NIT | 14 |
+| 🟢 POSITIVE | 37 |
+
+**The single most important structural fact:** the codebase has **multiple unguarded panic paths reachable from untrusted network input**, and **the fan-out layer has no `recover()`** — so any one of them takes down the whole exporter. These interlock (see §4). Second-most-important: **graceful shutdown is broken in several independent ways**, so buffered PostgreSQL data is lost on a normal container stop.
+
+---
+
+## 4. Cross-cutting themes (the issues that reinforce each other)
+
+These matter more together than as isolated line items:
+
+1. **Remote-crash chain.** `report.go:263-264` indexes `RadioStats[1]/[2]` with **no length guard** (CRITICAL) → panics on a short/malformed `hub_status` UDP packet from anyone on the LAN. The UDP receive path (`sink.go`) has **no panic recovery** (Review A, MEDIUM) → the panic is not contained → the process dies. Trivial remote DoS. Fix both: guard the index *and* add `defer recover()` in the fan-out goroutines.
+
+2. **Send-on-closed-channel panics on shutdown, in two packages.** Both `postgres/writer.go` (Review C, HIGH) and `prometheus/writer.go` (Review D, HIGH) close channels in `Close()` while producers may still `select`-send — and a `default:` case does **not** prevent a send on a closed channel from being chosen. A late in-flight UDP write during shutdown crashes the process. Neither `Close()` is idempotent (double-close panic). Same root cause, same fix pattern (`sync.Once` + a `done` channel gating sends).
+
+3. **Graceful shutdown loses buffered Postgres data — three independent causes.**
+   - `main.go:29` traps only SIGINT, **not SIGTERM** → `docker stop`/k8s never trigger graceful shutdown at all (Review A, HIGH).
+   - Even if it did, cleanup runs under the **already-cancelled** signal context (`main.go:33-34` + `sink.go`), so flushes abort immediately (Review A, MEDIUM).
+   - And the writer derives flush timeouts from that same cancelled ctx, and its `ctx.Done()` worker branches flush only the local slice, not the 1000-deep channel buffer (Review C, HIGH).
+   All three must be fixed for shutdown to actually persist buffered rows.
+
+4. **Errors that can't fire / can't be seen.** `MetricsServer.Start()` swallows bind failures in a goroutine and always returns nil (Review D, HIGH), so `main.go`'s error check is **dead code** (Review A, HIGH) — a failed `/metrics` endpoint runs silently. Similarly, `sink.SendReport/SendMetrics` always return nil, so the caller's error checks are dead (Review A, LOW).
+
+5. **HTTP-client footguns, all at once, in the API client** (Review F): no request timeout, no status-code check, token in the URL query string (leaks to proxy logs *and* into the `*url.Error` the caller `log.Fatalf`s), and a `log.Fatalf` inside a library method. Each is independently HIGH.
+
+6. **Docs ↔ code drift & inert knobs.** README documents an obsolete env-var scheme (`PUSH_URL`, `DATABASE_*`) so the headline quickstart cannot work (Review G, HIGH); and the documented `POSTGRES_BATCH_SIZE`/`FLUSH_INTERVAL`/`MAX_RETRIES` tunables are hardcoded and never read from the environment (Review C, HIGH).
+
+7. **The highest-risk code has the lowest test coverage.** The postgres writer (9.2%) and `main.go` mode-selection (0%) are exactly where the CRITICAL-adjacent lifecycle bugs live.
+
+---
+
+## 5. 🔴 CRITICAL
+
+### C-1 · `RadioStats` indexed without a length guard → remote panic/DoS
+`internal/tempestudp/report.go:263-264`
+```go
+prometheus.MustNewConstMetric(tempest.Reboots,   prometheus.CounterValue, r.RadioStats[1], ...),
+prometheus.MustNewConstMetric(tempest.BusErrors, prometheus.CounterValue, r.RadioStats[2], ...),
+```
+`RadioStats []float64` comes straight from the untrusted `radio_stats` JSON of a `hub_status` UDP packet. Every other array path in the file is length-guarded; this one is not. A packet with `radio_stats` missing / `null` / `[]` / `<3` elements panics with index-out-of-range. Combined with the missing `recover()` in `sink.go`, **any host on the LAN can crash the exporter with a single datagram.** Fix: `if len(r.RadioStats) >= 3 { … }` before indexing (guard shown in the agent report), and add panic recovery in the sink fan-out.
+
+---
+
+## 6. 🟠 HIGH (17)
+
+**main.go / sink (Review A)**
+- **A-H1 · SIGTERM ignored** — `main.go:29` `signal.NotifyContext(..., os.Interrupt)` only. `docker stop`/k8s send SIGTERM → graceful shutdown never fires → buffered Postgres rows lost. Fix: add `syscall.SIGTERM`.
+- **A-H2 · gzip-only API export mode is unreachable** — `main.go:86-95`. In `TOKEN` mode only Postgres can register as a writer, so `TOKEN + KEEP_EXPORT_FILES` with no Postgres dies on "no writers configured" despite being a documented mode. Enforce the writer-count invariant only in UDP mode.
+- **A-H3 · metrics-server start error check is dead code** — `main.go:60-64`. `Start()` always returns nil; real bind failures surface only inside a goroutine. (Root cause: D-H2.)
+
+**postgres/writer.go (Review C)**
+- **C-H1 · buffered data lost on shutdown** — `writer.go:179,270,346,402`. Flush inserts use `context.WithTimeout(w.ctx, …)`; if the app cancels `w.ctx` before/while `Close()` drains, every insert fails `context.Canceled`, `isRetryable`→false, batch dropped. Also the `ctx.Done()` worker branches flush only the local slice, not the buffered channel. Fix: drain under a fresh `context.Background()`-derived context, driven by `Close()` only.
+- **C-H2 · documented tunables are inert** — `writer.go:133-135`. `POSTGRES_BATCH_SIZE`/`FLUSH_INTERVAL`/`MAX_RETRIES` are hardcoded; grep confirms nothing reads them. Wire them into the constructor or remove from docs.
+- **C-H3 · producer/Close race → send-on-closed / double-close panic** — `writer.go:857-860` + all send sites. No `sync.Once`, no shutdown gate. Fix: `sync.Once` + `done` channel gating sends; make `Close()` idempotent.
+
+**prometheus (Review D)**
+- **D-H1 · send on closed channel panics** — `writer.go:60-61,71,82-83,91-92`. `Close()` closes `outbox`/`more` while `WriteMetrics`/`Flush` may still send; `default:` does not protect a send case. Crash on shutdown. Fix: `done` channel / mutex+closed-flag; don't close a channel producers still use.
+- **D-H2 · `Start()` swallows bind errors** — `server.go:64-74`. `ListenAndServe` errors only logged in the goroutine; `Start()` always returns nil → `/metrics` fails silently on an occupied/invalid port. Fix: `net.Listen` synchronously, return the bind error, then `go Serve(ln)`.
+
+**tempestapi/client.go (Review F)** — all four are independent and each production-blocking:
+- **F-H1 · TOKEN in URL query string** — `client.go:34,90`. Leaks to intermediary access logs and into Go's `*url.Error` (which redacts userinfo, *not* query params), then logged verbatim by `main.go:171/202` `log.Fatalf`. Move to `Authorization: Bearer` header (verify against current WeatherFlow API docs) and scrub error URLs.
+- **F-H2 · no HTTP status-code check** — `client.go:39-43,96-100`. 401/403/429/5xx decoded/parsed as success → auth failures and rate limits abort the export with a wrong diagnosis. Fix: check `resp.StatusCode` before decode.
+- **F-H3 · no request timeout** — `client.go:39,96` use `http.DefaultClient` (Timeout 0) and the caller ctx has no deadline → a stalled endpoint hangs indefinitely. Fix: dedicated `&http.Client{Timeout: 30*time.Second}`.
+- **F-H4 · `log.Fatalf` inside a library method** — `client.go:116`. An unexpected report type `os.Exit(1)`s the whole process. Fix: return an error.
+
+**Infra / CI / docs (Review G)**
+- **G-H1 · Docker action references undeclared `inputs.push`** — `.github/actions/docker/action.yml:50`. Commit `e722581` deleted the `push`/`latest`/`tag-strategy` input declarations but left the `fromJSON(inputs.push)` reference → `fromJSON('')` throws on every push/tag; workflows still pass three now-dead inputs. Image publish is very likely broken — verify against an Actions run.
+- **G-H2 · README quickstart is broken** — documents `PUSH_URL`/`DATABASE_*` env vars that no longer exist (renamed in PR #26 to `ENABLE_PROMETHEUS_*`/`POSTGRES_*`). The headline `docker run` cannot start the tool. CLAUDE.md is accurate; README must be brought in line.
+- **G-H3 · no `permissions:` block in any workflow** — inherits default `GITHUB_TOKEN` scope (not least-privilege; also a latent functional risk for ghcr push + GoReleaser release creation). Set explicit least-privilege per workflow.
+
+---
+
+## 7. 🟡 MEDIUM (31)
+
+**main.go / sink (A):** cleanup uses already-cancelled context (data loss) `main.go:33-34`; gzip export file opened without `O_TRUNC` (corrupt overwrite) `main.go:243`; `strconv.ParseBool` errors discarded — a typo (`ENABLE_POSTGRES=yes`) silently disables a sink `main.go:39,54,69,99,187`; a slow/blocked writer stalls the single UDP read loop (no per-writer timeout) `sink.go:58-101`; no panic recovery in fan-out goroutines `sink.go:66-125` (see C-1 chain).
+
+**config / schema (B):** no migration path — `CREATE TABLE IF NOT EXISTS` silently won't apply column changes to existing DBs, and the "safe on every startup" comment overstates evolution safety `schema.go:10-31`; tautological config tests with no special-char or round-trip case `database_test.go`.
+
+**postgres/writer.go (C):** "critical" events silently dropped under backpressure (non-blocking send drops discrete lightning/rain-start rows when the DB is slow) `writer.go:382,514-637`; `Flush()` is a no-op that misrepresents durability `writer.go:765-769`; `isRetryable` defaults unknown errors to *retryable* and the batch retry is non-transactional `writer.go:812-852`; retry backoff runs synchronously in the ingesting worker (backpressure amplification) `writer.go:772-810`.
+
+**prometheus (D):** every Desc uses the **reserved `instance` label** → renamed to `exported_instance` on scrape, breaking dashboards `metrics.go:32-50`; `tempest_wind_ms` ambiguous unit (m/s vs ms) `metrics.go:40`; explicit UDP timestamps re-served on the scrape endpoint → Prometheus "sample too old" rejection when a station goes quiet `server.go:135-141`; failed push permanently loses the drained batch `writer.go:98-105`; uptime modeled as a counter with `_total` though it resets on reboot `metrics.go:32`; `RainTotal` declared/registered/described but never emitted (dead) `metrics.go:45,66`.
+
+**tempestudp (E):** `wetBulb` `panic("failed to converge")` on a network-fed calculation `wetbulb.go:47`; `evt_precip`/`evt_strike`/`device_status` emit no metrics — silent drop on the metrics path (confirm intentional) `report.go:64,82,222`; missing obs values unmarshal to `0.0`, indistinguishable from a true zero → skews averages/`rate()` `report.go:134,147`.
+
+**tempestapi (F):** API `status.status_code` decoded but never checked (API-level errors read as "0 stations") `client.go:56-60`; token not URL-escaped `client.go:34,90`; full response body logged unbounded on parse error `client.go:108`.
+
+**Infra / CI (G):** third-party Actions pinned to floating tags not SHAs; `go clean -modcache` + `go mod tidy` in CI (no caching, masks module drift); `setup-go@v4` stale/inconsistent with `@v6`; CI Go `>=1.20` vs module `go 1.24.0`; base images floating tags (non-reproducible builds); GoReleaser runs with no `.goreleaser.yml` in the repo; `github.ref_name` interpolated into a `run:` script (injection antipattern); `.dockerignore` misses the local binary + `docs/`.
+
+---
+
+## 8. 🔵 LOW & ⚪ NIT (highlights)
+
+- **A:** `SendReport`/`SendMetrics` always return nil → caller error-checks are dead; single transient API fetch error `log.Fatalf`s a multi-hour backfill; gzip/file `Close()` errors ignored; dead "removed" comments.
+- **B:** integer counts stored as `DOUBLE PRECISION` (`lightning_strike_count`, `reboot_count`, `bus_errors`); overlapping unique+DESC indexes double write cost; use `t.Setenv`; `cmp.Or` for defaults.
+- **C:** `batchSize` dead for obs/events (batching only half-applied); `WriteMetrics` reconstruction brittle (`strings.Contains` matching, lossy fields, 1970 timestamps); ctx stored in struct field; duplicated batch-execute procedure across four `insertX`; drop logs lack serial/timestamp context.
+- **D:** missing `IdleTimeout`/`ReadHeaderTimeout` on the HTTP server; `Collect` holds `RLock` while sending; lossy `metricKey` fallback; `/health` ignores write error and accepts any method; `metrics.go` not gofmt-clean; `init()`+`var`+`All` triple-sync surface.
+- **E:** uptime counter/`_total` vs reset-on-reboot; pre-1.22 loop (`for range 10000`); `if/else` indent-error-flow; param `bytes` shadows stdlib; double JSON unmarshal.
+- **F:** unbounded `io.ReadAll`; `time.Unix` local-zone timestamps; value receivers / no owned `*http.Client`.
+- **G:** `go build main.go` vs `go build .`; no `HEALTHCHECK`/`EXPOSE`; `.gitignore` lists tracked `CLAUDE.md`; unused `SOURCE_COMMIT` bake var; YAML trailing whitespace (add `actionlint`).
+
+---
+
+## 9. What's genuinely well done (🟢 POSITIVE — 37 total)
+
+- **UDP field-index mapping is correct.** Every `obs_st` and `rapid_wind` index was verified against the Tempest UDP v143 field order and the metric descriptors; length guards on those two paths are tight and complete (Review E). The inline field-index docs are excellent.
+- **SQL is correct and safe.** All four INSERTs have fully-aligned column/placeholder/value mappings (verified field-by-field), are entirely parameterized (no injection surface), and retries are **idempotent** via UUIDv7-generated-once + `ON CONFLICT DO NOTHING` (Review C). The CRITICAL-class "swapped column" risk this file was flagged for is **not present**.
+- **The UDP listener's shutdown is subtly correct** — buffered `readErr` channel raced against `ctx.Done()`, `defer sock.Close()` unblocks the parked read; no goroutine leak (Review A).
+- **The scrape collector `latestMetricsCollector` is genuinely concurrency-correct** (RWMutex, last-value-wins), and HTTP graceful shutdown distinguishes `http.ErrServerClosed` (Review D).
+- **Wet-bulb math is legitimate** — standard Bolton (1980) + psychrometric with correct units and a correct shrinking-step solver (Review E).
+- **Container hardening is strong** — non-root `USER 65532`, static Chainguard base, `CGO_ENABLED=0`, stripped binary; tests genuinely gate merges/releases; deps current; only `GITHUB_TOKEN` used; ghcr login gated to non-PR (Review G).
+- **Config layer is clean and appropriately KISS/YAGNI**, schema uses correct UNIQUE constraints backing the dedup and correct nullable value columns (Review B).
+
+---
+
+## 10. Recommended priority order
+
+1. **Stop the remote crashes (do first):** guard `RadioStats` (C-1) **and** add `recover()` in the sink fan-out; fix both send-on-closed-channel panics (C-H3, D-H1) with `sync.Once`+`done`.
+2. **Fix graceful shutdown / data durability:** SIGTERM (A-H1), cleanup context (A-MEDIUM), writer drain context + channel-buffer drain (C-H1). Reconsider dropping "critical" events under backpressure (C-MEDIUM).
+3. **Make the API client production-grade:** timeout, status check, token-in-header, remove `log.Fatalf` (F-H1..H4).
+4. **Surface silent failures:** `Start()` bind error (D-H2 → A-H3); wire the Postgres tunables or delete the docs (C-H2); fix the unreachable gzip export mode (A-H2).
+5. **Fix the release pipeline & docs:** Docker action input mismatch (G-H1), README env vars (G-H2), workflow `permissions:` (G-H3).
+6. **Close the test gap where risk is highest:** `isRetryable` and routing/insert unit tests + a testcontainers integration test for the postgres writer (currently 9.2%); a `hub_status` short-`radio_stats` test (would have caught C-1); status-code/timeout tests for the API client; real DDL test for the schema.
+7. **Metric hygiene:** rename `instance`→`serial`, fix `_ms`/`_total`/dead `RainTotal`, `gofmt` `metrics.go`.
+8. **Housekeeping:** `git worktree prune` the stale `.worktrees/uuid-raw-values/`.
+
+---
+
+*Detailed per-file findings (with every `file:line`, failure scenario, and suggested fix) were produced by the seven review agents; this document consolidates and cross-references them. Coverage/build/vet figures above were independently re-run and verified.*

--- a/docs/review/2026-07-17-plan-cold-review-v2.md
+++ b/docs/review/2026-07-17-plan-cold-review-v2.md
@@ -1,0 +1,107 @@
+# Focused Cold Re-Review — Unified Weather Platform Plan v2
+
+**Reviewer:** cold, independent senior-Go pass. No prior context; this is a *targeted* re-review against the prior cold review's findings (`docs/review/2026-07-17-plan-cold-review.md`), not a full re-read. Conclusions reached fresh and checked against the live tree (`internal/sink/sink.go`, `internal/postgres/writer.go`, `internal/prometheus/writer.go`, `internal/prometheus/server.go`, `internal/config/database.go`, `internal/tempestapi/client.go`, `main.go`) and the design (`docs/designs/2026-07-17-unified-weather-platform-design.md`).
+**Skills applied:** `superpowers:test-driven-development`, `modern-go-guidelines:use-modern-go` (Go 1.24). Critical-thinking gate run before finalizing.
+
+---
+
+## Verdict
+
+**READY-WITH-MINORS.** Ready for a Haiku/Sonnet executor. **No remaining BLOCKER, no remaining MAJOR.**
+
+Every defect the prior cold review flagged is genuinely fixed in v2 — and, critically, the newly-**inlined GREEN code is correct**, not merely present. I verified each inlined block against the real signatures and line numbers it claims to change:
+
+- The two send-on-closed gates (0.9a postgres, 0.9b prometheus) are the *textbook-correct* fix and are shaped to each writer's **actual** channel topology, which I confirmed in source. This is the load-bearing check — a wrong gate here would reintroduce the C-H3/D-H1 panic — and it passes.
+- The `errors.Join` fan-out aggregation (0.7) is race-free (mutex around the append; `recover()` inside each goroutine).
+- The DSN `net/url` construction (0.4) genuinely percent-encodes credentials and round-trips.
+- The SIGTERM seam (0.8) is now a concrete, injectable, testable helper.
+- The pinned constants (3.3, 2.4) are present AND asserted in the RED tests.
+- Task 4.1's tautological table-equality branch is deleted and replaced with a real translation check.
+- B1/B2/B3 all landed in both docs.
+
+Remaining items are four **MINOR** cosmetic/narrative defects (below) that do not block execution. Fix them opportunistically; none warrant another revision cycle.
+
+---
+
+## BLOCKER 2.1 — Radar fixture — **RESOLVED**
+
+Both halves the prior review demanded are present:
+
+- **(a) Deterministic, fixture-independent RED case:** Task 2.1 Step 1 now leads with `test_decode.py::test_decode_bad_bytes_raises` — `decode.to_geojson(b"not-nids", "N0B")` must raise a typed `decode.DecodeError`. A weak model can write this and watch it fail (module→function→wrong-exception) with zero binary input. TDD is startable.
+- **(b) Concrete, runnable fixture-acquisition step:** Step 0 gives a pinned, commit-then-freeze recipe. It correctly handles the real-time bucket's rotating flat keys (`SSS_PPP_YYYY_MM_DD_HH_MM_SS`) by **listing newest → copying → committing the bytes** (`aws s3 ls --no-sign-request ... | grep 'TLX_N0B_' | sort | tail -1`), rather than hardcoding a key that would later 404. PROVENANCE.md records the source. The binary golden test (`test_decode_nids_to_isobands`) is second, gated on the committed file.
+
+The TDD loop no longer requires fabricating a binary. Evidence: plan lines 1421–1453.
+
+**Residual (not a defect):** Step 0 needs network + `aws` CLI *once* to seed the fixture; after commit, CI never touches S3. Acceptable and documented.
+
+---
+
+## MAJOR M1–M4
+
+### M1 — Vendored-UI forward references — **RESOLVED**
+
+Task 1.1 now emits a concrete UI manifest: the real `web/` file tree (lines 1156–1187) plus the **verbatim `web/src/types/weather.ts`** (lines 1189–1242) declared the single source of truth for Contract C. Downstream tasks cite present symbols: 1.2 (`ForecastStrip.getDayName`, `AlmanacCard`), 1.7a (`tempestApi.ts` stub fns, `stubData.ts`, `useWeatherData.ts`), 1.7b (`App.tsx`, `SolarUVCard.tsx`, named CSS classes), 1.7c (`SettingsPanel.tsx:103/:112`), 2.6 (`App.tsx`, `RadarCard.tsx`), UX.1 (`themes.ts`, `SettingsPanel.tsx`). The manifest header instructs STOP-and-reconcile if the clone diverges. Correctness spot-check: the `CurrentObservation` interface fields exactly match the Contract C key list on line 160 (SI units). Resolved — with one stale cross-reference noted under NEW issues.
+
+### M2 — Prose-only GREEN → inlined code — **RESOLVED** (correctness spot-checked)
+
+All named tasks now contain actual code, and the code is correct:
+
+- **0.9a (postgres gate) — correct.** Verified against source: the current `Close` unconditionally `close()`s all four batch channels (`writer.go:855–866`) and producers use `select { case w.xBatch <- row: … default: log-drop }` (e.g. `:543–550`). The v2 fix adds `done chan struct{}` + `closeOnce sync.Once`, **stops closing** the producer channels, makes producers `select` on `<-w.done`, makes workers exit on `<-w.done`, and closes only `done` once. This genuinely prevents send-on-closed and never closes a channel a producer still sends to. Correct for the 4-channel shape. (lines 500–533)
+- **0.9b (prometheus gate) — correct.** Verified: current `Close` closes both `outbox` and `more` (`writer.go:91–92`); `pushWorker` is `for range w.more` (`:100`); `WriteMetrics` sends into `outbox` then signals `more` (`:59–74`). The v2 fix adds `done`+`Once`, gates the metric send and the `more` signal on `done`, converts `pushWorker` to `select { case <-w.more … case <-w.done: final Add(); return }`, and closes only `done`. Correct for the `outbox`+`more` shape. The retained `default:` drop branch in `WriteMetrics` is fine (non-blocking, pre-existing behavior). (lines 553–609)
+- **The split itself is right.** The plan explicitly justifies 0.9→0.9a/0.9b because the two writers have structurally different channels and warns against "apply an identical pattern" (lines 483–484). This directly answers the prior review's central M2/concurrency concern.
+- **0.7 (`errors.Join` aggregation) — correct and race-free.** The append happens under `mu.Lock()` in both the error path and the `recover()` path; `recover()` is `defer`-installed per goroutine so a panicking writer is contained and the others still run; `wg.Wait()` then `errors.Join(errs...)` (nil when empty). Matches the current fan-out shape in `sink.go`. Modern idiom (`slices.Clone`, `log/slog`). (lines 341–403)
+- **0.4 (DSN via `net/url`) — correct.** `url.UserPassword(username, password)` percent-encodes `@ : / ? # &`; `net.JoinHostPort`; `u.RawQuery = url.Values{...}.Encode()`; `u.String()` round-trips through `url.Parse`, which is exactly the RED assertion. Replaces the raw `fmt.Sprintf` at `database.go:52–53` (verified present). Note is accurate that `pgxpool.ParseConfig` accepts this form. (lines 240–265)
+- **0.8 (SIGTERM seam) — concrete and testable.** The prior review's "impractical/via a seam" hand-wave is gone. v2 injects a `notifyFunc` matching `signal.NotifyContext`'s signature; `TestSignalContext_RegistersInterruptAndSIGTERM` asserts the exact signal set (`os.Interrupt`, `syscall.SIGTERM`) with no real signals. Replaces the real `signal.NotifyContext(ctx, os.Interrupt)` at `main.go:29` (verified — SIGTERM is currently absent). (lines 440–476)
+- **3.3 (single-writer batch loop) — inlined**, with the backpressure `enqueue`/`enqueueEvent` split shown (continuous = non-blocking drop-with-log; discrete events = bounded-block on a timer). Column mappings are pinned to the verified postgres field indices. (lines 886–939)
+
+### M3 — Unstated constants — **RESOLVED**
+
+- **3.3:** `rowChanCap = 1000`, `eventBlockTimeout = 5 * time.Second` — pinned as named consts AND asserted by `TestWriter_EventsNotDroppedUnderBackpressure` ("Assert the pinned constants exist: `rowChanCap == 1000`, `eventBlockTimeout == 5*time.Second`", line 884).
+- **2.4:** `radarCacheMaxEntries = 64`, `radarCacheTTL = 5*time.Minute` (+ `radarSidecarTimeout = 30s`) — pinned AND asserted by `TestProxy_Constants` (line 1509).
+
+The backpressure timeout that governs the C-MEDIUM "events not dropped" guarantee is now concrete. (One garbled comment noted under NEW issues — cosmetic.)
+
+### M4 — Task 4.1 dilution — **RESOLVED** (design-conformant)
+
+The tautological "OR table-equality" branch is deleted. `TestPrometheusExporterEmitsContractBNames` now drives the OTel writer through the **real** in-process `go.opentelemetry.io/otel/exporters/prometheus`, gathers the registry, and asserts the emitted family names equal Contract B's right column — plus **negative guards** that the old names (`tempest_wind_ms`, `tempest_uptime_seconds_total`, `tempest_rainfall_total`) are NOT emitted. This exercises real OTLP→Prometheus normalization (dotted→underscore, `_total`, unit suffixes) and catches a wrong instrument name/kind. (lines 1583–1638)
+
+Design-conformance: design §8 (line 294) asks for "an assertion test that the Collector emits the exact `tempest_*` names." The plan substitutes the in-process exporter — a faithful, deterministic stand-in that shares the Collector's normalization rules — and explicitly flags an optional `//go:build integration` real-Collector test. This is a defensible, in-spirit substitution, not a dilution. Step 5 (`TestMetricMigrationList`) additionally emits the complete old→new break set for DOC.2 (addresses the prior review's Axis-1 migration-diff MINOR).
+
+---
+
+## B1 / B2 / B3 — landed & conformant
+
+- **B1 (Postgres tunables) — landed, conformant.** New **Task 0.13** adds a pure `postgresTunables(getenv)` helper; `TestPostgresTunables` asserts a **non-default** value takes effect (`BATCH_SIZE=7`, `FLUSH_INTERVAL=2s`, `MAX_RETRIES=5`) AND that defaults hold when unset (100/10s/3). Verified against source: the values are currently hardcoded-and-inert at `writer.go:133–135` (`batchSize:100, flushInterval:10*time.Second, maxRetries:3`) — exactly the C-H2-for-Postgres defect. Design updated: §-refs at design lines 84, 164–166, 178 credit C-H2 for the Postgres path. (plan lines 737–806)
+- **B2 (basemap) — landed, conformant.** Basemap = OpenStreetMap via same-origin Protomaps `.pmtiles`; **CSP is self-only** with the exact directive pinned in Global Constraints (line 48) and asserted in `TestServer_SecurityHeaders` (1.3, line 1282) — including a positive assertion that the CSP names **no external host**. `blob:`/`wasm-unsafe-eval` are scoped to MapLibre's worker/WASM, adding no network origin. OSM attribution required and rendered (Task 2.6, line 1567–1574: visible `AttributionControl` "© OpenStreetMap contributors"). Both docs updated (design §7/§9/§15, lines 211, 378–381, 672–675). No API key, no external tile host.
+- **B3 (`/api/almanac`) — landed, conformant.** Contract C (line 164) and Task 1.5 make `/api/almanac` a WeatherFlow REST proxy (Bearer), not computed. Design §11 (line 494) updated to "v2/B3: proxy, not computed." DOC.2 documents it (line 1702).
+
+---
+
+## NEW issues introduced by the v2 edits
+
+All **MINOR** — none block execution:
+
+- **[MINOR] Stale cross-reference in Task 1.4.** Step 1 (line 1302) says the current-observation endpoint returns "Contract C **`CurrentWeather`**", but the Task 1.1 manifest and Contract C table name the type **`CurrentObservation`** — there is no `CurrentWeather` interface in `weather.ts`. The field list is unambiguous, so an executor will likely infer the right type, but the manifest edit left this dangling reference unreconciled. Fix: rename `CurrentWeather`→`CurrentObservation` on line 1302.
+- **[MINOR] 0.8 ↔ 0.9a forward reference.** Task 0.8 (line 476) tells the executor to "stop accepting new sends (the Task 0.9a `done` gate)" — but 0.9a *depends on* 0.8 and lands later. 0.8's own concrete GREEN keys the drain off the existing `w.ctx.Done()`/channel path, so it is executable in isolation, but the parenthetical invites a Haiku agent to implement the `done` gate early and collide with 0.9a. The plan acknowledges the shared shutdown path (line 487); tightening 0.8's wording to "drain off `w.ctx` here; the `done` gate is added in 0.9a" would remove the ambiguity.
+- **[MINOR] 0.8 inserter-interface ripple under-shown.** The `TestPostgresWriter_DrainOnClose` seam introduces `interface{ insertObservations(ctx, []observationRow) error }`, but the current `insertObservations` has **no** `ctx` param (`writer.go:174`, derives its 5s timeout from `w.ctx` at `:179`). The plan does say to "route `insertObservations` et al. to accept the passed `ctx`" (line 476), so the refactor is named — but the signature change ripples to `flushObservations`/`flushWithRetry` and the three sibling insert paths more than the text shows. Tractable (the row types and call sites exist), just larger than it reads.
+- **[MINOR/cosmetic] Garbled comment in 3.3.** The `eventBlockTimeout` doc comment contains "`5s > the 10s? No —`" (line 897), an editing artifact. Harmless to the code; clean up the prose.
+
+No new dependency-order violation from the task splits (0.9a/0.9b, 1.7a/b/c, +0.13) beyond the 0.8/0.9a wording above. No new broken symbol reference in the split UI tasks — all cite the manifest.
+
+---
+
+## Residual watch-items (inherent uncertainties, not defects)
+
+These are genuine execution-environment dependencies the plan already flags; listing them so the executor is not surprised:
+
+- **Litestream on PATH (Task 3.6):** the now-default (non-integration) file-replica restore test `t.Skip`s cleanly if `litestream` is absent. Good — but it means the PRAGMA/restore contract is only *actually* proven where the binary is installed (CI must install it). The plan states CI installs it; verify that holds.
+- **OTel logs API is experimental (WS6):** `otelslog`/`otlploggrpc` at v0.8.0 move. Plan mandates Context7 confirmation before coding (lines 74, 1122) and isolates the bridge to one file (No-Wall). Correct mitigation; still a live risk.
+- **Upstream UI clone must match the manifest (Task 1.1):** the manifest is captured from `tempest-display@49892063`; if the clone diverges, the STOP-and-reconcile instruction fires. This is a manual gate, not an automated one.
+- **NOAA HOMR awk column indices (Task 2.3 Step 0):** the plan itself says to verify `$(NF-4)`/`$(NF-3)` against the current file header once. A weak model may not catch a column shift; the `IsValidSite`/`NearestSite` RED tests (`TLX` near OKC) will catch a grossly wrong table, which is a reasonable backstop.
+- **Grafana JSON authoring (Task 4.2):** hand-authoring the 8-row dashboard JSON from prose remains large and error-prone for a weak model, but the validation test (parse + expr-names-in-Contract-B + `$serial`/`$__range` vars) constrains it. Acceptable.
+
+---
+
+## Bottom line
+
+The v2 edits did the hard thing the prior review asked for: they inlined **correct** concurrency-sensitive code, not just prose, and I confirmed each block against the real writer topology. The BLOCKER and all four MAJORs are resolved; B1/B2/B3 are landed and design-conformant. The only open items are four minor cosmetic/narrative defects. **A Sonnet/Haiku agent can execute this plan.**

--- a/docs/review/2026-07-17-plan-cold-review.md
+++ b/docs/review/2026-07-17-plan-cold-review.md
@@ -1,0 +1,153 @@
+# Cold SGE Review — Unified Weather Platform Plan vs Design
+
+**Reviewer:** cold, independent senior-Go pass. No prior context; conclusions reached fresh from the two documents, sanity-checked against the live tree (`main.go`, `internal/**`, `go.mod`).
+**Inputs:** `docs/designs/2026-07-17-unified-weather-platform-design.md`, `docs/plans/2026-07-17-unified-weather-platform-implementation.md`.
+**Skills applied:** `superpowers:writing-plans` (the plan's own stated bar), `superpowers:test-driven-development`.
+
+---
+
+## Verdict
+
+**Ready-after-fixes.** The plan is architecturally faithful to the design — I found **zero drift** on the three revised decisions (O1 Python Py-ART sidecar, O3 contoured GeoJSON, O5 app-ships-OTLP-only), every review CRITICAL/HIGH is traceably assigned to a task, the three cross-task contracts are single-sourced, and the WS0-first sequencing genuinely lands the lifecycle fixes that are the whole premise (SIGTERM, drain, panic recovery, send-on-closed gate) before anything depends on them. That is strong senior work and I want to be clear it is not the problem.
+
+The problem is **Axis 3 (executability), which is weighted heavily and where the plan is systematically thin.** Its GREEN (implementation) steps are almost universally *prose* ("Implement `Writer` satisfying `sink.MetricsWriter`... single writer goroutine... `ON CONFLICT DO NOTHING`") rather than the concrete code blocks the `writing-plans` skill mandates ("Complete code in every step — if a step changes code, show the code"; "Steps that describe what to do without showing how" is listed as a *plan failure*). A skilled human fills that gap; a Sonnet/Haiku executor reading only one task's text will stall or produce low-confidence work on the harder tasks. Layered on top are a handful of concrete blockers: tests that depend on binary fixtures a weak model cannot fabricate (Task 2.1 NIDS), unstated constants (backpressure timeout, channel capacities, LRU size), `main.go` refactor seams the executor must invent (`signalContext`/`requireWriters`/`selectStore`), one test that contradicts its design requirement and risks being tautological (Task 4.1), and one oversized task (Task 1.7). **Must fix before a weaker model executes: (1) show concrete code in the GREEN steps of the concurrency/DSN/writer tasks; (2) resolve the fixture-dependent RED tests so they can fail for the right reason; (3) repair Task 4.1 to actually exercise the Collector name-translation per design §8 and pin the unstated constants.**
+
+---
+
+## Axis 1 — Conformance to design
+
+### Coverage checklist
+
+| Design element | Covered by | Verdict |
+|---|---|---|
+| **W0** Foundation (lifecycle/review-fix bedrock) | Tasks 0.1–0.12 | Covered |
+| **W1** Embedded UI + backend JSON API | Tasks 1.1–1.8 | Covered |
+| **W2** NEXRAD radar overlay | Tasks 2.1–2.6 | Covered |
+| **W3** SQLite + Litestream | Tasks 3.1–3.6 | Covered |
+| **W4** Grafana dashboard | Tasks 4.1–4.2 | Covered |
+| **W5** UX scan | P0/P1 folded into 1.2/1.7/2.6; P2 in UX.1; P3 recorded in DOC.2 | Covered |
+| **W6** OTLP backbone | Tasks 6.1–6.5 | Covered |
+| **R1** unified OTLP, app ships signals only | Global Constraints + 6.1 + DOC.1 | Covered |
+| **R2** SQLite default + Postgres optional | Task 3.5 (`selectStore`) | Covered |
+| **R3** radar server-side via Py-ART sidecar | Tasks 2.1–2.6 | Covered |
+| **O1** Python Py-ART sidecar (NOT pure-Go) | Task 2.1 (FastAPI + Py-ART) | **Conforms — no drift** |
+| **O2** N0B default, N0Q fallback | Global Constraints + Task 2.4 | Covered |
+| **O3** contoured GeoJSON isobands (NOT PNG-primary) | Contract A + Task 2.1/2.6 | **Conforms — no drift** |
+| **O4** deprecate-then-remove prometheus | Global Constraints + Task 6.5 | Covered |
+| **O5** app ships OTLP; backends operator's choice | Global Constraints + DOC.1 (Tempo/Loki commented) | **Conforms — no drift** |
+| **O6** `modernc.org/sqlite` CGO-free | Global Constraints + Task 3.1/3.2 | Covered |
+| CRITICAL/HIGH fix map (both reviews) | see below | All assigned |
+
+**CRITICAL/HIGH assignment audit (verified each):** C-1→0.2; A-H1→0.8; A-H2→0.11; A-H3→0.10; C-H1→0.8; C-H2→3.2; C-H3→0.9; D-H1→0.9; D-H2→0.10; F-H1..H4→0.5; G-H1..H3→0.12; B-HIGH→0.4. UI: A-H1..H4→1.7; B-H1→1.5; B-H2→1.4/1.7; E-H1→1.3; F-H1→1.8. **Every promised fix has a home.** Good.
+
+### Findings
+
+- **[MINOR] Axis 1 — Task 4.1 waters down a design §8 requirement.** Design §8 Risks explicitly demands "an **assertion test that the Collector emits** the exact `tempest_*` names WS4 queries" — i.e. exercise the real OTLP→Prometheus translation. Task 4.1 offers an "OR" branch: "assert the instrument-name→expected-prom-name **mapping table** equals Contract B exactly (a data-driven table test comparing every row)." That branch compares a hand-written map in the test to a hand-written map in code, both copied from Contract B — it asserts nothing about actual translation and is tautological. This is also an Axis 2 (TDD) finding. **Fix:** require the test to drive the OTel writer through the `sdk/metric` Prometheus exporter (or a real Collector in an integration test) and assert the emitted names, deleting the table-equality escape hatch.
+
+- **[MINOR] Axis 1 — Litestream "restore-safety" proof is integration-gated and may silently skip.** Design §10 Risks names "misconfigured PRAGMAs silently lose Litestream data" as a top risk and §18 mandates a restore-from-replica test. Task 3.6 provides it but tags it `//go:build integration` with a fallback to "a local filesystem replica if S3 is unavailable in CI." The design's whole point is that WAL/checkpoint semantics are proven; if CI routinely skips the integration tag, the guard is decorative. **Fix:** make the filesystem-replica variant the *default* (non-integration) test so the PRAGMA/restore contract is proven on every run.
+
+- **[MINOR] Axis 1 — no task verifies the `instance`→`serial` break is actually the *only* metric break.** Global Constraints and DoD assert `tempest_*` names are "preserved," but the design renames several (`_ms`→`_meters_per_second`, uptime `_total` dropped, RainTotal wired). These are intended, but there is no task asserting the *full* old-vs-new name set so a consumer migration doc is complete. Contract B is the source but nothing diffs it against the current `internal/tempest/metrics.go` descriptors. **Fix:** add a step in Task 6.2/4.1 that diffs Contract B against the existing descriptor names and emits the migration list DOC.2 consumes.
+
+No scope-invention drift found: the plan adds nothing the design didn't call for. P3 items are correctly recorded-not-built (YAGNI-clean).
+
+---
+
+## Axis 2 — SGE standards / skills / rules
+
+- **[MAJOR] TDD — GREEN steps are prose, not code, across the whole plan.** The `writing-plans` skill lists "Steps that describe what to do without showing how (code blocks required for code steps)" as a **plan failure**, and `test-driven-development` requires the *minimal implementation* be concrete enough to know the test drove it. Nearly every GREEN step here is a paragraph of intent: 0.7 (panic recovery + `errors.Join` aggregation), 0.9 (the `sync.Once`+`done`+`select{case ch<-x: case <-done}` gate), 3.3 (single-writer batch loop), 6.2 (instrument registration). The RED tests are mostly concrete and good; the implementations are hand-waved. A skilled human bridges it; a weak executor guesses. **Fix:** for at least the concurrency-sensitive tasks (0.7, 0.8, 0.9, 3.3) and the DSN task (0.4), inline the actual code the step should produce.
+
+- **[MAJOR] Concurrency — the load-bearing send-on-closed gate (Task 0.9) is specified once in prose and told to "apply the identical pattern to both writers."** This is the exact fix for the design's C-H3/D-H1 premise, and it is subtle (never `close()` a channel producers may still send to; signal via `done`; drain). The plan neither shows the code nor accounts for the two writers having *different* internal channel shapes (`postgres/writer.go` is 870 lines with a 4-goroutine design per the review; `prometheus/writer.go` is ~2.7 KB). "Identical pattern" is not "identical code." A weak executor applying a copy-paste to structurally different writers is a regression risk on the very bug being fixed. **Fix:** show the concrete gate per writer, or split into 0.9a/0.9b with each writer's actual code.
+
+- **[MAJOR] `main.go` refactor seams are invented by the executor, not specified.** `main.go` is a flat 281-line file (verified). Tasks 0.8 (`signalContext`), 0.11 (`requireWriters`), 3.5 (`selectStore`) each say "extract a testable helper `func X(...)`" but never show the current code being extracted or the resulting signatures' bodies. Task 0.8 itself admits `TestMain_TrapsSIGTERM` "is impractical" and hand-waves "unit-test that the helper lists both signals **via a seam**" — an unresolved judgment call handed to the weakest reader. **Fix:** show the before/after of each extraction with the concrete helper body; resolve the SIGTERM-test approach to one named technique (e.g. table-assert the signal set passed to a thin injectable `notify` func).
+
+- **[MINOR] KISS/right-sizing — Task 1.7 bundles five independent concerns.** It does: replace stub data layer + AbortController + ErrorBoundary + define all missing CSS + responsive breakpoints + reduced-motion/focus-visible + `formatX` NaN guard + remove SettingsPanel inputs + self-host fonts. The `writing-plans` "Task Right-Sizing" rule: a reviewer should be able to reject one task while approving its neighbor — impossible here. **Fix:** split into 1.7a (data layer + AbortController + stale indicator), 1.7b (ErrorBoundary + missing CSS + responsive/a11y), 1.7c (settings-input removal + font self-host).
+
+- **[MINOR] Modern-Go — good, with one gap.** Global Constraints correctly mandate 1.24 idioms (`cmp.Or`, `for range n`, `errors.Join`, `slices`/`maps`). Task 0.3 modernizes the wetbulb loop to `for range 10000`. One miss: Task 0.7 says "mutex-guarded slice + `errors.Join`" for aggregation but the current fan-out uses `sync.WaitGroup` with per-goroutine `log.Printf` (verified in `sink.go`) — the plan should note that collecting errors from goroutines needs the mutex *around the append*, which the prose says, but should show it to avoid a data race the `-race` test would catch late.
+
+- **[MINOR] Go↔Python contract — Contract A is well-specified but the error-transport is ambiguous.** Contract A says errors come "HTTP 200 with error envelope OR non-200" — allowing both. A weak executor implementing the Go client (Task 2.4) and the Python side (Task 2.1) independently may disagree on which. **Fix:** pick one (recommend: non-200 status + JSON envelope) and state it once in Contract A.
+
+---
+
+## Axis 3 — Executability by a Sonnet/Haiku agent
+
+### Per-task verdict
+
+| Task | Verdict | Gap (if not Executable) |
+|---|---|---|
+| 0.1 golangci/gofmt | Executable | — |
+| 0.2 RadioStats guard | Executable | Cited symbols verified in `report.go` (`RadioStats[1]/[2]` at ~263). |
+| 0.3 wetBulb NaN | Executable | `panic("failed to converge")` verified at `wetbulb.go:47`. |
+| 0.4 DSN via net/url | Needs-tightening | GREEN gives the `url.URL` skeleton (good) but not the full function replacing `database.go:52`'s `fmt.Sprintf`; show the whole body. |
+| 0.5 API client hardening | Needs-tightening | Large multi-assertion task; `NewClient` returns value receiver (verified `client.go:21`) — plan says "change to pointer receiver as needed" without showing the ripple to `main.go` call sites. Bearer-header format left to "verify against docs." |
+| 0.6 bool env parsing | Executable | — |
+| 0.7 sink Close(ctx)+recover+aggregate | Needs-tightening | Interface change verified feasible (`Close() error` at `sink.go:25`, `Flush(ctx)` already exists). Prose-only GREEN for panic-recovery + `errors.Join`; show code. |
+| 0.8 SIGTERM + pg drain | Ambiguous | Admits its own test is "impractical," hand-waves "via a seam"; `signalContext` extraction unshown; pg drain over "an injected fake `pgxpool`-like interface" that doesn't exist and isn't defined. |
+| 0.9 idempotent Close both writers | Ambiguous | The subtle send-on-closed gate shown only in prose; "apply identical pattern to both" ignores structural differences between the two writers. |
+| 0.10 metrics server bind error | Executable | `Start()`/`ListenAndServe` in goroutine verified (`server.go:64-69`); the `net.Listen` fix is concrete. |
+| 0.11 writer invariant + O_TRUNC | Needs-tightening | `requireWriters` extraction + `Mode` type unshown; `writeMetricsToFile` open flags verified (`main.go:243`, missing `O_TRUNC`) — that half is concrete. |
+| 0.12 CI/supply-chain | Needs-tightening | "Re-declare the inputs the action references OR remove `fromJSON(inputs.push)`" requires reading `.github/actions/docker/action.yml` + caller to disambiguate; no concrete diff. |
+| 3.1 sqlite schema/migrations | Executable | DDL is fully specified in design §12; `Migrate` contract clear. |
+| 3.2 sqlite Open/PRAGMAs | Needs-tightening | Exact PRAGMAs given (good) but modernc `_pragma` DSN syntax flagged "verify via Context7" — an unresolved lookup mid-task. |
+| 3.3 sqlite writer | Needs-tightening | Column mappings deferred to "mirror the postgres writer's verified mappings" (870-line file); backpressure "block-with-bounded-timeout" has **no timeout value or channel capacity**. |
+| 3.4 drain + read methods | Executable | Field allowlist concept clear; signatures given. |
+| 3.5 wire default store | Needs-tightening | `selectStore` extraction unshown; `storeChoice` type undefined. |
+| 3.6 Litestream restore | Needs-tightening | "MinIO testcontainer OR local filesystem replica … document which" — unresolved choice; spawning litestream subprocess unspecified. |
+| 6.1 otel setup | Needs-tightening | Correctly defers to Context7 (logs API experimental) — acceptable, but the whole provider wiring is prose. |
+| 6.2 otel writer | Needs-tightening | Contract B fully enumerates names/kinds (good); the in-memory manual-reader assertion is real; instrument registration code unshown. |
+| 6.3 tracing spans | Executable | `tracetest.SpanRecorder` + span-name assertions concrete. |
+| 6.4 slog→OTel bridge | Needs-tightening | slog.Handler-over-LoggerProvider is nontrivial and prose-only; depends on experimental API. |
+| 6.5 prometheus deprecation | Executable | Single `slog.Warn`; trivial. |
+| 1.1 vendor UI | Ambiguous | Depends on cloning `tempest-display@49892063` — an external repo not in this tree; a weak model cannot fabricate it. RED-less scaffolding task. |
+| 1.2 vitest + math | Needs-tightening | Depends on file names inside the not-yet-present vendored app (`ForecastStrip.getDayName`, hemisphere logic) — unknowable until 1.1 lands. |
+| 1.3 Go HTTP server/embed | Needs-tightening | Good detail on `//go:embed` cross-dir pitfall; SPA/headers concrete-ish but middleware code unshown. |
+| 1.4 observation handlers | Needs-tightening | `CurrentWeather` shape deferred to `web/src/types/weather.ts` (arrives in 1.1) — must read a vendored file. |
+| 1.5 WF proxy handlers | Executable | httptest-driven, bearer assertion concrete. |
+| 1.6 otelhttp + wire main | Executable | — |
+| 1.7 data layer + boundary + CSS | Ambiguous | Five concerns; oversized (Axis 2). Depends on vendored file internals. |
+| 1.8 multi-stage Dockerfile | Executable | Concrete stages + `USER 65532` + healthcheck. |
+| 2.1 python sidecar | **BLOCKER** | RED test `test_decode_nids_to_isobands` requires `radar/tests/fixtures/<captured_nids_file>` — a **binary NEXRAD L3 fixture** a weak model cannot generate. The TDD loop cannot fail-for-the-right-reason without it. |
+| 2.2 sidecar Dockerfile | Executable | — |
+| 2.3 radar site table | Needs-tightening | "~160 CONUS sites: code + lat/lon" — the actual table data is not provided; "reuse DRAS conventions" points at an external repo. |
+| 2.4 radar proxy + LRU | Needs-tightening | LRU size ("bounded") and TTL ("~5 min") are approximate; concrete cap unset. |
+| 2.5 radar handler | Executable | Error→status mapping enumerated (503/502). |
+| 2.6 UI radar card | Needs-tightening | MapLibre tile source ("self-hostable tiles") unspecified; depends on vendored app. |
+| 4.1 prom-name assertion | Ambiguous | Tautology risk (Axis 1/2) — the "OR table-equality" branch asserts nothing about real translation. |
+| 4.2 grafana dashboard | Needs-tightening | 8 rows enumerated in §13 (good); authoring full Grafana JSON by hand from prose is large and error-prone for a weak model. |
+| UX.1 P2 polish | Needs-tightening | Depends on vendored component internals. |
+| DOC.1 compose | Needs-tightening | Service inventory in §15a is detailed; exact YAML unshown. |
+| DOC.2 README/CI | Executable | — |
+
+### BLOCKER / MAJOR write-ups
+
+- **[BLOCKER] Axis 3 — Task 2.1 RED test depends on a binary NIDS fixture that cannot be authored from task text.** `test_decode.py::test_decode_nids_to_isobands` needs a real captured NEXRAD Level 3 object at `radar/tests/fixtures/`. A Sonnet/Haiku executor cannot synthesize a valid binary NIDS file, so the test cannot be written or watched-fail per TDD. **Fix:** add a pre-task step that specifies *how* the fixture is obtained (e.g. a documented `aws s3 cp --no-sign-request s3://unidata-nexrad-level3/TLX_N0B_... radar/tests/fixtures/` command with a pinned key, or commit the fixture and reference it), and give `decode.to_geojson` a smaller deterministic RED case (e.g. malformed-bytes→`DecodeError`) that *can* be written first.
+
+- **[MAJOR] Axis 3 — vendored-UI dependency chain (Tasks 1.1, 1.2, 1.4, 1.7, 2.6, UX.1) rests on an external repo and its internal file names.** Task 1.1 clones `tempest-display@49892063` (not in this tree, verified). Every downstream UI task references symbols inside it (`ForecastStrip.getDayName`, `tempestApi.ts` stubs, `types/weather.ts`, `SettingsPanel.tsx`, `themes.ts`). A weak executor running 1.2+ in isolation cannot know these exist or their shapes. **Fix:** Task 1.1 must emit a concrete manifest (the actual file tree + the exact `weather.ts` type block) into the plan or a committed doc so downstream tasks cite real, present names instead of forward-referencing a repo that must be fetched.
+
+- **[MAJOR] Axis 3 — unstated constants block several GREEN steps.** Task 3.3 "block-with-bounded-timeout" has no timeout and no channel capacity; Task 2.4 LRU is "bounded" with no size; Task 1.6 default addr `:8080` is stated (good) but Task 3.3/3.2 `SQLITE_*` defaults are stated (good) — the gap is specifically the backpressure timeout, event-channel cap, and LRU cap. A weak model will invent divergent values, and the backpressure one directly governs the C-MEDIUM "events not dropped" guarantee. **Fix:** pin exact values in the tasks (e.g. events channel cap N, block timeout T, LRU max entries M) and assert them in the RED tests.
+
+- **[MAJOR] Axis 3 — Task 0.8's own admission of test impracticality is an unresolved judgment call.** The plan literally says the SIGTERM test "is impractical" and offers "(or, simpler, unit-test that the helper lists both signals via a seam)" without defining the seam. This is the acceptance criterion for the design's #1 HIGH (A-H1). **Fix:** specify one concrete testable shape — extract `func signalContext(ctx, sigs ...os.Signal)` and assert the call site passes `[os.Interrupt, syscall.SIGTERM]`, or inject a `notifyFunc` and assert its arguments.
+
+---
+
+## Prioritized fix list (most important first)
+
+1. **Resolve Task 2.1's fixture blocker** — specify how the binary NIDS fixture is obtained/committed, and add a deterministic malformed-bytes RED case so TDD can start. (BLOCKER)
+2. **Make Task 1.1 emit a concrete UI manifest** (file tree + `weather.ts` types) so Tasks 1.2/1.4/1.7/2.6/UX.1 reference present, real symbols instead of forward-referencing an external repo. (MAJOR)
+3. **Inline concrete code in the concurrency/DSN GREEN steps** — 0.4, 0.7, 0.8, 0.9 (per-writer gate code), 3.3. This is the single biggest lift for weak-model executability and the `writing-plans` bar. (MAJOR)
+4. **Pin the unstated constants** — 3.3 backpressure timeout + event channel cap, 2.4 LRU size/TTL — and assert them in RED tests. (MAJOR)
+5. **Repair Task 4.1** to exercise real OTLP→Prometheus translation (delete the table-equality escape hatch) per design §8. (MINOR but corrects a design-requirement dilution)
+6. **Specify the `main.go` extractions** (`signalContext`, `requireWriters`, `selectStore`, `storeChoice`) with before/after and helper bodies. (MAJOR, folded with #3)
+7. **Split Task 1.7** into 3 right-sized tasks. (MINOR)
+8. **Disambiguate Contract A error transport** (non-200 + envelope) and **make Task 3.6's replica choice concrete** (default to filesystem replica, non-integration). (MINOR)
+9. Provide the **radar site table data** (Task 2.3) inline rather than "reuse DRAS." (MINOR)
+
+---
+
+## What's genuinely good (brief)
+
+- **Zero conformance drift on the three revised decisions** (O1/O3/O5) and full CRITICAL/HIGH traceability — the hard part of faithfulness is done.
+- **Correct sequencing:** WS0 lands the lifecycle bedrock first; interface-breaking changes (Task 0.7) are explicitly confined to one commit with all implementers updated — the plan even flags the compile-ripple. This genuinely fixes the shutdown/drain/panic premise rather than reintroducing it.
+- **Cross-task contracts (A/B/C) are single-sourced** and cited by dependents — textbook No-Wall/DRY for the variant boundaries.
+- **Contract B is fully enumerated** (every instrument → Prometheus name + kind), which makes the OTel writer and the dashboard genuinely buildable.
+- **RED tests are mostly concrete and behavior-asserting** (temp DBs, `httptest`, `tracetest.SpanRecorder`, `-race` on the concurrency tasks) — the test-first discipline is real where it counts, even where the GREEN side is thin.
+- **CGO-free constraint is treated as load-bearing** and repeated at the points it matters (driver choice, Dockerfile) — the static-image property is protected.

--- a/docs/review/2026-07-17-ui-code-review-summary.md
+++ b/docs/review/2026-07-17-ui-code-review-summary.md
@@ -1,0 +1,140 @@
+# Code Review Summary — tempest-display (UI)
+
+**Repository:** [`github.com/jacaudi/tempest-display`](https://github.com/jacaudi/tempest-display)
+**Reviewed commit:** [`49892063`](https://github.com/jacaudi/tempest-display/tree/49892063dab064a7864c4810b4d266b9ea3f4985) (branch `main`)
+**Date:** 2026-07-17
+**Reviewer:** Claude Code, via 6 parallel senior-engineer review agents (file-by-file, line-by-line)
+**Scope:** All 24 tracked source files (~3,480 LoC frontend + a 63-line Go static server), plus build/config/container/docs.
+
+> All `file:line` references below link to the exact line at commit `49892063`. Permalink base:
+> `https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/`
+
+---
+
+## 1. What this project is (as-built)
+
+`tempest-display` (`package.json` name `tempest-app`) is a **React 19.2 + TypeScript 5.9 + Vite 7** glassmorphism weather dashboard for WeatherFlow Tempest stations, served by a **zero-dependency Go static-file server** (`server/main.go`) that embeds the built `dist/` via `//go:embed` and serves it with an SPA fallback. Seven themes, unit toggles, ~15 weather cards.
+
+**The single most important architectural fact:** the app currently runs **entirely on stub data**. Every function in `src/api/tempestApi.ts` returns fixtures from `stubData.ts`; the real network code exists only as commented-out `// TODO` blocks. The Go server is **not a proxy** — it never talks to WeatherFlow. So the whole review splits into two questions: *is the shell well-built?* (largely yes) and *is the not-yet-written data path safe?* (there is a latent HIGH security trap baked into the commented design).
+
+### Review partition
+
+| Agent | Area | Files |
+|---|---|---|
+| A | App shell + global CSS | `index.html`, `src/main.tsx`, `src/App.tsx`, `src/App.css` (1177 lines), `src/index.css` |
+| B | Data layer | `src/api/tempestApi.ts`, `src/api/stubData.ts`, `src/hooks/useWeatherData.ts`, `src/hooks/useUnits.ts`, `src/types/weather.ts` |
+| C | Components 1 | GlassCard, Header, TemperatureHero, Wind, Humidity, Pressure, Rain |
+| D | Components 2 | Lightning, SolarUV, StationHealth, ForecastStrip, Almanac, WeatherIcon, SettingsPanel, `themes/themes.ts` |
+| E | Go backend | `server/main.go`, `server/go.mod` |
+| F | Build / config / container / deps / docs | Dockerfile, `vite.config.ts`, 3× tsconfig, ESLint, `package.json`, README, etc. |
+
+---
+
+## 2. Findings roll-up
+
+| Severity | Count |
+|---|---:|
+| 🔴 CRITICAL | 0 |
+| 🟠 HIGH | 8 |
+| 🟡 MEDIUM | 25 |
+| 🔵 LOW | 20 |
+| ⚪ NIT | 18 |
+| 🟢 POSITIVE | 27 |
+
+**Verified non-issues (good news):** no committed secrets; **no `VITE_`-embedded token** (token is runtime user-entered, not build-baked); no client-side token *persistence* today (the token input stores nothing); path traversal is structurally impossible (read-only `embed.FS` + `fs.ValidPath`); the moon-phase geometry and **all 10 unit conversions are mathematically correct**; WeatherIcon has a safe default fallback (no crash on unknown conditions).
+
+---
+
+## 3. Cross-cutting themes
+
+1. **The app ships fixtures as production data.** The entire API client is stub-only (B-H2); a deployed container shows a hard-coded Seattle station with randomized wind and no indication the data is fake. Everything below about "the data path" is about code that doesn't exist yet but is partly designed in comments.
+
+2. **The commented-out live design is a token-exposure trap.** `API_BASE` points straight at `swd.weatherflow.com`, and every reference fetch appends `?token=${_apiToken}` — in the URL query string, from browser JS, with **no backend proxy** to hold the secret (E confirmed the Go server is static-only). Uncommenting as written ships a WeatherFlow Personal Access Token to every visitor and leaks it via server/proxy logs and `Referer`. This is flagged three times from three angles (B-H1, E token assessment, F-M token). **The fix — add a proxy endpoint to the Go server and fetch tokenless relative URLs — should be decided before the data path is implemented.**
+
+3. **The shell is not production-hardened for a 24/7 display.** No error boundary (A-H1) → one card's render error blanks the whole screen; the loading/error/Retry CSS is *referenced but never defined* (A-H2) → the first screen users see is broken; zero media queries (A-H3) → non-responsive on the tablets/phones such displays actually run on; no `prefers-reduced-motion` (A-H4) despite many infinite animations.
+
+4. **Both container/server layers miss basic hardening.** The Go server has no HTTP timeouts (E-H1, Slowloris) and no graceful shutdown; the Docker image runs as **root** (F-H1). Both are one-line-ish fixes.
+
+5. **No tests, no CI.** No test runner is configured and there's no `.github/` at all (F-M) — so the pure functions most worth testing (unit conversions, moon phase, battery curve, day-name derivation) are unguarded, and lint/typecheck/build are never enforced.
+
+6. **Small civil-calendar / i18n correctness bugs.** Hard-coded `°N/°W` hemisphere suffixes (C-M) render wrong coordinates for non-US stations; `ForecastStrip.getDayName` uses the current year (D-M) → wrong weekday labels across a Dec→Jan boundary; sunrise/sunset shown in the viewer's timezone, not the station's (C/D).
+
+---
+
+## 4. 🟠 HIGH (8)
+
+### App shell (Review A)
+
+- **A-H1 · No error boundary anywhere** — [`src/App.tsx:51-88`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.tsx#L51-L88). ~10 cards render with no `ErrorBoundary`/`getDerivedStateFromError` anywhere in `src/`. A render-time exception in any one card unmounts the entire app to a blank page — the worst outcome for a wall display. Fix: wrap the dashboard (or each card) in an error boundary with a fallback.
+- **A-H2 · Loading/error/Retry styles used but never defined** — [`src/App.tsx:30-47`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.tsx#L30-L47). `.loading-screen`, `.loading-spinner`, `.error-screen`, `.glass-btn` have no CSS in either stylesheet, so the initial spinner is an invisible zero-size div and the failure screen + Retry button are unstyled. This is literally the first screen every visitor sees.
+- **A-H3 · No responsive design** — [`src/App.css:240-244`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.css#L240-L244). `grid-template-columns: repeat(3, 1fr)` is fixed and there is **not one `@media` rule** in the codebase; span-2/span-3 cards force a rigid 3-up layout on phones/tablets.
+- **A-H4 · No `prefers-reduced-motion`** — [`src/App.css:57-62`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.css#L57-L62). Continuous `orbFloat`/`pulse`/`rainfall`/`flashBadge` animations with no reduce-motion opt-out (WCAG 2.3.3 / vestibular safety).
+
+### Data layer (Review B)
+
+- **B-H1 · Commented live-API design embeds the token in the frontend; no proxy exists** — [`src/api/tempestApi.ts:69-72`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/api/tempestApi.ts#L69-L72). PAT in `?token=` query string, from browser JS, static-only backend. Route through a Go proxy that injects the token server-side; frontend uses tokenless relative URLs. (See §3.2.)
+- **B-H2 · Entire API client returns stub data — no real data path** — [`src/api/tempestApi.ts:49-133`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/api/tempestApi.ts#L49-L133). The app renders fixtures in production with no error and no "fake data" indication. Must not ship as a release without a loud dev-only/offline banner until the real fetch layer (with `response.ok`/timeout/validation) lands.
+
+### Backend (Review E)
+
+- **E-H1 · Missing HTTP server timeouts → Slowloris** — [`server/main.go:59`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/server/main.go#L59). `http.ListenAndServe` uses a zero-value `http.Server` (all timeouts 0). The scratch image binds `0.0.0.0:3000` and ships standalone, so slow-header connections can exhaust goroutines/FDs with no auth. Fix: explicit `http.Server` with `ReadHeaderTimeout`/`ReadTimeout`/`WriteTimeout`/`IdleTimeout`.
+
+### Container (Review F)
+
+- **F-H1 · Final container runs as root (UID 0)** — [`Dockerfile:42`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/Dockerfile#L42). `FROM scratch` with no `USER`. The Go binary needs no root and PodSecurity `restricted`/OpenShift reject UID-0 containers. Fix: `USER 65532:65532` (or switch to `distroless/static:nonroot`, which also ships CA certs the planned proxy will need).
+
+---
+
+## 5. 🟡 MEDIUM (25)
+
+**App shell (A):** no `:focus-visible`/outline anywhere (WCAG 2.4.7) [`index.css`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/index.css#L57-L64); blank-screen when a successful fetch yields null `current` [`App.tsx:49`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.tsx#L49); all ~10 cards re-render on every ~3s tick (no `React.memo`) [`App.tsx:66-78`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.tsx#L66-L78); external Google Fonts dependency, no CSP, breaks offline/air-gapped kiosks [`index.html:8-10`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/index.html#L8-L10); `transition: all` on blur-heavy cards [`App.css:73`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/App.css#L73).
+
+**Data layer (B):** `loadData` has no AbortController/overlap guard → stale-response race once real latency exists [`useWeatherData.ts:44-75`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/hooks/useWeatherData.ts#L44-L75); `savePrefs` calls `localStorage.setItem` with no try/catch (throws in private mode / quota) [`useUnits.ts:26-28`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/hooks/useUnits.ts#L26-L28); no runtime validation of untrusted input (localStorage prefs spread unchecked; future API JSON `as`-cast) [`useUnits.ts:18-24`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/hooks/useUnits.ts#L18-L24); token-in-URL smell even server-side.
+
+**Components 1 (C):** `GlassCard` `role="button"`+`tabIndex` with **no `onKeyDown`** → focusable but not keyboard-activatable (WCAG 2.1.1), baked into the shared wrapper [`GlassCard.tsx:14-20`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/GlassCard.tsx#L14-L20); hard-coded `°N/°W` renders wrong coordinates for southern/eastern-hemisphere stations [`Header.tsx:28`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/Header.tsx#L28); systemic missing-field handling — `current.uvIndex.toFixed(1)` **throws** (unmounts dashboard) while `formatX`/`Math.round` sites degrade to visible `NaN` [`TemperatureHero.tsx:62`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/TemperatureHero.tsx#L62).
+
+**Components 2 (D):** SettingsPanel Station ID / API Token inputs are **dead UI** — uncontrolled `defaultValue=""`, no wiring, no matching pref field [`SettingsPanel.tsx:104-119`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/SettingsPanel.tsx#L104-L119); settings modal has no `role="dialog"`/`aria-modal`, no Escape, no focus trap/restore [`SettingsPanel.tsx:17-18`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/SettingsPanel.tsx#L17-L18); `themes.ts` `desert-sunset` omits `--text-shadow` and `applyTheme` never clears prior vars → stale shadow leaks across theme switches [`themes.ts:223-233`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/themes/themes.ts#L223-L233); `ForecastStrip.getDayName` uses the current year → wrong weekday across a year boundary, ignoring the entry's own `sunrise` epoch [`ForecastStrip.tsx:16-20`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/ForecastStrip.tsx#L16-L20).
+
+**Backend (E):** no graceful shutdown / signal handling → truncated responses on every restart [`server/main.go:59-61`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/server/main.go#L59-L61); `Cache-Control: immutable` set before the existence check → a missing `/assets/*` returns `index.html` cached for a year (cache poisoning + wrong 404 semantics) [`server/main.go:34-36`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/server/main.go#L34-L36); no security response headers (nosniff/CSP/frame/referrer) [`server/main.go:32-55`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/server/main.go#L32-L55).
+
+**Build / config (F):** base images float on mutable tags (no digest pin) [`Dockerfile:4`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/Dockerfile#L4); README documents phantom build args (`VITE_ENABLE_RADAR`, `VITE_RADAR_TILE_HOST`) and dead `docs/*.md` links [`README.md:37`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/README.md#L37); **no CI** (no `.github/`) → lint/typecheck/build never enforced [`package.json:6`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/package.json#L6); **no test tooling / no `test` script**; TS strictness omits `noUncheckedIndexedAccess` despite index-heavy code [`tsconfig.app.json:20`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/tsconfig.app.json#L20); the live-API token-in-URL design (same root as B-H1) [`tempestApi.ts:35`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/api/tempestApi.ts#L35).
+
+---
+
+## 6. 🔵 LOW & ⚪ NIT (highlights)
+
+- **A:** default Vite favicon still shipped; `100vh` vs `100dvh` (mobile viewport bug); `background-attachment: fixed` janky on iOS; `App` ignores the `hourly` data the hook fetches (dead round-trip); unsafe `as ThemeName` cast; ~7 near-identical card-label styles (DRY); a single `!important`.
+- **C:** `RainCard` recomputes `Math.random()` raindrops every render (reshuffle on each poll); WindCard has no "Calm" handling (0 wind shows a direction); Header time in viewer TZ not station TZ; decorative SVGs lack `aria-hidden`; `GlassCard` className double-space; magic pressure/solar thresholds.
+- **D:** Almanac `daylightDuration` mishandles polar day/night (negative durations); WeatherIcon mapping incomplete (`foggy`/`sleet`/`possibly-*` silently render "partly cloudy"); decorative header SVGs not `aria-hidden`; forecast `key={i}` has a natural stable id; WeatherIcon uses UMD `React` namespace; `UserPreferences.theme` typed `string`; `signalBars` `number[]` used as booleans; `timeSince` returns negative strings for future timestamps.
+- **E:** `PORT` parsed with `fmt.Sscanf` (ignored error, silent fallback); cache policy keyed on URL prefix not file identity; no server tests; double `stat` on happy path; log advertises `http://0.0.0.0:3000`; `go.mod` pins only minor Go version.
+- **F:** no HEALTHCHECK (constrained by scratch); `.gitignore` doesn't ignore `.env`; Google-CDN fonts (offline/privacy); no Prettier; ESLint `ecmaVersion 2020` lags tsconfig target; README says "six themes" but ships seven; `package.json` name `tempest-app` ≠ repo, version `0.0.0`; `renovate.json` is schema-only (no `config:recommended`).
+
+---
+
+## 7. What's genuinely well done (🟢 27 positives)
+
+- **All 10 unit conversions are mathematically correct** (°C↔°F, m/s↔mph/kph/kts, mb↔inHg, mm↔in — each verified against reference constants) — [`useUnits.ts:32-57`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/hooks/useUnits.ts#L32-L57). The strongest part of the data layer.
+- **Moon-phase geometry is correct and elegantly derived**, verified across all phases with a clean quarter-degeneracy guard — [`AlmanacCard.tsx:11-49`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/AlmanacCard.tsx#L11-L49).
+- **Wind compass shortest-arc animation** (normalizes delta to `[-180,180]`) and correct `degToCompass` wrap — [`WindCard.tsx:20-31`](https://github.com/jacaudi/tempest-display/blob/49892063dab064a7864c4810b4d266b9ea3f4985/src/components/WindCard.tsx#L20-L31).
+- **Every displayed measurement routes through the units hook** — no raw-unit leakage into any card.
+- **Backend is minimal and safe by construction:** zero third-party deps (stdlib-only), embedded assets on `scratch`, path traversal structurally prevented by read-only `embed.FS` + `fs.ValidPath`, no hardcoded secrets, correct KISS/YAGNI scope — Review E.
+- **Strong build/toolchain posture:** `strict: true` + correct TS project references, `eslint-plugin-react-hooks` recommended (exhaustive-deps on), `npm ci --ignore-scripts`, `CGO_ENABLED=0`/`-trimpath`/`-ldflags="-s -w"`, thorough `.dockerignore`, **no `VITE_`-embedded secret** (token runtime-entered) — Review F.
+- **Clean, idiomatic types** (const-object enums, per-field unit comments, no `any`), correct effect/interval cleanup in the WS stub, correct staleness semantics (retain prior data on failure) — Review B.
+- **Consistent numeric clamping** where it matters (battery %, UV/lightning bar positions), correct cross-type field selection (`status.batteryLevel` vs `current.battery`), WeatherIcon safe default — Reviews C/D.
+
+---
+
+## 8. Recommended priority order
+
+1. **Decide the data-path security model before writing it:** add a proxy endpoint to `server/main.go` (token from env, injected server-side) and have the frontend fetch tokenless relative URLs (B-H1). Do not uncomment the token-in-URL design.
+2. **Harden the two infra layers (one-liners):** HTTP server timeouts (E-H1) and non-root container `USER` (F-H1); add graceful shutdown + a `/healthz` route while there.
+3. **Make the shell production-safe for a 24/7 display:** error boundary (A-H1), define the missing loading/error/Retry CSS (A-H2), add breakpoints (A-H3) and `prefers-reduced-motion` + `:focus-visible` (A-H4 / A-MEDIUM).
+4. **Fix the correctness bugs users will actually see:** hemisphere suffixes (C-M), forecast weekday across year boundary (D-M), theme-var leak (D-M), and route UV through a `formatX` helper so a missing field can't hard-crash (C-M).
+5. **Wire or remove the dead SettingsPanel config** (D-M) and add dialog semantics/Escape/focus-trap.
+6. **Establish the safety net:** add Vitest + a `test` script and cover the pure math (conversions, moon phase, battery, day-name); add a CI workflow running lint/typecheck/build/`docker build` (F-M); turn on `noUncheckedIndexedAccess`.
+7. **Before shipping stub-only:** add a loud "demo/offline data" banner so fixtures are never mistaken for live readings (B-H2).
+8. **Supply-chain/docs polish:** digest-pin base images, fix README drift (phantom args, dead links, theme count), self-host fonts, enrich `renovate.json`.
+
+---
+
+*Detailed per-file findings (every `file:line`, GitHub permalink, failure scenario, and suggested fix) were produced by the six review agents and consolidated here. Every finding in this document links to the exact line at commit [`49892063`](https://github.com/jacaudi/tempest-display/tree/49892063dab064a7864c4810b4d266b9ea3f4985).*

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 )
 
@@ -24,11 +27,6 @@ func GetDatabaseConfig() (string, error) {
 		return "", nil // No database configured
 	}
 
-	port := os.Getenv("POSTGRES_PORT")
-	if port == "" {
-		port = "5432"
-	}
-
 	username := os.Getenv("POSTGRES_USERNAME")
 	if username == "" {
 		return "", fmt.Errorf("POSTGRES_USERNAME required when using POSTGRES_HOST")
@@ -44,11 +42,15 @@ func GetDatabaseConfig() (string, error) {
 		return "", fmt.Errorf("POSTGRES_NAME required when using POSTGRES_HOST")
 	}
 
-	sslmode := os.Getenv("POSTGRES_SSLMODE")
-	if sslmode == "" {
-		sslmode = "disable"
-	}
+	port := cmp.Or(os.Getenv("POSTGRES_PORT"), "5432")
+	sslmode := cmp.Or(os.Getenv("POSTGRES_SSLMODE"), "disable")
 
-	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
-		username, password, host, port, dbname, sslmode), nil
+	u := url.URL{
+		Scheme: "postgresql",
+		User:   url.UserPassword(username, password), // percent-encodes @ : / ? # &
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/" + dbname,
+	}
+	u.RawQuery = url.Values{"sslmode": {sslmode}}.Encode()
+	return u.String(), nil
 }

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -1,21 +1,19 @@
 package config
 
 import (
-	"os"
 	"testing"
 )
 
 func TestGetDatabaseConfig_FullURL(t *testing.T) {
 	// Set full connection string
-	os.Setenv("POSTGRES_URL", "postgresql://user:pass@localhost:5432/testdb")
-	defer os.Unsetenv("POSTGRES_URL")
+	t.Setenv("POSTGRES_URL", "postgresql://user:pass@localhost:5432/testdb")
 
 	url, err := GetDatabaseConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := "postgresql://user:pass@localhost:5432/testdb"
+	expected := "postgresql://user:pass@localhost:5432/testdb" //nolint:gosec // test fixture value, not a real credential
 	if url != expected {
 		t.Errorf("got %q, want %q", url, expected)
 	}
@@ -23,63 +21,49 @@ func TestGetDatabaseConfig_FullURL(t *testing.T) {
 
 func TestGetDatabaseConfig_Components(t *testing.T) {
 	// Clear POSTGRES_URL
-	os.Unsetenv("POSTGRES_URL")
+	t.Setenv("POSTGRES_URL", "")
 
 	// Set individual components
-	os.Setenv("POSTGRES_HOST", "postgres")
-	os.Setenv("POSTGRES_PORT", "5433")
-	os.Setenv("POSTGRES_USERNAME", "tempest")
-	os.Setenv("POSTGRES_PASSWORD", "secret")
-	os.Setenv("POSTGRES_NAME", "weather")
-	os.Setenv("POSTGRES_SSLMODE", "require")
-	defer func() {
-		os.Unsetenv("POSTGRES_HOST")
-		os.Unsetenv("POSTGRES_PORT")
-		os.Unsetenv("POSTGRES_USERNAME")
-		os.Unsetenv("POSTGRES_PASSWORD")
-		os.Unsetenv("POSTGRES_NAME")
-		os.Unsetenv("POSTGRES_SSLMODE")
-	}()
+	t.Setenv("POSTGRES_HOST", "postgres")
+	t.Setenv("POSTGRES_PORT", "5433")
+	t.Setenv("POSTGRES_USERNAME", "tempest")
+	t.Setenv("POSTGRES_PASSWORD", "secret")
+	t.Setenv("POSTGRES_NAME", "weather")
+	t.Setenv("POSTGRES_SSLMODE", "require")
 
 	url, err := GetDatabaseConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := "postgresql://tempest:secret@postgres:5433/weather?sslmode=require"
+	expected := "postgresql://tempest:secret@postgres:5433/weather?sslmode=require" //nolint:gosec // test fixture value, not a real credential
 	if url != expected {
 		t.Errorf("got %q, want %q", url, expected)
 	}
 }
 
 func TestGetDatabaseConfig_ComponentDefaults(t *testing.T) {
-	os.Unsetenv("POSTGRES_URL")
-	os.Setenv("POSTGRES_HOST", "postgres")
-	os.Setenv("POSTGRES_USERNAME", "user")
-	os.Setenv("POSTGRES_PASSWORD", "pass")
-	os.Setenv("POSTGRES_NAME", "db")
+	t.Setenv("POSTGRES_URL", "")
+	t.Setenv("POSTGRES_HOST", "postgres")
+	t.Setenv("POSTGRES_USERNAME", "user")
+	t.Setenv("POSTGRES_PASSWORD", "pass")
+	t.Setenv("POSTGRES_NAME", "db")
 	// Don't set PORT or SSLMODE - should use defaults
-	defer func() {
-		os.Unsetenv("POSTGRES_HOST")
-		os.Unsetenv("POSTGRES_USERNAME")
-		os.Unsetenv("POSTGRES_PASSWORD")
-		os.Unsetenv("POSTGRES_NAME")
-	}()
 
 	url, err := GetDatabaseConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := "postgresql://user:pass@postgres:5432/db?sslmode=disable"
+	expected := "postgresql://user:pass@postgres:5432/db?sslmode=disable" //nolint:gosec // test fixture value, not a real credential
 	if url != expected {
 		t.Errorf("got %q, want %q", url, expected)
 	}
 }
 
 func TestGetDatabaseConfig_NoConfig(t *testing.T) {
-	os.Unsetenv("POSTGRES_URL")
-	os.Unsetenv("POSTGRES_HOST")
+	t.Setenv("POSTGRES_URL", "")
+	t.Setenv("POSTGRES_HOST", "")
 
 	url, err := GetDatabaseConfig()
 	if err != nil {
@@ -124,12 +108,11 @@ func TestGetDatabaseConfig_MissingRequired(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Unsetenv("POSTGRES_URL")
+			t.Setenv("POSTGRES_URL", "")
 
 			// Set provided vars
 			for k, v := range tt.envVars {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
+				t.Setenv(k, v)
 			}
 
 			_, err := GetDatabaseConfig()

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -58,6 +59,35 @@ func TestGetDatabaseConfig_ComponentDefaults(t *testing.T) {
 	expected := "postgresql://user:pass@postgres:5432/db?sslmode=disable" //nolint:gosec // test fixture value, not a real credential
 	if url != expected {
 		t.Errorf("got %q, want %q", url, expected)
+	}
+}
+
+func TestGetDatabaseConfig_EscapesCredentials(t *testing.T) {
+	t.Setenv("POSTGRES_URL", "")
+
+	const specialPassword = "p@ss:w/o?r#d&1" //nolint:gosec // test fixture value, not a real credential
+
+	t.Setenv("POSTGRES_HOST", "postgres")
+	t.Setenv("POSTGRES_USERNAME", "tempest")
+	t.Setenv("POSTGRES_PASSWORD", specialPassword)
+	t.Setenv("POSTGRES_NAME", "weather")
+
+	dsn, err := GetDatabaseConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("DSN %q did not round-trip through url.Parse: %v", dsn, err)
+	}
+
+	got, ok := parsed.User.Password()
+	if !ok {
+		t.Fatalf("DSN %q has no password component", dsn)
+	}
+	if got != specialPassword {
+		t.Errorf("password round-trip mismatch: got %q, want %q", got, specialPassword)
 	}
 }
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// ParseBoolEnv reads the named environment variable and parses it as a
+// boolean using strconv.ParseBool. An unset or empty variable is treated as
+// false with no error. A value that strconv.ParseBool cannot parse (e.g. a
+// typo like "ture") is a fatal configuration error rather than a silently
+// disabled feature: the returned error names both the variable and the
+// offending value.
+func ParseBoolEnv(key string) (bool, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return false, nil
+	}
+
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean value %q for %s: %w", v, key, err)
+	}
+	return b, nil
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBoolEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		unset   bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset key", key: "PARSE_BOOL_ENV_TEST_UNSET", unset: true, want: false, wantErr: false},
+		{name: "true", key: "PARSE_BOOL_ENV_TEST_TRUE", value: "true", want: true, wantErr: false},
+		{name: "1", key: "PARSE_BOOL_ENV_TEST_ONE", value: "1", want: true, wantErr: false},
+		{name: "yes is invalid", key: "PARSE_BOOL_ENV_TEST_YES", value: "yes", want: false, wantErr: true},
+		{name: "nonsense is invalid", key: "PARSE_BOOL_ENV_TEST_NONSENSE", value: "nonsense", want: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.unset {
+				t.Setenv(tt.key, tt.value)
+			}
+
+			got, err := ParseBoolEnv(tt.key)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseBoolEnv(%q) = %v, nil; want error", tt.key, got)
+				}
+				if !strings.Contains(err.Error(), tt.key) {
+					t.Errorf("ParseBoolEnv(%q) error %q does not name the key", tt.key, err.Error())
+				}
+				if !strings.Contains(err.Error(), tt.value) {
+					t.Errorf("ParseBoolEnv(%q) error %q does not name the offending value %q", tt.key, err.Error(), tt.value)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseBoolEnv(%q) unexpected error: %v", tt.key, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseBoolEnv(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/postgres/tunables.go
+++ b/internal/postgres/tunables.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"strconv"
+	"time"
+)
+
+// tunables holds the batching/retry knobs documented in CLAUDE.md
+// (POSTGRES_BATCH_SIZE, POSTGRES_FLUSH_INTERVAL, POSTGRES_MAX_RETRIES) so
+// NewPostgresWriter can wire them from the environment instead of the
+// previously-hardcoded, inert defaults (C-H2).
+type tunables struct {
+	batchSize     int
+	flushInterval time.Duration
+	maxRetries    int
+}
+
+// postgresTunables is a pure helper (testable without a live DB): getenv is
+// injected so tests can supply a fake instead of the real os.Getenv. Each
+// value falls back to its default when unset, unparseable, or non-positive.
+func postgresTunables(getenv func(string) string) tunables {
+	atoiOr := func(s string, def int) int {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return n
+		}
+		return def
+	}
+	durOr := func(s string, def time.Duration) time.Duration {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+		return def
+	}
+	return tunables{
+		batchSize:     atoiOr(getenv("POSTGRES_BATCH_SIZE"), 100),
+		flushInterval: durOr(getenv("POSTGRES_FLUSH_INTERVAL"), 10*time.Second),
+		maxRetries:    atoiOr(getenv("POSTGRES_MAX_RETRIES"), 3),
+	}
+}

--- a/internal/postgres/tunables_test.go
+++ b/internal/postgres/tunables_test.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPostgresTunables(t *testing.T) {
+	getenv := func(k string) string {
+		return map[string]string{
+			"POSTGRES_BATCH_SIZE":     "7",
+			"POSTGRES_FLUSH_INTERVAL": "2s",
+			"POSTGRES_MAX_RETRIES":    "5",
+		}[k]
+	}
+	tn := postgresTunables(getenv)
+	if tn.batchSize != 7 || tn.flushInterval != 2*time.Second || tn.maxRetries != 5 {
+		t.Fatalf("tunables not applied: %+v", tn)
+	}
+	// defaults when unset:
+	def := postgresTunables(func(string) string { return "" })
+	if def.batchSize != 100 || def.flushInterval != 10*time.Second || def.maxRetries != 3 {
+		t.Fatalf("defaults wrong: %+v", def)
+	}
+	// non-positive/unparseable values fall back to defaults (the n > 0 / d > 0 guard):
+	badEnv := func(k string) string {
+		return map[string]string{
+			"POSTGRES_BATCH_SIZE":     "0",
+			"POSTGRES_FLUSH_INTERVAL": "abc",
+			"POSTGRES_MAX_RETRIES":    "-1",
+		}[k]
+	}
+	badTn := postgresTunables(badEnv)
+	if badTn.batchSize != 100 || badTn.flushInterval != 10*time.Second || badTn.maxRetries != 3 {
+		t.Fatalf("non-positive/unparseable values should fall back to defaults: %+v", badTn)
+	}
+}

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -165,6 +165,15 @@ func (w *PostgresWriter) batchObservations() {
 	}
 }
 
+// closeBatchResults closes a pgx batch result set, logging any error.
+// A close error here is not actionable by the caller (per-statement errors
+// are already surfaced by br.Exec()), so it is logged rather than returned.
+func closeBatchResults(br pgx.BatchResults) {
+	if err := br.Close(); err != nil {
+		log.Printf("postgres: batch close error: %v", err)
+	}
+}
+
 func (w *PostgresWriter) flushObservations(batch []observationRow) {
 	w.flushWithRetry(func() error {
 		return w.insertObservations(batch)
@@ -201,7 +210,7 @@ func (w *PostgresWriter) insertObservations(batch []observationRow) error {
 	}
 
 	br := w.pool.SendBatch(ctx, b)
-	defer br.Close()
+	defer closeBatchResults(br)
 
 	for i := 0; i < len(batch); i++ {
 		_, err := br.Exec()
@@ -282,7 +291,7 @@ func (w *PostgresWriter) insertRapidWind(batch []rapidWindRow) error {
 	}
 
 	br := w.pool.SendBatch(ctx, b)
-	defer br.Close()
+	defer closeBatchResults(br)
 
 	for i := 0; i < len(batch); i++ {
 		_, err := br.Exec()
@@ -358,7 +367,7 @@ func (w *PostgresWriter) insertHubStatus(batch []hubStatusRow) error {
 	}
 
 	br := w.pool.SendBatch(ctx, b)
-	defer br.Close()
+	defer closeBatchResults(br)
 
 	for i := 0; i < len(batch); i++ {
 		_, err := br.Exec()
@@ -414,7 +423,7 @@ func (w *PostgresWriter) insertEvents(batch []eventRow) error {
 	}
 
 	br := w.pool.SendBatch(ctx, b)
-	defer br.Close()
+	defer closeBatchResults(br)
 
 	for i := 0; i < len(batch); i++ {
 		_, err := br.Exec()

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -101,6 +101,14 @@ type PostgresWriter struct {
 
 	ctx context.Context
 	wg  sync.WaitGroup
+
+	// done is the sole shutdown signal: closing it tells every producer
+	// send and every batch worker that Close is in progress. The batch
+	// channels themselves are never closed (see Close), which is what
+	// keeps a concurrent producer send from ever panicking on a
+	// send-on-closed-channel (D-H1).
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewPostgresWriter creates a new PostgreSQL writer with connection pooling.
@@ -147,6 +155,7 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 		flushInterval: 10 * time.Second,
 		maxRetries:    3,
 		ctx:           ctx,
+		done:          make(chan struct{}),
 	}
 	w.obsInserter = w
 
@@ -166,12 +175,12 @@ func (w *PostgresWriter) batchObservations() {
 
 	for {
 		select {
-		case row, ok := <-w.obsBatch:
-			if !ok {
-				return // Channel closed
-			}
+		case row := <-w.obsBatch:
 			// Immediate flush for observations
 			w.flushObservations(w.ctx, []observationRow{row})
+
+		case <-w.done:
+			return
 
 		case <-w.ctx.Done():
 			return
@@ -245,15 +254,7 @@ func (w *PostgresWriter) batchRapidWind() {
 
 	for {
 		select {
-		case row, ok := <-w.windBatch:
-			if !ok {
-				// Channel closed - flush remaining
-				if len(batch) > 0 {
-					w.flushRapidWind(w.ctx, batch)
-				}
-				return
-			}
-
+		case row := <-w.windBatch:
 			batch = append(batch, row)
 
 			// Flush when batch is full
@@ -268,6 +269,14 @@ func (w *PostgresWriter) batchRapidWind() {
 				w.flushRapidWind(w.ctx, batch)
 				batch = batch[:0]
 			}
+
+		case <-w.done:
+			// Shutdown - flush the local in-flight batch; whatever is still
+			// sitting in the channel is drained by Close after wg.Wait().
+			if len(batch) > 0 {
+				w.flushRapidWind(w.ctx, batch)
+			}
+			return
 
 		case <-w.ctx.Done():
 			// Shutdown - flush remaining
@@ -326,14 +335,7 @@ func (w *PostgresWriter) batchHubStatus() {
 
 	for {
 		select {
-		case row, ok := <-w.hubBatch:
-			if !ok {
-				if len(batch) > 0 {
-					w.flushHubStatus(w.ctx, batch)
-				}
-				return
-			}
-
+		case row := <-w.hubBatch:
 			batch = append(batch, row)
 			if len(batch) >= w.batchSize {
 				w.flushHubStatus(w.ctx, batch)
@@ -345,6 +347,12 @@ func (w *PostgresWriter) batchHubStatus() {
 				w.flushHubStatus(w.ctx, batch)
 				batch = batch[:0]
 			}
+
+		case <-w.done:
+			if len(batch) > 0 {
+				w.flushHubStatus(w.ctx, batch)
+			}
+			return
 
 		case <-w.ctx.Done():
 			if len(batch) > 0 {
@@ -398,12 +406,12 @@ func (w *PostgresWriter) batchEvents() {
 
 	for {
 		select {
-		case row, ok := <-w.eventBatch:
-			if !ok {
-				return
-			}
+		case row := <-w.eventBatch:
 			// Immediate flush for events (critical)
 			w.flushEvents(w.ctx, []eventRow{row})
+
+		case <-w.done:
+			return
 
 		case <-w.ctx.Done():
 			return
@@ -534,13 +542,12 @@ func (w *PostgresWriter) handleObservationReport(ctx context.Context, r *tempest
 			row.reportInterval = &interval
 		}
 
-		// Send to batch channel (non-blocking)
 		select {
 		case w.obsBatch <- row:
+		case <-w.done: // Close in progress — stop producing, no send-on-closed
+			return nil
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			log.Printf("postgres: observation batch channel full, dropping")
 		}
 	}
 
@@ -562,13 +569,12 @@ func (w *PostgresWriter) handleRapidWindReport(ctx context.Context, r *tempestud
 		windDirection: r.Ob[2],
 	}
 
-	// Send to batch channel (non-blocking)
 	select {
 	case w.windBatch <- row:
+	case <-w.done: // Close in progress — stop producing, no send-on-closed
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		log.Printf("postgres: rapid_wind batch channel full, dropping")
 	}
 
 	return nil
@@ -591,13 +597,12 @@ func (w *PostgresWriter) handleHubStatusReport(ctx context.Context, r *tempestud
 		busErrors:    r.RadioStats[2],
 	}
 
-	// Send to batch channel (non-blocking)
 	select {
 	case w.hubBatch <- row:
+	case <-w.done: // Close in progress — stop producing, no send-on-closed
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		log.Printf("postgres: hub_status batch channel full, dropping")
 	}
 
 	return nil
@@ -619,13 +624,12 @@ func (w *PostgresWriter) handleRainStartReport(ctx context.Context, r *tempestud
 		energy:       nil, // Not applicable for rain
 	}
 
-	// Send to batch channel (non-blocking)
 	select {
 	case w.eventBatch <- row:
+	case <-w.done: // Close in progress — stop producing, no send-on-closed
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		log.Printf("postgres: event batch channel full, dropping")
 	}
 
 	return nil
@@ -649,13 +653,12 @@ func (w *PostgresWriter) handleLightningStrikeReport(ctx context.Context, r *tem
 		energy:       &energy,
 	}
 
-	// Send to batch channel (non-blocking)
 	select {
 	case w.eventBatch <- row:
+	case <-w.done: // Close in progress — stop producing, no send-on-closed
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		log.Printf("postgres: event batch channel full, dropping")
 	}
 
 	return nil
@@ -774,10 +777,10 @@ func (w *PostgresWriter) WriteMetrics(ctx context.Context, metrics []prometheus.
 	for _, obs := range observations {
 		select {
 		case w.obsBatch <- *obs:
+		case <-w.done: // Close in progress — stop producing, no send-on-closed
+			return nil
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			log.Printf("postgres: observation batch channel full during WriteMetrics, dropping")
 		}
 	}
 
@@ -786,8 +789,8 @@ func (w *PostgresWriter) WriteMetrics(ctx context.Context, metrics []prometheus.
 
 // Flush implements MetricsWriter interface
 func (w *PostgresWriter) Flush(ctx context.Context) error {
-	// Flush is handled by the batch workers
-	// When Close() is called, channels are closed and workers flush remaining data
+	// Flush is handled by the batch workers.
+	// When Close() is called, done is closed and workers flush remaining data.
 	return nil
 }
 
@@ -874,58 +877,70 @@ func isRetryable(err error) bool {
 	return true
 }
 
-// Close implements MetricsWriter interface. Idempotent-close (safe to call
-// more than once, no send-on-closed-channel panic from a concurrent write)
-// is out of scope here — see Task 0.9a.
+// Close implements MetricsWriter interface. Idempotent — safe to call more
+// than once (C-H3) — and never closes a batch channel, so a concurrent
+// producer send can never panic on a send-on-closed-channel (D-H1). done is
+// the sole shutdown signal (see the PostgresWriter.done field comment).
 func (w *PostgresWriter) Close(ctx context.Context) error {
-	// Close channels to stop workers. Closing a channel does not discard
-	// buffered values, but each worker's select races <-w.ctx.Done() against
-	// the channel receive — if w.ctx is already canceled (the normal
-	// shutdown sequence: SIGTERM cancels the shared context the writer was
-	// built with before Close(cleanupCtx) runs with its own context), a
-	// worker can exit via ctx.Done() while rows are still buffered.
-	close(w.obsBatch)
-	close(w.windBatch)
-	close(w.hubBatch)
-	close(w.eventBatch)
+	w.closeOnce.Do(func() {
+		// Signal producers and workers. Each worker's select also still
+		// races <-w.ctx.Done() against the channel receive — if w.ctx is
+		// already canceled (the normal shutdown sequence: SIGTERM cancels
+		// the shared context the writer was built with before
+		// Close(cleanupCtx) runs with its own context), a worker can exit
+		// via ctx.Done() while rows are still buffered.
+		close(w.done)
 
-	// Wait for workers to finish; any worker that exited early left its
-	// remaining buffered rows unread.
-	w.wg.Wait()
+		// Wait for workers to finish; any worker that exited early left its
+		// remaining buffered rows unread.
+		w.wg.Wait()
 
-	// Drain and flush whatever is still buffered, using the passed-in ctx
-	// (not the writer's own, already-canceled ctx) so the insert has a live
-	// deadline to work with (C-H1).
-	if batch := drainChannel(w.obsBatch); len(batch) > 0 {
-		w.flushObservations(ctx, batch)
-	}
-	if batch := drainChannel(w.windBatch); len(batch) > 0 {
-		w.flushRapidWind(ctx, batch)
-	}
-	if batch := drainChannel(w.hubBatch); len(batch) > 0 {
-		w.flushHubStatus(ctx, batch)
-	}
-	if batch := drainChannel(w.eventBatch); len(batch) > 0 {
-		w.flushEvents(ctx, batch)
-	}
+		// Drain and flush whatever is still buffered, using the passed-in
+		// ctx (not the writer's own, already-canceled ctx) so the insert
+		// has a live deadline to work with (C-H1). The batch channels are
+		// never closed, so this drain must be non-blocking (see
+		// drainChannel) rather than a `range` over the channel.
+		if batch := drainChannel(w.obsBatch); len(batch) > 0 {
+			w.flushObservations(ctx, batch)
+		}
+		if batch := drainChannel(w.windBatch); len(batch) > 0 {
+			w.flushRapidWind(ctx, batch)
+		}
+		if batch := drainChannel(w.hubBatch); len(batch) > 0 {
+			w.flushHubStatus(ctx, batch)
+		}
+		if batch := drainChannel(w.eventBatch); len(batch) > 0 {
+			w.flushEvents(ctx, batch)
+		}
 
-	// Close connection pool. Guarded against nil so tests can exercise Close
-	// on a writer constructed without a live pool (see writer_test.go).
-	if w.pool != nil {
-		w.pool.Close()
-	}
-	log.Printf("postgres: closed")
+		// Close connection pool. Guarded against nil so tests can exercise
+		// Close on a writer constructed without a live pool (see
+		// writer_test.go).
+		if w.pool != nil {
+			w.pool.Close()
+		}
+		log.Printf("postgres: closed")
+	})
 
 	return nil
 }
 
-// drainChannel receives every value still buffered in a closed channel.
-// Callers must guarantee no other goroutine is still receiving from ch (in
-// Close, w.wg.Wait() has already ensured every batch worker has returned).
+// drainChannel receives every value currently buffered in ch without
+// blocking. The batch channels are never closed (Close signals shutdown via
+// done, not by closing them — see D-H1), so a `range` over ch would block
+// forever once it's empty; the non-blocking select below stops as soon as
+// nothing more is immediately available. Callers must guarantee no other
+// goroutine is still receiving from ch (in Close, w.wg.Wait() has already
+// ensured every batch worker has returned) so that a single non-blocking
+// pass is sufficient to catch everything buffered.
 func drainChannel[T any](ch <-chan T) []T {
 	var batch []T
-	for v := range ch {
-		batch = append(batch, v)
+	for {
+		select {
+		case v := <-ch:
+			batch = append(batch, v)
+		default:
+			return batch
+		}
 	}
-	return batch
 }

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -860,8 +860,10 @@ func isRetryable(err error) bool {
 	return true
 }
 
-// Close implements MetricsWriter interface
-func (w *PostgresWriter) Close() error {
+// Close implements MetricsWriter interface. The channel-drain/pool-teardown
+// sequence below is unchanged for this task — see Task 0.8/0.9a for the
+// drain rework and idempotency gate.
+func (w *PostgresWriter) Close(ctx context.Context) error {
 	// Close channels to stop workers
 	close(w.obsBatch)
 	close(w.windBatch)

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -71,6 +71,15 @@ type eventRow struct {
 	energy       *float64
 }
 
+// obsInserter abstracts the observation batch-insert path so the
+// Close(ctx)-time drain (TestPostgresWriter_DrainOnClose) can be exercised
+// with a fake in place of a live database connection. Scoped to observations
+// only: it is the row type the drain test needs to assert on, and no second
+// present consumer exists yet for the other three tables.
+type obsInserter interface {
+	insertObservations(ctx context.Context, batch []observationRow) error
+}
+
 // PostgresWriter writes metrics to PostgreSQL with batching and retry logic.
 type PostgresWriter struct {
 	pool *pgxpool.Pool
@@ -85,6 +94,10 @@ type PostgresWriter struct {
 	batchSize     int
 	flushInterval time.Duration
 	maxRetries    int
+
+	// obsInserter defaults to the writer itself (see NewPostgresWriter);
+	// tests may substitute a fake.
+	obsInserter obsInserter
 
 	ctx context.Context
 	wg  sync.WaitGroup
@@ -135,6 +148,7 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 		maxRetries:    3,
 		ctx:           ctx,
 	}
+	w.obsInserter = w
 
 	// Start background batch workers
 	w.wg.Add(4)
@@ -157,7 +171,7 @@ func (w *PostgresWriter) batchObservations() {
 				return // Channel closed
 			}
 			// Immediate flush for observations
-			w.flushObservations([]observationRow{row})
+			w.flushObservations(w.ctx, []observationRow{row})
 
 		case <-w.ctx.Done():
 			return
@@ -174,18 +188,18 @@ func closeBatchResults(br pgx.BatchResults) {
 	}
 }
 
-func (w *PostgresWriter) flushObservations(batch []observationRow) {
+func (w *PostgresWriter) flushObservations(ctx context.Context, batch []observationRow) {
 	w.flushWithRetry(func() error {
-		return w.insertObservations(batch)
+		return w.obsInserter.insertObservations(ctx, batch)
 	}, "tempest_observations", len(batch))
 }
 
-func (w *PostgresWriter) insertObservations(batch []observationRow) error {
+func (w *PostgresWriter) insertObservations(ctx context.Context, batch []observationRow) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	b := &pgx.Batch{}
@@ -235,7 +249,7 @@ func (w *PostgresWriter) batchRapidWind() {
 			if !ok {
 				// Channel closed - flush remaining
 				if len(batch) > 0 {
-					w.flushRapidWind(batch)
+					w.flushRapidWind(w.ctx, batch)
 				}
 				return
 			}
@@ -244,39 +258,39 @@ func (w *PostgresWriter) batchRapidWind() {
 
 			// Flush when batch is full
 			if len(batch) >= w.batchSize {
-				w.flushRapidWind(batch)
+				w.flushRapidWind(w.ctx, batch)
 				batch = batch[:0]
 			}
 
 		case <-ticker.C:
 			// Periodic flush
 			if len(batch) > 0 {
-				w.flushRapidWind(batch)
+				w.flushRapidWind(w.ctx, batch)
 				batch = batch[:0]
 			}
 
 		case <-w.ctx.Done():
 			// Shutdown - flush remaining
 			if len(batch) > 0 {
-				w.flushRapidWind(batch)
+				w.flushRapidWind(w.ctx, batch)
 			}
 			return
 		}
 	}
 }
 
-func (w *PostgresWriter) flushRapidWind(batch []rapidWindRow) {
+func (w *PostgresWriter) flushRapidWind(ctx context.Context, batch []rapidWindRow) {
 	w.flushWithRetry(func() error {
-		return w.insertRapidWind(batch)
+		return w.insertRapidWind(ctx, batch)
 	}, "tempest_rapid_wind", len(batch))
 }
 
-func (w *PostgresWriter) insertRapidWind(batch []rapidWindRow) error {
+func (w *PostgresWriter) insertRapidWind(ctx context.Context, batch []rapidWindRow) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	b := &pgx.Batch{}
@@ -315,44 +329,44 @@ func (w *PostgresWriter) batchHubStatus() {
 		case row, ok := <-w.hubBatch:
 			if !ok {
 				if len(batch) > 0 {
-					w.flushHubStatus(batch)
+					w.flushHubStatus(w.ctx, batch)
 				}
 				return
 			}
 
 			batch = append(batch, row)
 			if len(batch) >= w.batchSize {
-				w.flushHubStatus(batch)
+				w.flushHubStatus(w.ctx, batch)
 				batch = batch[:0]
 			}
 
 		case <-ticker.C:
 			if len(batch) > 0 {
-				w.flushHubStatus(batch)
+				w.flushHubStatus(w.ctx, batch)
 				batch = batch[:0]
 			}
 
 		case <-w.ctx.Done():
 			if len(batch) > 0 {
-				w.flushHubStatus(batch)
+				w.flushHubStatus(w.ctx, batch)
 			}
 			return
 		}
 	}
 }
 
-func (w *PostgresWriter) flushHubStatus(batch []hubStatusRow) {
+func (w *PostgresWriter) flushHubStatus(ctx context.Context, batch []hubStatusRow) {
 	w.flushWithRetry(func() error {
-		return w.insertHubStatus(batch)
+		return w.insertHubStatus(ctx, batch)
 	}, "tempest_hub_status", len(batch))
 }
 
-func (w *PostgresWriter) insertHubStatus(batch []hubStatusRow) error {
+func (w *PostgresWriter) insertHubStatus(ctx context.Context, batch []hubStatusRow) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	b := &pgx.Batch{}
@@ -389,7 +403,7 @@ func (w *PostgresWriter) batchEvents() {
 				return
 			}
 			// Immediate flush for events (critical)
-			w.flushEvents([]eventRow{row})
+			w.flushEvents(w.ctx, []eventRow{row})
 
 		case <-w.ctx.Done():
 			return
@@ -397,18 +411,18 @@ func (w *PostgresWriter) batchEvents() {
 	}
 }
 
-func (w *PostgresWriter) flushEvents(batch []eventRow) {
+func (w *PostgresWriter) flushEvents(ctx context.Context, batch []eventRow) {
 	w.flushWithRetry(func() error {
-		return w.insertEvents(batch)
+		return w.insertEvents(ctx, batch)
 	}, "tempest_events", len(batch))
 }
 
-func (w *PostgresWriter) insertEvents(batch []eventRow) error {
+func (w *PostgresWriter) insertEvents(ctx context.Context, batch []eventRow) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	b := &pgx.Batch{}
@@ -860,22 +874,58 @@ func isRetryable(err error) bool {
 	return true
 }
 
-// Close implements MetricsWriter interface. The channel-drain/pool-teardown
-// sequence below is unchanged for this task — see Task 0.8/0.9a for the
-// drain rework and idempotency gate.
+// Close implements MetricsWriter interface. Idempotent-close (safe to call
+// more than once, no send-on-closed-channel panic from a concurrent write)
+// is out of scope here — see Task 0.9a.
 func (w *PostgresWriter) Close(ctx context.Context) error {
-	// Close channels to stop workers
+	// Close channels to stop workers. Closing a channel does not discard
+	// buffered values, but each worker's select races <-w.ctx.Done() against
+	// the channel receive — if w.ctx is already canceled (the normal
+	// shutdown sequence: SIGTERM cancels the shared context the writer was
+	// built with before Close(cleanupCtx) runs with its own context), a
+	// worker can exit via ctx.Done() while rows are still buffered.
 	close(w.obsBatch)
 	close(w.windBatch)
 	close(w.hubBatch)
 	close(w.eventBatch)
 
-	// Wait for workers to finish
+	// Wait for workers to finish; any worker that exited early left its
+	// remaining buffered rows unread.
 	w.wg.Wait()
 
-	// Close connection pool
-	w.pool.Close()
+	// Drain and flush whatever is still buffered, using the passed-in ctx
+	// (not the writer's own, already-canceled ctx) so the insert has a live
+	// deadline to work with (C-H1).
+	if batch := drainChannel(w.obsBatch); len(batch) > 0 {
+		w.flushObservations(ctx, batch)
+	}
+	if batch := drainChannel(w.windBatch); len(batch) > 0 {
+		w.flushRapidWind(ctx, batch)
+	}
+	if batch := drainChannel(w.hubBatch); len(batch) > 0 {
+		w.flushHubStatus(ctx, batch)
+	}
+	if batch := drainChannel(w.eventBatch); len(batch) > 0 {
+		w.flushEvents(ctx, batch)
+	}
+
+	// Close connection pool. Guarded against nil so tests can exercise Close
+	// on a writer constructed without a live pool (see writer_test.go).
+	if w.pool != nil {
+		w.pool.Close()
+	}
 	log.Printf("postgres: closed")
 
 	return nil
+}
+
+// drainChannel receives every value still buffered in a closed channel.
+// Callers must guarantee no other goroutine is still receiving from ch (in
+// Close, w.wg.Wait() has already ensured every batch worker has returned).
+func drainChannel[T any](ch <-chan T) []T {
+	var batch []T
+	for v := range ch {
+		batch = append(batch, v)
+	}
+	return batch
 }

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -32,7 +33,7 @@ type observationRow struct {
 	windSampleInterval   *float64
 	pressure             float64
 	tempAir              float64
-	tempWetbulb          float64
+	tempWetbulb          *float64 // nil (SQL NULL) when WetBulbTemperatureC is non-convergent (NaN)
 	humidity             float64
 	illuminance          float64
 	uvIndex              float64
@@ -81,6 +82,17 @@ type obsInserter interface {
 	insertObservations(ctx context.Context, batch []observationRow) error
 }
 
+// windInserter abstracts the rapid-wind batch-insert path, mirroring
+// obsInserter exactly. Needed so
+// TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx can assert on
+// batchRapidWind's local-accumulator shutdown flush without a live database
+// connection: unlike observations/events, rapidWind (and hubStatus) hold rows
+// in a local slice across select iterations, which is the exact codepath the
+// C-H1 shutdown-drain bug lives in.
+type windInserter interface {
+	insertRapidWind(ctx context.Context, batch []rapidWindRow) error
+}
+
 // PostgresWriter writes metrics to PostgreSQL with batching and retry logic.
 type PostgresWriter struct {
 	pool *pgxpool.Pool
@@ -100,6 +112,10 @@ type PostgresWriter struct {
 	// tests may substitute a fake.
 	obsInserter obsInserter
 
+	// windInserter defaults to the writer itself (see NewPostgresWriter);
+	// tests may substitute a fake.
+	windInserter windInserter
+
 	ctx context.Context
 	wg  sync.WaitGroup
 
@@ -110,6 +126,18 @@ type PostgresWriter struct {
 	// send-on-closed-channel (D-H1).
 	done      chan struct{}
 	closeOnce sync.Once
+
+	// shutdownCtx is the live ctx a batch worker must use to flush its local
+	// in-flight batch on shutdown — never w.ctx, which SIGTERM cancels
+	// before Close ever runs in production (that was the C-H1 residual bug:
+	// flushing with an already-canceled ctx made the flush fail as
+	// non-retryable, silently dropping the batch). Close sets shutdownCtx
+	// *before* close(w.done); a worker only ever reads shutdownCtx after its
+	// own `<-w.done` case fires, and the Go memory model guarantees a send
+	// happens-before the corresponding receive on a closed channel — so this
+	// plain field write is safely visible to every worker goroutine without
+	// a mutex or atomic.
+	shutdownCtx context.Context
 }
 
 // NewPostgresWriter creates a new PostgreSQL writer with connection pooling.
@@ -161,6 +189,7 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 		done:          make(chan struct{}),
 	}
 	w.obsInserter = w
+	w.windInserter = w
 
 	// Start background batch workers
 	w.wg.Add(4)
@@ -183,9 +212,6 @@ func (w *PostgresWriter) batchObservations() {
 			w.flushObservations(w.ctx, []observationRow{row})
 
 		case <-w.done:
-			return
-
-		case <-w.ctx.Done():
 			return
 		}
 	}
@@ -274,17 +300,13 @@ func (w *PostgresWriter) batchRapidWind() {
 			}
 
 		case <-w.done:
-			// Shutdown - flush the local in-flight batch; whatever is still
-			// sitting in the channel is drained by Close after wg.Wait().
+			// Shutdown - flush the local in-flight batch using the live
+			// shutdownCtx (not w.ctx, which SIGTERM may have already
+			// canceled — see the shutdownCtx field comment and C-H1).
+			// Whatever is still sitting in the channel is drained by Close
+			// after wg.Wait().
 			if len(batch) > 0 {
-				w.flushRapidWind(w.ctx, batch)
-			}
-			return
-
-		case <-w.ctx.Done():
-			// Shutdown - flush remaining
-			if len(batch) > 0 {
-				w.flushRapidWind(w.ctx, batch)
+				w.flushRapidWind(w.shutdownCtx, batch)
 			}
 			return
 		}
@@ -293,7 +315,7 @@ func (w *PostgresWriter) batchRapidWind() {
 
 func (w *PostgresWriter) flushRapidWind(ctx context.Context, batch []rapidWindRow) {
 	w.flushWithRetry(func() error {
-		return w.insertRapidWind(ctx, batch)
+		return w.windInserter.insertRapidWind(ctx, batch)
 	}, "tempest_rapid_wind", len(batch))
 }
 
@@ -352,14 +374,11 @@ func (w *PostgresWriter) batchHubStatus() {
 			}
 
 		case <-w.done:
+			// Shutdown - flush the local in-flight batch using the live
+			// shutdownCtx (not w.ctx, which SIGTERM may have already
+			// canceled — see the shutdownCtx field comment and C-H1).
 			if len(batch) > 0 {
-				w.flushHubStatus(w.ctx, batch)
-			}
-			return
-
-		case <-w.ctx.Done():
-			if len(batch) > 0 {
-				w.flushHubStatus(w.ctx, batch)
+				w.flushHubStatus(w.shutdownCtx, batch)
 			}
 			return
 		}
@@ -414,9 +433,6 @@ func (w *PostgresWriter) batchEvents() {
 			w.flushEvents(w.ctx, []eventRow{row})
 
 		case <-w.done:
-			return
-
-		case <-w.ctx.Done():
 			return
 		}
 	}
@@ -505,12 +521,19 @@ func (w *PostgresWriter) handleObservationReport(ctx context.Context, r *tempest
 			windDirection: ob[4],
 			pressure:      ob[6], // Raw mb value (no conversion)
 			tempAir:       ob[7],
-			tempWetbulb:   wetBulb,
 			humidity:      ob[8],
 			illuminance:   ob[9],
 			uvIndex:       ob[10],
 			irradiance:    ob[11],
 			rainRate:      ob[12],
+		}
+
+		// WetBulbTemperatureC returns NaN for non-convergent inputs (e.g.
+		// physically impossible humidity/pressure from a malformed report);
+		// store SQL NULL rather than IEEE NaN (mirrors the same guard in
+		// tempestudp/report.go's Prometheus metrics path).
+		if !math.IsNaN(wetBulb) {
+			row.tempWetbulb = &wetBulb
 		}
 
 		// Field 5: wind_sample_interval (seconds)
@@ -750,7 +773,7 @@ func (w *PostgresWriter) WriteMetrics(ctx context.Context, metrics []prometheus.
 					case "air":
 						obs.tempAir = value
 					case "wetbulb":
-						obs.tempWetbulb = value
+						obs.tempWetbulb = &value
 					}
 					break
 				}
@@ -886,12 +909,19 @@ func isRetryable(err error) bool {
 // the sole shutdown signal (see the PostgresWriter.done field comment).
 func (w *PostgresWriter) Close(ctx context.Context) error {
 	w.closeOnce.Do(func() {
-		// Signal producers and workers. Each worker's select also still
-		// races <-w.ctx.Done() against the channel receive — if w.ctx is
-		// already canceled (the normal shutdown sequence: SIGTERM cancels
-		// the shared context the writer was built with before
-		// Close(cleanupCtx) runs with its own context), a worker can exit
-		// via ctx.Done() while rows are still buffered.
+		// Set shutdownCtx before closing done: this write happens-before
+		// close(w.done), which happens-before any worker's `<-w.done` case
+		// firing (Go memory model), so every worker is guaranteed to see
+		// this live ctx once it starts its shutdown flush — see the
+		// shutdownCtx field comment.
+		w.shutdownCtx = ctx
+
+		// Signal producers and workers that Close is in progress. There is
+		// no longer a competing <-w.ctx.Done() case in the batch workers
+		// (removed as the C-H1 fix): w.ctx canceling on SIGTERM no longer
+		// races a worker into flushing its local batch with a dead ctx.
+		// <-w.done is the workers' sole shutdown signal, and it always
+		// carries a live ctx via shutdownCtx.
 		close(w.done)
 
 		// Wait for workers to finish; any worker that exited early left its

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -144,6 +145,8 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 
 	log.Printf("postgres: connected, schema ready")
 
+	tn := postgresTunables(os.Getenv)
+
 	// Initialize writer
 	w := &PostgresWriter{
 		pool:          pool,
@@ -151,9 +154,9 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 		windBatch:     make(chan rapidWindRow, 1000),
 		hubBatch:      make(chan hubStatusRow, 1000),
 		eventBatch:    make(chan eventRow, 1000),
-		batchSize:     100,
-		flushInterval: 10 * time.Second,
-		maxRetries:    3,
+		batchSize:     tn.batchSize,
+		flushInterval: tn.flushInterval,
+		maxRetries:    tn.maxRetries,
 		ctx:           ctx,
 		done:          make(chan struct{}),
 	}

--- a/internal/postgres/writer_integration_test.go
+++ b/internal/postgres/writer_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// requirePostgresURL returns the POSTGRES_URL used to reach a live database
+// for integration tests, skipping the test if it isn't set.
+func requirePostgresURL(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("POSTGRES_URL not set, skipping integration test")
+	}
+	return dsn
+}
+
+// TestPostgresWriter_DrainOnClose_Integration is the real-DB counterpart to
+// TestPostgresWriter_DrainOnClose: it exercises the actual connection pool
+// (not the fake obsInserter) to prove buffered observation rows are
+// persisted by Close(ctx) even when the writer's own ctx has already been
+// canceled, matching the real SIGTERM shutdown sequence (C-H1).
+//
+// Run with a live Postgres instance:
+//
+//	POSTGRES_URL=postgres://user:pass@localhost:5432/weather?sslmode=disable \
+//	  go test -tags integration ./internal/postgres/ -run DrainOnClose_Integration
+func TestPostgresWriter_DrainOnClose_Integration(t *testing.T) {
+	dsn := requirePostgresURL(t)
+
+	// A separate, cancelable context stands in for the shared context
+	// SIGTERM cancels in production; canceling it before Close mirrors the
+	// real shutdown ordering (signal fires -> shared ctx canceled -> Close
+	// runs with its own, still-live cleanup ctx).
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+	w, err := NewPostgresWriter(workerCtx, dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresWriter: %v", err)
+	}
+
+	serial := "INTEGRATION-DRAIN-" + uuid.Must(uuid.NewV7()).String()
+	const wantRows = 50
+	base := time.Now().Add(-time.Hour)
+	for i := range wantRows {
+		w.obsBatch <- observationRow{
+			id:           uuid.Must(uuid.NewV7()),
+			serialNumber: serial,
+			timestamp:    base.Add(time.Duration(i) * time.Second),
+		}
+	}
+
+	cancelWorkerCtx()
+
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelClose()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	verifyPool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect for verification: %v", err)
+	}
+	defer verifyPool.Close()
+
+	var got int
+	err = verifyPool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM tempest_observations WHERE serial_number = $1`, serial).Scan(&got)
+	if err != nil {
+		t.Fatalf("verify persisted count: %v", err)
+	}
+	if got != wantRows {
+		t.Fatalf("expected %d rows persisted by Close, got %d", wantRows, got)
+	}
+}

--- a/internal/postgres/writer_test.go
+++ b/internal/postgres/writer_test.go
@@ -101,6 +101,9 @@ func TestPostgresWriter_RouteObservation(t *testing.T) {
 		if row.windAvg != 2.0 {
 			t.Errorf("wrong wind avg: got %f", row.windAvg)
 		}
+		if row.tempWetbulb == nil {
+			t.Error("expected non-nil temp_wetbulb for a convergent observation")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for observation")
 	}
@@ -172,6 +175,142 @@ func TestPostgresWriter_DrainOnClose(t *testing.T) {
 
 	if got := fake.count(); got != wantRows {
 		t.Fatalf("expected %d rows drained via Close, got %d", wantRows, got)
+	}
+}
+
+// TestHandleObservationReport_NaNWetbulbYieldsNull proves a non-convergent
+// (physically impossible) observation stores SQL NULL for temp_wetbulb
+// rather than IEEE NaN. tempest_observations.temp_wetbulb is a nullable
+// DOUBLE PRECISION column; unlike internal/tempestudp/report.go's Prometheus
+// path (which skips emitting the wetbulb metric on NaN), the Postgres path
+// had no such guard before this fix.
+func TestHandleObservationReport_NaNWetbulbYieldsNull(t *testing.T) {
+	w := &PostgresWriter{
+		obsBatch: make(chan observationRow, 10),
+		done:     make(chan struct{}),
+	}
+
+	// temp=25, humidity=-500 (physically impossible), pressure=900 is the
+	// exact non-convergent input proven by
+	// tempestudp.TestWetBulb_NonConvergentReturnsNaN to make
+	// WetBulbTemperatureC return NaN.
+	report := &tempestudp.TempestObservationReport{
+		SerialNumber: "ST-NAN",
+		Obs: [][]float64{
+			{1234567890, 1.5, 2.0, 2.5, 180, 0, 900, 25, -500, 50000, 3, 500, 0.5},
+		},
+	}
+
+	if err := w.handleObservationReport(t.Context(), report); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case row := <-w.obsBatch:
+		if row.tempWetbulb != nil {
+			t.Errorf("expected NULL (nil) temp_wetbulb for a non-convergent observation, got %v", *row.tempWetbulb)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for observation")
+	}
+}
+
+// fakeWindInserter is a test double for the windInserter seam, letting
+// TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx assert on the
+// worker's local in-flight batch without a live Postgres connection.
+type fakeWindInserter struct {
+	mu   sync.Mutex
+	rows []rapidWindRow
+}
+
+// insertRapidWind mirrors the real insertRapidWind's ctx-sensitivity: a real
+// pgx insert against an already-canceled ctx fails immediately with
+// context.Canceled (a non-retryable error per isRetryable), which is exactly
+// how the shutdown-drain bug drops rows. A fake that ignored ctx entirely
+// would pass this test regardless of whether the shutdown flush used the
+// live or the canceled context, defeating the point of the test.
+func (f *fakeWindInserter) insertRapidWind(ctx context.Context, batch []rapidWindRow) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, batch...)
+	return nil
+}
+
+func (f *fakeWindInserter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+// TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx proves the
+// residual C-H1 shutdown-drain bug: batchRapidWind accumulates rows below
+// batchSize in a LOCAL slice (never flushed, never sitting in the channel for
+// drainChannel to find), and on shutdown must flush that local slice using
+// the live cleanup ctx passed to Close — not the writer's own w.ctx, which
+// SIGTERM cancels before Close ever runs in production. Mirrors the real
+// wiring: w.ctx is canceled up front, exactly like main.go's shared signal
+// context is canceled before the deferred sink.Close(cleanupCtx) executes.
+func TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx(t *testing.T) {
+	// w.ctx starts LIVE so the rows below land deterministically in
+	// batchRapidWind's local accumulator (no race against a ctx.Done() case
+	// that's already ready). It is only canceled afterward, mirroring the
+	// real SIGTERM sequence: the shared context is canceled first, then
+	// Close(cleanupCtx) runs with its own, separately-live context.
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+
+	fake := &fakeWindInserter{}
+	w := &PostgresWriter{
+		obsBatch:      make(chan observationRow, 10),
+		windBatch:     make(chan rapidWindRow, 10),
+		hubBatch:      make(chan hubStatusRow, 10),
+		eventBatch:    make(chan eventRow, 10),
+		batchSize:     100, // rows below this stay in the worker's local slice
+		flushInterval: time.Hour,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		done:          make(chan struct{}),
+		windInserter:  fake,
+	}
+
+	w.wg.Add(4)
+	go w.batchObservations()
+	go w.batchRapidWind()
+	go w.batchHubStatus()
+	go w.batchEvents()
+
+	const wantRows = 5
+	for i := 0; i < wantRows; i++ {
+		w.windBatch <- rapidWindRow{windSpeed: float64(i)}
+	}
+
+	// Wait for batchRapidWind to pull the rows off the channel into its local
+	// accumulator (below batchSize, so it does NOT flush them yet). w.ctx is
+	// still live here, so the worker has no competing shutdown case to race
+	// against — this drains deterministically.
+	deadline := time.After(time.Second)
+	for len(w.windBatch) != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for batchRapidWind to drain windBatch into its local accumulator")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// Now simulate SIGTERM: cancel the shared context the writer was
+	// constructed with, before Close runs with its own live cleanup ctx.
+	cancelWorkerCtx()
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := fake.count(); got != wantRows {
+		t.Fatalf("expected %d in-flight rows flushed via the live cleanup ctx, got %d (rows dropped because shutdown flush used the canceled w.ctx)", wantRows, got)
 	}
 }
 

--- a/internal/postgres/writer_test.go
+++ b/internal/postgres/writer_test.go
@@ -57,6 +57,7 @@ func TestPostgresWriter_RouteObservation(t *testing.T) {
 		hubBatch:   make(chan hubStatusRow, 10),
 		eventBatch: make(chan eventRow, 10),
 		ctx:        ctx,
+		done:       make(chan struct{}),
 	}
 
 	report := &tempestudp.TempestObservationReport{
@@ -148,6 +149,7 @@ func TestPostgresWriter_DrainOnClose(t *testing.T) {
 		flushInterval: time.Second,
 		maxRetries:    3,
 		ctx:           workerCtx,
+		done:          make(chan struct{}),
 		obsInserter:   fake,
 	}
 
@@ -171,4 +173,99 @@ func TestPostgresWriter_DrainOnClose(t *testing.T) {
 	if got := fake.count(); got != wantRows {
 		t.Fatalf("expected %d rows drained via Close, got %d", wantRows, got)
 	}
+}
+
+// TestPostgresClose_Idempotent proves Close(ctx) can be called more than
+// once without panicking (C-H3: the old implementation unconditionally
+// closed the four batch channels on every call, so a second Close double-
+// closed them).
+func TestPostgresClose_Idempotent(t *testing.T) {
+	w := &PostgresWriter{
+		obsBatch:   make(chan observationRow, 10),
+		windBatch:  make(chan rapidWindRow, 10),
+		hubBatch:   make(chan hubStatusRow, 10),
+		eventBatch: make(chan eventRow, 10),
+		ctx:        t.Context(),
+		done:       make(chan struct{}),
+	}
+
+	ctx := t.Context()
+	if err := w.Close(ctx); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := w.Close(ctx); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestPostgresWriteDuringClose_NoPanic proves WriteReport (which sends into
+// the batch channels) can run concurrently with Close without a
+// send-on-closed-channel panic (D-H1), and that Close still returns
+// promptly rather than deadlocking on a drain of a never-closed channel.
+func TestPostgresWriteDuringClose_NoPanic(t *testing.T) {
+	workerCtx, cancelWorkerCtx := context.WithCancel(t.Context())
+	defer cancelWorkerCtx()
+
+	w := &PostgresWriter{
+		obsBatch:      make(chan observationRow, 10),
+		windBatch:     make(chan rapidWindRow, 10),
+		hubBatch:      make(chan hubStatusRow, 10),
+		eventBatch:    make(chan eventRow, 10),
+		batchSize:     100,
+		flushInterval: time.Second,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		done:          make(chan struct{}),
+		obsInserter:   &fakeObsInserter{},
+	}
+
+	w.wg.Add(4)
+	go w.batchObservations()
+	go w.batchRapidWind()
+	go w.batchHubStatus()
+	go w.batchEvents()
+
+	report := &tempestudp.TempestObservationReport{
+		SerialNumber: "ST-RACE",
+		Obs: [][]float64{
+			{1234567890, 1, 1, 1, 1, 1, 1013.25, 20, 75, 50000, 3, 500, 0.5, 0, 0, 0, 3.5, 1},
+		},
+	}
+
+	stop := make(chan struct{})
+	var producers sync.WaitGroup
+	for range 5 {
+		producers.Add(1)
+		go func() {
+			defer producers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = w.WriteReport(t.Context(), report)
+				}
+			}
+		}()
+	}
+
+	closeCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	closeErr := make(chan error, 1)
+	go func() {
+		closeErr <- w.Close(closeCtx)
+	}()
+
+	select {
+	case err := <-closeErr:
+		if err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return in time (deadlock)")
+	}
+
+	close(stop)
+	producers.Wait()
 }

--- a/internal/postgres/writer_test.go
+++ b/internal/postgres/writer_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -101,5 +102,73 @@ func TestPostgresWriter_RouteObservation(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for observation")
+	}
+}
+
+// fakeObsInserter is a test double for the obsInserter seam, letting
+// TestPostgresWriter_DrainOnClose assert on drained rows without a live
+// Postgres connection.
+type fakeObsInserter struct {
+	mu   sync.Mutex
+	rows []observationRow
+}
+
+func (f *fakeObsInserter) insertObservations(_ context.Context, batch []observationRow) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, batch...)
+	return nil
+}
+
+func (f *fakeObsInserter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+// TestPostgresWriter_DrainOnClose proves Close(ctx) drains rows still
+// sitting in the buffered channel (not just each worker's local in-flight
+// batch) using the passed-in cleanup ctx rather than the writer's own
+// (already-canceled) ctx (C-H1).
+func TestPostgresWriter_DrainOnClose(t *testing.T) {
+	// The writer's own ctx is canceled up front, simulating the real
+	// shutdown sequence where SIGTERM cancels the shared context the
+	// writer was constructed with before Close(cleanupCtx) is called with a
+	// separate, still-live context.
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+	cancelWorkerCtx()
+
+	fake := &fakeObsInserter{}
+	w := &PostgresWriter{
+		obsBatch:      make(chan observationRow, 1000),
+		windBatch:     make(chan rapidWindRow, 1000),
+		hubBatch:      make(chan hubStatusRow, 1000),
+		eventBatch:    make(chan eventRow, 1000),
+		batchSize:     100,
+		flushInterval: time.Second,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		obsInserter:   fake,
+	}
+
+	w.wg.Add(4)
+	go w.batchObservations()
+	go w.batchRapidWind()
+	go w.batchHubStatus()
+	go w.batchEvents()
+
+	const wantRows = 250
+	for i := 0; i < wantRows; i++ {
+		w.obsBatch <- observationRow{serialNumber: "ST-DRAIN"}
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := fake.count(); got != wantRows {
+		t.Fatalf("expected %d rows drained via Close, got %d", wantRows, got)
 	}
 }

--- a/internal/prometheus/server.go
+++ b/internal/prometheus/server.go
@@ -2,8 +2,10 @@ package prometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -48,10 +50,12 @@ func NewMetricsServer(port string) *MetricsServer {
 
 	addr := ":" + port
 	server := &http.Server{
-		Addr:         addr,
-		Handler:      mux,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              addr,
+		Handler:           mux,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	return &MetricsServer{
@@ -62,13 +66,20 @@ func NewMetricsServer(port string) *MetricsServer {
 	}
 }
 
-// Start begins serving the metrics endpoint in a background goroutine.
+// Start binds the metrics listener synchronously, returning any bind error
+// (e.g. port already in use) to the caller, then serves the endpoint in a
+// background goroutine.
 func (s *MetricsServer) Start() error {
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return fmt.Errorf("metrics: listen on %s: %w", s.server.Addr, err)
+	}
+
 	s.shutdownWg.Add(1)
 	go func() {
 		defer s.shutdownWg.Done()
 		log.Printf("metrics: starting HTTP server on port %s", s.port)
-		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("metrics: server error: %v", err)
 		}
 	}()

--- a/internal/prometheus/server.go
+++ b/internal/prometheus/server.go
@@ -92,12 +92,14 @@ func (s *MetricsServer) Flush(ctx context.Context) error {
 	return nil
 }
 
-// Close shuts down the HTTP server gracefully.
-func (s *MetricsServer) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+// Close shuts down the HTTP server gracefully. The passed-in ctx is accepted
+// for MetricsWriter conformance and currently unused — the shutdown still
+// builds its own bounded 5s context internally; see Task 0.9b/0.10.
+func (s *MetricsServer) Close(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := s.server.Shutdown(ctx); err != nil {
+	if err := s.server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("metrics: shutdown error: %v", err)
 		return err
 	}

--- a/internal/prometheus/server.go
+++ b/internal/prometheus/server.go
@@ -41,7 +41,9 @@ func NewMetricsServer(port string) *MetricsServer {
 	}))
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		if _, err := w.Write([]byte("OK")); err != nil {
+			log.Printf("metrics: health response write error: %v", err)
+		}
 	})
 
 	addr := ":" + port

--- a/internal/prometheus/server_test.go
+++ b/internal/prometheus/server_test.go
@@ -63,8 +63,7 @@ func TestMetricsServer_WriteMetrics(t *testing.T) {
 		"ST-00001", "air",
 	)
 
-	err := server.WriteMetrics(ctx, []prometheus.Metric{metric})
-	if err != nil {
+	if err := server.WriteMetrics(ctx, []prometheus.Metric{metric}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -80,7 +79,7 @@ func TestMetricsServer_MetricsEndpoint(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	// Give server time to start
 	time.Sleep(50 * time.Millisecond)
@@ -92,14 +91,14 @@ func TestMetricsServer_MetricsEndpoint(t *testing.T) {
 		22.5,
 		"ST-00001", "air",
 	)
-	server.WriteMetrics(context.Background(), []prometheus.Metric{metric})
+	_ = server.WriteMetrics(context.Background(), []prometheus.Metric{metric})
 
 	// Fetch metrics endpoint
 	resp, err := http.Get("http://127.0.0.1:19090/metrics")
 	if err != nil {
 		t.Fatalf("failed to fetch metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status 200, got %d", resp.StatusCode)
@@ -117,7 +116,7 @@ func TestMetricsServer_HealthEndpoint(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	// Give server time to start
 	time.Sleep(50 * time.Millisecond)
@@ -126,7 +125,7 @@ func TestMetricsServer_HealthEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to fetch health: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status 200, got %d", resp.StatusCode)

--- a/internal/prometheus/server_test.go
+++ b/internal/prometheus/server_test.go
@@ -24,7 +24,7 @@ func TestMetricsServer_StartAndClose(t *testing.T) {
 	// Give server time to start
 	time.Sleep(50 * time.Millisecond)
 
-	if err := server.Close(); err != nil {
+	if err := server.Close(t.Context()); err != nil {
 		t.Fatalf("failed to close server: %v", err)
 	}
 }
@@ -79,7 +79,7 @@ func TestMetricsServer_MetricsEndpoint(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
-	defer func() { _ = server.Close() }()
+	defer func() { _ = server.Close(t.Context()) }()
 
 	// Give server time to start
 	time.Sleep(50 * time.Millisecond)
@@ -116,7 +116,7 @@ func TestMetricsServer_HealthEndpoint(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
-	defer func() { _ = server.Close() }()
+	defer func() { _ = server.Close(t.Context()) }()
 
 	// Give server time to start
 	time.Sleep(50 * time.Millisecond)

--- a/internal/prometheus/server_test.go
+++ b/internal/prometheus/server_test.go
@@ -3,7 +3,9 @@ package prometheus
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +28,37 @@ func TestMetricsServer_StartAndClose(t *testing.T) {
 
 	if err := server.Close(t.Context()); err != nil {
 		t.Fatalf("failed to close server: %v", err)
+	}
+}
+
+func TestMetricsServer_StartReturnsBindError(t *testing.T) {
+	// Discover a free port by binding to :0 with a plain listener, then
+	// release it immediately. Closing a listener that never accepted a
+	// connection releases the port with no lingering state, so it's safe
+	// to reuse straight away.
+	probe, err := net.Listen("tcp", ":0") //nolint:gosec // test-only: binds an ephemeral port on localhost to discover a free port number, not a production listener
+	if err != nil {
+		t.Fatalf("failed to discover a free port: %v", err)
+	}
+	port := strconv.Itoa(probe.Addr().(*net.TCPAddr).Port)
+	if err := probe.Close(); err != nil {
+		t.Fatalf("failed to release probe listener: %v", err)
+	}
+
+	server1 := NewMetricsServer(port)
+	if err := server1.Start(); err != nil {
+		t.Fatalf("first server failed to bind %s: %v", port, err)
+	}
+	defer func() { _ = server1.Close(t.Context()) }()
+
+	// server1 is still holding the port, so a second server bound to the
+	// same port must fail synchronously.
+	server2 := NewMetricsServer(port)
+	err = server2.Start()
+	defer func() { _ = server2.Close(t.Context()) }()
+
+	if err == nil {
+		t.Fatal("expected second Start() on the same port to return a bind error, got nil")
 	}
 }
 

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -3,7 +3,9 @@ package prometheus
 import (
 	"context"
 	"log"
+	"net/http"
 	"sync"
+	"time"
 
 	"tempestwx-utilities/internal/tempestudp"
 
@@ -11,6 +13,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/prometheus/common/expfmt"
 )
+
+// pushTimeout bounds every pusher.Add() call (periodic pushes and the
+// final-flush push in pushWorker) so a dead/slow push gateway can never
+// stall shutdown. Add() uses context.Background() internally, so without
+// this the pusher's HTTP client would otherwise have no deadline at all.
+const pushTimeout = 10 * time.Second
 
 // PrometheusWriter wraps the existing Prometheus push logic.
 type PrometheusWriter struct {
@@ -39,7 +47,8 @@ func NewPrometheusWriter(pushURL, jobName string) *PrometheusWriter {
 	// Create pusher
 	pusher := push.New(pushURL, jobName).
 		Collector(collector).
-		Format(expfmt.NewFormat(expfmt.TypeTextPlain))
+		Format(expfmt.NewFormat(expfmt.TypeTextPlain)).
+		Client(&http.Client{Timeout: pushTimeout})
 
 	w := &PrometheusWriter{
 		pusher: pusher,

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -18,6 +18,14 @@ type PrometheusWriter struct {
 	outbox chan prometheus.Metric
 	more   chan bool
 	wg     sync.WaitGroup
+
+	// done is the sole shutdown signal: closing it tells every producer
+	// send in WriteMetrics/Flush and pushWorker that Close is in
+	// progress. outbox and more are never closed (see Close), which is
+	// what keeps a concurrent producer send from ever panicking on a
+	// send-on-closed-channel (D-H1).
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewPrometheusWriter creates a new Prometheus writer.
@@ -37,6 +45,7 @@ func NewPrometheusWriter(pushURL, jobName string) *PrometheusWriter {
 		pusher: pusher,
 		outbox: outbox,
 		more:   more,
+		done:   make(chan struct{}),
 	}
 
 	// Start background push worker
@@ -59,6 +68,8 @@ func (w *PrometheusWriter) WriteMetrics(ctx context.Context, metrics []prometheu
 	for _, m := range metrics {
 		select {
 		case w.outbox <- m:
+		case <-w.done:
+			return nil
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
@@ -69,6 +80,7 @@ func (w *PrometheusWriter) WriteMetrics(ctx context.Context, metrics []prometheu
 	// Signal push worker
 	select {
 	case w.more <- true:
+	case <-w.done:
 	default:
 		// Already signaled
 	}
@@ -81,26 +93,36 @@ func (w *PrometheusWriter) Flush(ctx context.Context) error {
 	// Trigger immediate push
 	select {
 	case w.more <- true:
+	case <-w.done:
 	default:
 	}
 	return nil
 }
 
-// Close stops the push worker. ctx is accepted for MetricsWriter conformance
-// and is currently unused — see Task 0.9b for the idempotency gate.
+// Close signals the push worker to stop via the done gate and waits for it
+// to finish. It is idempotent (safe to call more than once) and never closes
+// outbox or more, so a concurrent WriteMetrics/Flush send can never panic on
+// a send-on-closed-channel (D-H1).
 func (w *PrometheusWriter) Close(ctx context.Context) error {
-	close(w.outbox)
-	close(w.more)
-	w.wg.Wait() // Wait for pushWorker to finish
+	w.closeOnce.Do(func() {
+		close(w.done)
+		w.wg.Wait() // Wait for pushWorker to finish
+	})
 	log.Printf("prometheus: closed")
 	return nil
 }
 
 func (w *PrometheusWriter) pushWorker() {
 	defer w.wg.Done()
-	for range w.more {
-		if err := w.pusher.Add(); err != nil {
-			log.Printf("prometheus: push error: %v", err)
+	for {
+		select {
+		case <-w.more:
+			if err := w.pusher.Add(); err != nil {
+				log.Printf("prometheus: push error: %v", err)
+			}
+		case <-w.done:
+			_ = w.pusher.Add() // final flush of whatever the collector can drain
+			return
 		}
 	}
 }

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -31,7 +31,7 @@ func NewPrometheusWriter(pushURL, jobName string) *PrometheusWriter {
 	// Create pusher
 	pusher := push.New(pushURL, jobName).
 		Collector(collector).
-		Format(expfmt.FmtText)
+		Format(expfmt.NewFormat(expfmt.TypeTextPlain))
 
 	w := &PrometheusWriter{
 		pusher: pusher,

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -86,8 +86,9 @@ func (w *PrometheusWriter) Flush(ctx context.Context) error {
 	return nil
 }
 
-// Close stops the push worker.
-func (w *PrometheusWriter) Close() error {
+// Close stops the push worker. ctx is accepted for MetricsWriter conformance
+// and is currently unused — see Task 0.9b for the idempotency gate.
+func (w *PrometheusWriter) Close(ctx context.Context) error {
 	close(w.outbox)
 	close(w.more)
 	w.wg.Wait() // Wait for pushWorker to finish

--- a/internal/prometheus/writer_test.go
+++ b/internal/prometheus/writer_test.go
@@ -71,6 +71,34 @@ func TestPrometheusClose_Idempotent(t *testing.T) {
 	}
 }
 
+// TestPrometheusWriter_ClosePushTimeoutBounded verifies the pusher's HTTP
+// client carries a bounded Timeout, so a push gateway that accepts the
+// connection but never responds cannot stall the final-flush Add() (and
+// therefore Close) indefinitely. Add() uses context.Background() internally
+// (see github.com/prometheus/client_golang/prometheus/push), so without a
+// client-level Timeout this hangs until the test's own outer deadline — the
+// 0.9b review finding.
+func TestPrometheusWriter_ClosePushTimeoutBounded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // hang until the client gives up waiting
+	}))
+	t.Cleanup(server.Close)
+
+	writer := NewPrometheusWriter(server.URL, "test-job")
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- writer.Close(t.Context()) }()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Errorf("Close: unexpected error: %v", err)
+		}
+	case <-time.After(pushTimeout + 5*time.Second):
+		t.Fatal("Close did not return within the bounded push timeout")
+	}
+}
+
 // TestPrometheusWriteDuringClose_NoPanic drives concurrent WriteMetrics
 // producers against a Close in progress. Before the done-gate, this panics
 // with a send-on-closed-channel from either the outbox send or the more

--- a/internal/prometheus/writer_test.go
+++ b/internal/prometheus/writer_test.go
@@ -2,18 +2,35 @@ package prometheus
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"tempestwx-utilities/internal/tempestudp"
 )
 
+// newTestPushGateway starts a local HTTP server that accepts any push
+// request and returns its URL. Close (per Task 0.9b) makes exactly one
+// final-flush Add() call per writer, which performs a real HTTP request —
+// pointing that at an unreachable dead port (e.g. localhost:9091) makes
+// timing depend on this environment's TCP-refusal latency for closed ports,
+// which is not always instant and can make tests asserting "Close returns
+// promptly" flaky for reasons unrelated to the code under test.
+func newTestPushGateway(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
 func TestPrometheusWriter_WriteReport(t *testing.T) {
 	ctx := context.Background()
 
-	// Mock push gateway - use httptest
-	// For now, just test construction
-	writer := NewPrometheusWriter("http://localhost:9091", "test-job")
+	writer := NewPrometheusWriter(newTestPushGateway(t), "test-job")
 
 	report := &tempestudp.TempestObservationReport{
 		SerialNumber: "ST-00001",
@@ -33,10 +50,76 @@ func TestPrometheusWriter_WriteReport(t *testing.T) {
 }
 
 func TestPrometheusWriter_Close(t *testing.T) {
-	writer := NewPrometheusWriter("http://localhost:9091", "test-job")
+	writer := NewPrometheusWriter(newTestPushGateway(t), "test-job")
 
 	err := writer.Close(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+// TestPrometheusClose_Idempotent verifies calling Close twice does not panic
+// (double-close of a channel) and returns nil both times.
+func TestPrometheusClose_Idempotent(t *testing.T) {
+	writer := NewPrometheusWriter(newTestPushGateway(t), "test-job")
+
+	if err := writer.Close(t.Context()); err != nil {
+		t.Fatalf("first Close: unexpected error: %v", err)
+	}
+	if err := writer.Close(t.Context()); err != nil {
+		t.Fatalf("second Close: unexpected error: %v", err)
+	}
+}
+
+// TestPrometheusWriteDuringClose_NoPanic drives concurrent WriteMetrics
+// producers against a Close in progress. Before the done-gate, this panics
+// with a send-on-closed-channel from either the outbox send or the more
+// signal in WriteMetrics, and Close itself double-closes those channels.
+// Run with -race.
+//
+// Each producer sends a bounded number of metric batches (not an unbounded
+// tight loop): flooding outbox with hundreds of same-name/same-label metric
+// sends from one reused report makes the underlying Prometheus Gatherer's
+// duplicate-metric-descriptor error formatting (which runs on every Add,
+// before any network call) arbitrarily expensive and turns "Close returns
+// promptly" into a workload-size assertion rather than a done-gate one.
+func TestPrometheusWriteDuringClose_NoPanic(t *testing.T) {
+	writer := NewPrometheusWriter(newTestPushGateway(t), "test-job")
+
+	report := &tempestudp.TempestObservationReport{
+		SerialNumber: "ST-00001",
+		Obs: [][]float64{
+			{1234567890, 1.5, 2.0, 2.5, 180, 0, 1013.25, 20.5, 75, 50000, 3, 500, 0.5},
+		},
+	}
+	metrics := report.Metrics()
+
+	const writesPerProducer = 20
+
+	var producers sync.WaitGroup
+	for range 4 {
+		producers.Add(1)
+		go func() {
+			defer producers.Done()
+			for range writesPerProducer {
+				_ = writer.WriteMetrics(t.Context(), metrics)
+			}
+		}()
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- writer.Close(t.Context())
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Errorf("Close: unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return promptly")
+	}
+
+	producers.Wait()
 }

--- a/internal/prometheus/writer_test.go
+++ b/internal/prometheus/writer_test.go
@@ -35,7 +35,7 @@ func TestPrometheusWriter_WriteReport(t *testing.T) {
 func TestPrometheusWriter_Close(t *testing.T) {
 	writer := NewPrometheusWriter("http://localhost:9091", "test-job")
 
-	err := writer.Close()
+	err := writer.Close(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -128,7 +128,10 @@ func (s *MetricsSink) SendMetrics(ctx context.Context, metrics []prometheus.Metr
 }
 
 // Close flushes and closes all writers using the caller-supplied context
-// (never a stored one), aggregating per-writer errors via errors.Join.
+// (never a stored one), aggregating per-writer errors via errors.Join. A
+// panic in one writer's Flush/Close is recovered and reported as an error
+// rather than crashing the process during shutdown — mirroring the panic
+// recovery already in SendReport/SendMetrics.
 func (s *MetricsSink) Close(ctx context.Context) error {
 	s.mu.RLock()
 	writers := slices.Clone(s.writers)
@@ -143,6 +146,14 @@ func (s *MetricsSink) Close(ctx context.Context) error {
 		wg.Add(1)
 		go func(writer MetricsWriter) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("writer panic recovered during close", "panic", r, "writer", fmt.Sprintf("%T", writer))
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("writer %T panicked during close: %v", writer, r))
+					mu.Unlock()
+				}
+			}()
 			if err := writer.Flush(ctx); err != nil {
 				mu.Lock()
 				errs = append(errs, err)

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -2,7 +2,10 @@ package sink
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
 	"sync"
 
 	"tempestwx-utilities/internal/tempestudp"
@@ -21,22 +24,20 @@ type MetricsWriter interface {
 	// Flush ensures any buffered data is written
 	Flush(ctx context.Context) error
 
-	// Close performs cleanup
-	Close() error
+	// Close performs cleanup using the caller-supplied context.
+	Close(ctx context.Context) error
 }
 
 // MetricsSink coordinates sending metrics to multiple backends.
 type MetricsSink struct {
 	writers []MetricsWriter
-	ctx     context.Context
 	mu      sync.RWMutex
 }
 
 // NewMetricsSink creates a new metrics sink.
-func NewMetricsSink(ctx context.Context) *MetricsSink {
+func NewMetricsSink() *MetricsSink {
 	return &MetricsSink{
 		writers: make([]MetricsWriter, 0),
-		ctx:     ctx,
 	}
 }
 
@@ -54,77 +55,106 @@ func (s *MetricsSink) WriterCount() int {
 	return len(s.writers)
 }
 
-// SendReport sends a typed report to all writers.
+// SendReport sends a typed report to all writers. A panic in one writer is
+// recovered and reported as an error rather than crashing the process or
+// blocking delivery to the other writers; per-writer errors are aggregated
+// via errors.Join rather than silently discarded.
 func (s *MetricsSink) SendReport(ctx context.Context, report tempestudp.Report) error {
 	s.mu.RLock()
-	writers := make([]MetricsWriter, len(s.writers))
-	copy(writers, s.writers)
+	writers := slices.Clone(s.writers)
 	s.mu.RUnlock()
 
-	// Fan out to all writers concurrently
-	var wg sync.WaitGroup
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
 	for _, w := range writers {
 		wg.Add(1)
 		go func(writer MetricsWriter) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("writer panic recovered", "panic", r, "writer", fmt.Sprintf("%T", writer))
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("writer %T panicked: %v", writer, r))
+					mu.Unlock()
+				}
+			}()
 			if err := writer.WriteReport(ctx, report); err != nil {
-				log.Printf("writer error (report): %v", err)
+				mu.Lock() // mutex guards the append — required, else -race flags the concurrent slice write
+				errs = append(errs, fmt.Errorf("writer %T: %w", writer, err))
+				mu.Unlock()
 			}
 		}(w)
 	}
 	wg.Wait()
-
-	return nil
+	return errors.Join(errs...) // nil when errs is empty
 }
 
-// SendMetrics sends Prometheus metrics to all writers.
+// SendMetrics sends Prometheus metrics to all writers. Same panic-recovery
+// and error-aggregation semantics as SendReport.
 func (s *MetricsSink) SendMetrics(ctx context.Context, metrics []prometheus.Metric) error {
 	s.mu.RLock()
-	writers := make([]MetricsWriter, len(s.writers))
-	copy(writers, s.writers)
+	writers := slices.Clone(s.writers)
 	s.mu.RUnlock()
 
-	// Fan out to all writers concurrently
-	var wg sync.WaitGroup
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
 	for _, w := range writers {
 		wg.Add(1)
 		go func(writer MetricsWriter) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("writer panic recovered", "panic", r, "writer", fmt.Sprintf("%T", writer))
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("writer %T panicked: %v", writer, r))
+					mu.Unlock()
+				}
+			}()
 			if err := writer.WriteMetrics(ctx, metrics); err != nil {
-				log.Printf("writer error (metrics): %v", err)
+				mu.Lock() // mutex guards the append — required, else -race flags the concurrent slice write
+				errs = append(errs, fmt.Errorf("writer %T: %w", writer, err))
+				mu.Unlock()
 			}
 		}(w)
 	}
 	wg.Wait()
-
-	return nil
+	return errors.Join(errs...) // nil when errs is empty
 }
 
-// Close flushes and closes all writers.
-func (s *MetricsSink) Close() error {
+// Close flushes and closes all writers using the caller-supplied context
+// (never a stored one), aggregating per-writer errors via errors.Join.
+func (s *MetricsSink) Close(ctx context.Context) error {
 	s.mu.RLock()
-	writers := make([]MetricsWriter, len(s.writers))
-	copy(writers, s.writers)
+	writers := slices.Clone(s.writers)
 	s.mu.RUnlock()
 
-	var wg sync.WaitGroup
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
 	for _, w := range writers {
 		wg.Add(1)
 		go func(writer MetricsWriter) {
 			defer wg.Done()
-
-			// Flush first
-			if err := writer.Flush(s.ctx); err != nil {
-				log.Printf("writer flush error: %v", err)
+			if err := writer.Flush(ctx); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
 			}
-
-			// Then close
-			if err := writer.Close(); err != nil {
-				log.Printf("writer close error: %v", err)
+			if err := writer.Close(ctx); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
 			}
 		}(w)
 	}
 	wg.Wait()
-
-	return nil
+	return errors.Join(errs...)
 }

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -13,13 +13,13 @@ import (
 
 // Mock writer for testing
 type mockWriter struct {
-	reportCalls  int
-	metricCalls  int
-	reportErr    error
-	metricsErr   error
-	flushCalled  bool
-	closeCalled  bool
-	mu           sync.Mutex
+	reportCalls int
+	metricCalls int
+	reportErr   error
+	metricsErr  error
+	flushCalled bool
+	closeCalled bool
+	mu          sync.Mutex
 }
 
 func (m *mockWriter) WriteReport(ctx context.Context, report tempestudp.Report) error {

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -3,6 +3,7 @@ package sink
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -17,8 +18,10 @@ type mockWriter struct {
 	metricCalls int
 	reportErr   error
 	metricsErr  error
+	panicMsg    string // non-empty triggers a panic from WriteReport
 	flushCalled bool
 	closeCalled bool
+	closeCtx    context.Context
 	mu          sync.Mutex
 }
 
@@ -26,6 +29,9 @@ func (m *mockWriter) WriteReport(ctx context.Context, report tempestudp.Report) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.reportCalls++
+	if m.panicMsg != "" {
+		panic(m.panicMsg)
+	}
 	return m.reportErr
 }
 
@@ -43,16 +49,16 @@ func (m *mockWriter) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockWriter) Close() error {
+func (m *mockWriter) Close(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.closeCalled = true
+	m.closeCtx = ctx
 	return nil
 }
 
 func TestMetricsSink_AddWriter(t *testing.T) {
-	ctx := context.Background()
-	sink := NewMetricsSink(ctx)
+	sink := NewMetricsSink()
 
 	if sink.WriterCount() != 0 {
 		t.Errorf("expected 0 writers, got %d", sink.WriterCount())
@@ -68,7 +74,7 @@ func TestMetricsSink_AddWriter(t *testing.T) {
 
 func TestMetricsSink_SendReport(t *testing.T) {
 	ctx := context.Background()
-	sink := NewMetricsSink(ctx)
+	sink := NewMetricsSink()
 
 	writer1 := &mockWriter{}
 	writer2 := &mockWriter{}
@@ -97,7 +103,7 @@ func TestMetricsSink_SendReport(t *testing.T) {
 
 func TestMetricsSink_SendMetrics(t *testing.T) {
 	ctx := context.Background()
-	sink := NewMetricsSink(ctx)
+	sink := NewMetricsSink()
 
 	writer := &mockWriter{}
 	sink.AddWriter(writer)
@@ -115,7 +121,7 @@ func TestMetricsSink_SendMetrics(t *testing.T) {
 
 func TestMetricsSink_WriterError(t *testing.T) {
 	ctx := context.Background()
-	sink := NewMetricsSink(ctx)
+	sink := NewMetricsSink()
 
 	// Writer that returns error
 	failWriter := &mockWriter{reportErr: errors.New("write failed")}
@@ -128,10 +134,11 @@ func TestMetricsSink_WriterError(t *testing.T) {
 		SerialNumber: "TEST-001",
 	}
 
-	// Should not return error - errors are logged but don't fail the send
+	// A failing writer's error is now aggregated and returned (A-LOW: no more
+	// dead nil returns that silently swallow writer errors).
 	err := sink.SendReport(ctx, report)
-	if err != nil {
-		t.Errorf("expected no error when writer fails, got %v", err)
+	if err == nil {
+		t.Error("expected aggregated error when a writer fails, got nil")
 	}
 
 	// Both writers should have been called
@@ -145,14 +152,14 @@ func TestMetricsSink_WriterError(t *testing.T) {
 
 func TestMetricsSink_Close(t *testing.T) {
 	ctx := context.Background()
-	sink := NewMetricsSink(ctx)
+	sink := NewMetricsSink()
 
 	writer1 := &mockWriter{}
 	writer2 := &mockWriter{}
 	sink.AddWriter(writer1)
 	sink.AddWriter(writer2)
 
-	err := sink.Close()
+	err := sink.Close(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,5 +176,102 @@ func TestMetricsSink_Close(t *testing.T) {
 	}
 	if !writer2.closeCalled {
 		t.Error("writer2.Close should have been called")
+	}
+}
+
+// TestSink_RecoversPanickingWriter verifies a panicking writer cannot crash
+// the sink or block delivery to sibling writers (A-MEDIUM: panic recovery).
+func TestSink_RecoversPanickingWriter(t *testing.T) {
+	ctx := context.Background()
+	s := NewMetricsSink()
+
+	panicker := &mockWriter{panicMsg: "boom"}
+	healthy := &mockWriter{}
+	s.AddWriter(panicker)
+	s.AddWriter(healthy)
+
+	report := &tempestudp.TempestObservationReport{SerialNumber: "TEST-001"}
+
+	err := s.SendReport(ctx, report)
+	if err == nil {
+		t.Fatal("expected a non-nil error naming the recovered panic")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected error to mention the panic value, got: %v", err)
+	}
+
+	// The panicking writer was still invoked, and the sibling writer must
+	// still have been called despite the panic.
+	if panicker.reportCalls != 1 {
+		t.Errorf("panicker: expected 1 call, got %d", panicker.reportCalls)
+	}
+	if healthy.reportCalls != 1 {
+		t.Errorf("healthy writer: expected 1 call, got %d", healthy.reportCalls)
+	}
+}
+
+// TestSink_SendReportAggregatesErrors verifies SendReport joins per-writer
+// errors instead of silently discarding them (A-LOW: no dead nil returns).
+func TestSink_SendReportAggregatesErrors(t *testing.T) {
+	ctx := context.Background()
+	report := &tempestudp.TempestObservationReport{SerialNumber: "TEST-001"}
+
+	t.Run("two failing writers aggregate", func(t *testing.T) {
+		s := NewMetricsSink()
+		s.AddWriter(&mockWriter{reportErr: errors.New("writer1 failed")})
+		s.AddWriter(&mockWriter{reportErr: errors.New("writer2 failed")})
+
+		err := s.SendReport(ctx, report)
+		if err == nil {
+			t.Fatal("expected non-nil aggregated error")
+		}
+		if !strings.Contains(err.Error(), "writer1 failed") || !strings.Contains(err.Error(), "writer2 failed") {
+			t.Errorf("expected both writer errors present, got: %v", err)
+		}
+	})
+
+	t.Run("one failing one ok names the failure", func(t *testing.T) {
+		s := NewMetricsSink()
+		s.AddWriter(&mockWriter{reportErr: errors.New("writer1 failed")})
+		s.AddWriter(&mockWriter{})
+
+		err := s.SendReport(ctx, report)
+		if err == nil {
+			t.Fatal("expected non-nil error naming the failing writer")
+		}
+		if !strings.Contains(err.Error(), "writer1 failed") {
+			t.Errorf("expected failure to be named, got: %v", err)
+		}
+	})
+
+	t.Run("all ok returns nil", func(t *testing.T) {
+		s := NewMetricsSink()
+		s.AddWriter(&mockWriter{})
+		s.AddWriter(&mockWriter{})
+
+		if err := s.SendReport(ctx, report); err != nil {
+			t.Errorf("expected nil error when all writers succeed, got: %v", err)
+		}
+	})
+}
+
+// TestSink_ClosePassesContext verifies Close(ctx) forwards the caller's
+// cleanup context to each writer rather than a stored/cancelled one.
+func TestSink_ClosePassesContext(t *testing.T) {
+	s := NewMetricsSink()
+	writer := &mockWriter{}
+	s.AddWriter(writer)
+
+	// context.WithCancel yields a context distinct from context.Background(),
+	// so identity comparison below actually proves the parameter was forwarded.
+	cleanupCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Close(cleanupCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if writer.closeCtx != cleanupCtx {
+		t.Error("expected Close to receive the caller-supplied cleanup context")
 	}
 }

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -14,15 +14,16 @@ import (
 
 // Mock writer for testing
 type mockWriter struct {
-	reportCalls int
-	metricCalls int
-	reportErr   error
-	metricsErr  error
-	panicMsg    string // non-empty triggers a panic from WriteReport
-	flushCalled bool
-	closeCalled bool
-	closeCtx    context.Context
-	mu          sync.Mutex
+	reportCalls   int
+	metricCalls   int
+	reportErr     error
+	metricsErr    error
+	panicMsg      string // non-empty triggers a panic from WriteReport
+	closePanicMsg string // non-empty triggers a panic from Close
+	flushCalled   bool
+	closeCalled   bool
+	closeCtx      context.Context
+	mu            sync.Mutex
 }
 
 func (m *mockWriter) WriteReport(ctx context.Context, report tempestudp.Report) error {
@@ -54,6 +55,9 @@ func (m *mockWriter) Close(ctx context.Context) error {
 	defer m.mu.Unlock()
 	m.closeCalled = true
 	m.closeCtx = ctx
+	if m.closePanicMsg != "" {
+		panic(m.closePanicMsg)
+	}
 	return nil
 }
 
@@ -253,6 +257,34 @@ func TestSink_SendReportAggregatesErrors(t *testing.T) {
 			t.Errorf("expected nil error when all writers succeed, got: %v", err)
 		}
 	})
+}
+
+// TestSink_ClosePanicRecovered verifies a writer whose Close panics cannot
+// crash the sink or block the sibling writer's shutdown, mirroring
+// SendReport's/SendMetrics's existing panic-recovery pattern.
+func TestSink_ClosePanicRecovered(t *testing.T) {
+	ctx := context.Background()
+	s := NewMetricsSink()
+
+	panicker := &mockWriter{closePanicMsg: "boom on close"}
+	healthy := &mockWriter{}
+	s.AddWriter(panicker)
+	s.AddWriter(healthy)
+
+	err := s.Close(ctx)
+	if err == nil {
+		t.Fatal("expected a non-nil error naming the recovered panic")
+	}
+	if !strings.Contains(err.Error(), "boom on close") {
+		t.Errorf("expected error to mention the panic value, got: %v", err)
+	}
+
+	if !panicker.closeCalled {
+		t.Error("panicker.Close should have been called")
+	}
+	if !healthy.closeCalled {
+		t.Error("healthy.Close should still have been called despite the sibling panic")
+	}
 }
 
 // TestSink_ClosePassesContext verifies Close(ctx) forwards the caller's

--- a/internal/tempest/metrics.go
+++ b/internal/tempest/metrics.go
@@ -10,20 +10,20 @@ var (
 	Reboots   *prometheus.Desc
 	BusErrors *prometheus.Desc
 
-	Illuminance    *prometheus.Desc
-	UV             *prometheus.Desc
-	RainRate       *prometheus.Desc
-	Wind           *prometheus.Desc // "lull", "avg", "gust", "rapid"
-	WindDirection  *prometheus.Desc
-	Battery        *prometheus.Desc
-	ReportInterval *prometheus.Desc
-	Irradiance     *prometheus.Desc
-	RainTotal      *prometheus.Desc
-	Pressure              *prometheus.Desc
-	Temperature           *prometheus.Desc // "air", "wetbulb"
-	Humidity              *prometheus.Desc
-	LightningDistance     *prometheus.Desc
-	LightningStrikeCount  *prometheus.Desc
+	Illuminance          *prometheus.Desc
+	UV                   *prometheus.Desc
+	RainRate             *prometheus.Desc
+	Wind                 *prometheus.Desc // "lull", "avg", "gust", "rapid"
+	WindDirection        *prometheus.Desc
+	Battery              *prometheus.Desc
+	ReportInterval       *prometheus.Desc
+	Irradiance           *prometheus.Desc
+	RainTotal            *prometheus.Desc
+	Pressure             *prometheus.Desc
+	Temperature          *prometheus.Desc // "air", "wetbulb"
+	Humidity             *prometheus.Desc
+	LightningDistance    *prometheus.Desc
+	LightningStrikeCount *prometheus.Desc
 )
 
 var All []*prometheus.Desc

--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -40,7 +40,7 @@ func (c Client) ListStations(ctx context.Context) ([]Station, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // client hardening (timeouts, retries, close handling) addressed in Task 0.5
 
 	var data struct {
 		Stations []struct {
@@ -97,7 +97,7 @@ func (c Client) GetObservations(ctx context.Context, station Station, startAt ti
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // client hardening (timeouts, retries, close handling) addressed in Task 0.5
 
 	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -113,7 +113,7 @@ func (c Client) GetObservations(ctx context.Context, station Station, startAt ti
 	case *tempestudp.TempestObservationReport:
 		r.SerialNumber = station.serialNumber
 	default:
-		log.Fatalf("unhandled report type")
+		log.Fatalf("unhandled report type") //nolint:gocritic // process-exiting error handling for the API client is reworked in Task 0.5
 	}
 
 	metrics := report.Metrics()

--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -16,10 +16,14 @@ import (
 
 type Client struct {
 	token string
+	http  *http.Client
 }
 
-func NewClient(token string) Client {
-	return Client{token: token}
+func NewClient(token string) *Client {
+	return &Client{
+		token: token,
+		http:  &http.Client{Timeout: 30 * time.Second},
+	}
 }
 
 type Station struct {
@@ -30,17 +34,27 @@ type Station struct {
 	CreatedAt    time.Time
 }
 
-func (c Client) ListStations(ctx context.Context) ([]Station, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://swd.weatherflow.com/swd/rest/stations?token="+c.token, nil)
+func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://swd.weatherflow.com/swd/rest/stations", nil)
 	if err != nil {
 		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("weatherflow API status %d", resp.StatusCode)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck // client hardening (timeouts, retries, close handling) addressed in Task 0.5
 
 	var data struct {
 		Stations []struct {
@@ -58,8 +72,11 @@ func (c Client) ListStations(ctx context.Context) ([]Station, error) {
 			StatusMessage string `json:"status_message"`
 		} `json:"status"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+	if err := json.Unmarshal(body, &data); err != nil {
 		return nil, err
+	}
+	if data.Status.StatusCode != 0 {
+		return nil, fmt.Errorf("weatherflow status_code %d: %s", data.Status.StatusCode, data.Status.StatusMessage)
 	}
 
 	var out []Station
@@ -86,26 +103,31 @@ func (c Client) ListStations(ctx context.Context) ([]Station, error) {
 	return out, nil
 }
 
-func (c Client) GetObservations(ctx context.Context, station Station, startAt time.Time, endAt time.Time) ([]prometheus.Metric, error) {
-	url := fmt.Sprintf("https://swd.weatherflow.com/swd/rest/observations/device/%d?token=%s&time_start=%d&time_end=%d", station.deviceID, c.token, startAt.Unix(), endAt.Unix())
+func (c *Client) GetObservations(ctx context.Context, station Station, startAt time.Time, endAt time.Time) ([]prometheus.Metric, error) {
+	url := fmt.Sprintf("https://swd.weatherflow.com/swd/rest/observations/device/%d?time_start=%d&time_end=%d", station.deviceID, startAt.Unix(), endAt.Unix())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck // client hardening (timeouts, retries, close handling) addressed in Task 0.5
+	defer func() { _ = resp.Body.Close() }()
 
-	bytes, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("weatherflow API status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return nil, err
 	}
-	report, err := tempestudp.ParseReport(bytes)
+	report, err := tempestudp.ParseReport(body)
 	if err != nil {
-		log.Printf("read %s", string(bytes))
+		log.Printf("read %s", string(body))
 		return nil, err
 	}
 
@@ -113,7 +135,7 @@ func (c Client) GetObservations(ctx context.Context, station Station, startAt ti
 	case *tempestudp.TempestObservationReport:
 		r.SerialNumber = station.serialNumber
 	default:
-		log.Fatalf("unhandled report type") //nolint:gocritic // process-exiting error handling for the API client is reworked in Task 0.5
+		return nil, fmt.Errorf("unhandled report type %T", report)
 	}
 
 	metrics := report.Metrics()

--- a/internal/tempestapi/client_test.go
+++ b/internal/tempestapi/client_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -67,14 +69,11 @@ func TestListStations_Success_SingleStation(t *testing.T) {
 		}
 	}`
 
-	// Replace http.DefaultClient temporarily
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -139,13 +138,11 @@ func TestListStations_Success_MultipleStations(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -205,13 +202,11 @@ func TestListStations_Success_MultipleDevicesPerStation(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -254,13 +249,11 @@ func TestListStations_NoSTDevice(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -282,13 +275,11 @@ func TestListStations_EmptyStations(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -340,13 +331,11 @@ func TestListStations_MixedValidAndInvalid(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -364,13 +353,11 @@ func TestListStations_MixedValidAndInvalid(t *testing.T) {
 }
 
 func TestListStations_InvalidJSON(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, "invalid json{{{"),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	_, err := client.ListStations(context.Background())
 
 	if err == nil {
@@ -379,13 +366,11 @@ func TestListStations_InvalidJSON(t *testing.T) {
 }
 
 func TestListStations_HTTPError(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		err: errors.New("network error"),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	_, err := client.ListStations(context.Background())
 
 	if err == nil {
@@ -394,13 +379,11 @@ func TestListStations_HTTPError(t *testing.T) {
 }
 
 func TestListStations_ContextCancellation(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		err: context.Canceled,
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
@@ -427,13 +410,11 @@ func TestGetObservations_Success(t *testing.T) {
 		"firmware_revision": 143
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{
 		Name:         "Test Station",
 		StationID:    12345,
@@ -474,13 +455,11 @@ func TestGetObservations_MultipleObservations(t *testing.T) {
 		"firmware_revision": 143
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{
 		deviceID:     67890,
 		serialNumber: "ST-00012345",
@@ -498,13 +477,11 @@ func TestGetObservations_MultipleObservations(t *testing.T) {
 }
 
 func TestGetObservations_HTTPError(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		err: errors.New("network error"),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
 
 	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
@@ -515,13 +492,11 @@ func TestGetObservations_HTTPError(t *testing.T) {
 }
 
 func TestGetObservations_InvalidJSON(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, "not valid json"),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
 
 	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
@@ -531,17 +506,12 @@ func TestGetObservations_InvalidJSON(t *testing.T) {
 	}
 }
 
-// Note: We can't test the wrong report type case because the client uses log.Fatalf
-// which exits the process. This would require refactoring the client to return an error instead.
-
 func TestGetObservations_ContextCancellation(t *testing.T) {
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		err: context.Canceled,
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -564,13 +534,11 @@ func TestGetObservations_EmptyObservations(t *testing.T) {
 		"firmware_revision": 143
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
 
 	metrics, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
@@ -611,13 +579,11 @@ func TestListStations_StationWithZeroDeviceID(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -652,13 +618,11 @@ func TestListStations_StationWithEmptySerialNumber(t *testing.T) {
 		}
 	}`
 
-	originalTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &mockRoundTripper{
+	client := NewClient("test-token")
+	client.http.Transport = &mockRoundTripper{
 		response: mockResponse(http.StatusOK, mockBody),
 	}
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("test-token")
 	stations, err := client.ListStations(context.Background())
 
 	if err != nil {
@@ -672,12 +636,14 @@ func TestListStations_StationWithEmptySerialNumber(t *testing.T) {
 }
 
 func TestGetObservations_URLParameters(t *testing.T) {
-	// Test that URL is constructed correctly with all parameters
+	// Test that URL is constructed correctly and auth is sent via header, not URL
 	var capturedURL string
+	var capturedAuth string
 
-	originalTransport := http.DefaultClient.Transport
-	mockTransport := mockRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	client := NewClient("my-secret-token")
+	client.http.Transport = mockRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		capturedURL = req.URL.String()
+		capturedAuth = req.Header.Get("Authorization")
 
 		mockResp := `{
 			"type": "obs_st",
@@ -689,10 +655,7 @@ func TestGetObservations_URLParameters(t *testing.T) {
 
 		return mockResponse(http.StatusOK, mockResp), nil
 	})
-	http.DefaultClient.Transport = mockTransport
-	defer func() { http.DefaultClient.Transport = originalTransport }()
 
-	client := NewClient("my-secret-token")
 	station := Station{
 		deviceID:     98765,
 		serialNumber: "ST-00098765",
@@ -706,12 +669,15 @@ func TestGetObservations_URLParameters(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	// Verify URL contains all required parameters
+	// Verify URL contains all required parameters, but never the token
 	if !strings.Contains(capturedURL, "device/98765") {
 		t.Errorf("URL should contain device ID 98765: %s", capturedURL)
 	}
-	if !strings.Contains(capturedURL, "token=my-secret-token") {
-		t.Errorf("URL should contain token: %s", capturedURL)
+	if strings.Contains(capturedURL, "token=") {
+		t.Errorf("URL must not contain a token query parameter: %s", capturedURL)
+	}
+	if capturedAuth != "Bearer my-secret-token" {
+		t.Errorf("Authorization header = %q, want %q", capturedAuth, "Bearer my-secret-token")
 	}
 	if !strings.Contains(capturedURL, "time_start=1609459000") {
 		t.Errorf("URL should contain start time: %s", capturedURL)
@@ -726,4 +692,119 @@ type mockRoundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f mockRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+// ============================================================================
+// Hardening Tests (F-H1..H4, F-MEDIUM)
+// ============================================================================
+
+// redirectTransport rewrites the outgoing request's scheme/host to point at a
+// local httptest.Server, so the real request built by the client (headers,
+// path, query) is delivered over the wire to a real server for inspection.
+type redirectTransport struct {
+	target *url.URL
+}
+
+func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.target.Scheme
+	req.URL.Host = t.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// newRedirectingClient returns a Client whose requests are transparently
+// redirected to server, so tests can assert on the actual request the client
+// sends while getting a response from a real httptest.Server.
+func newRedirectingClient(token string, server *httptest.Server) *Client {
+	c := NewClient(token)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		panic(err)
+	}
+	c.http.Transport = &redirectTransport{target: target}
+	return c
+}
+
+func TestClient_UsesBearerHeader_NotURLToken(t *testing.T) {
+	var gotAuth, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"stations":[],"status":{"status_code":0,"status_message":"SUCCESS"}}`))
+	}))
+	defer server.Close()
+
+	client := newRedirectingClient("secret-token", server)
+
+	if _, err := client.ListStations(context.Background()); err != nil {
+		t.Fatalf("ListStations() error = %v", err)
+	}
+
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer secret-token")
+	}
+	if strings.Contains(gotQuery, "token=") {
+		t.Errorf("request URL query %q must not contain a token parameter", gotQuery)
+	}
+}
+
+func TestClient_ReturnsErrorOn401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := newRedirectingClient("secret-token", server)
+
+	if _, err := client.ListStations(context.Background()); err == nil {
+		t.Error("ListStations() error = nil, want error mentioning status 401")
+	} else if !strings.Contains(err.Error(), "401") {
+		t.Errorf("ListStations() error = %v, want it to mention status 401", err)
+	}
+
+	station := Station{deviceID: 1, serialNumber: "ST-1"}
+	if _, err := client.GetObservations(context.Background(), station, time.Now(), time.Now()); err == nil {
+		t.Error("GetObservations() error = nil, want error mentioning status 401")
+	} else if !strings.Contains(err.Error(), "401") {
+		t.Errorf("GetObservations() error = %v, want it to mention status 401", err)
+	}
+}
+
+func TestClient_HasTimeout(t *testing.T) {
+	client := NewClient("secret-token")
+
+	if client.http.Timeout != 30*time.Second {
+		t.Errorf("http.Timeout = %v, want %v", client.http.Timeout, 30*time.Second)
+	}
+}
+
+func TestClient_UnhandledReportType_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"type":"rapid_wind","serial_number":"ST-1","hub_sn":"HB-1","ob":[1609459200,1.2,180]}`))
+	}))
+	defer server.Close()
+
+	client := newRedirectingClient("secret-token", server)
+	station := Station{deviceID: 1, serialNumber: "ST-1"}
+
+	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
+	if err == nil {
+		t.Fatal("GetObservations() error = nil, want error for unhandled report type")
+	}
+}
+
+func TestClient_ChecksStatusCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"stations":[],"status":{"status_code":2,"status_message":"BAD TOKEN"}}`))
+	}))
+	defer server.Close()
+
+	client := newRedirectingClient("secret-token", server)
+
+	_, err := client.ListStations(context.Background())
+	if err == nil {
+		t.Fatal("ListStations() error = nil, want error for non-zero status_code")
+	}
+	if !strings.Contains(err.Error(), "2") {
+		t.Errorf("ListStations() error = %v, want it to mention status_code 2", err)
+	}
 }

--- a/internal/tempestudp/report.go
+++ b/internal/tempestudp/report.go
@@ -3,6 +3,7 @@ package tempestudp
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"tempestwx-utilities/internal/tempest"
@@ -153,13 +154,24 @@ func (r TempestObservationReport) Metrics() []prometheus.Metric {
 			prometheus.MustNewConstMetric(tempest.WindDirection, prometheus.GaugeValue, ob[4], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.Pressure, prometheus.GaugeValue, ob[6], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.Temperature, prometheus.GaugeValue, ob[7], r.SerialNumber, "air"),
-			prometheus.MustNewConstMetric(tempest.Temperature, prometheus.GaugeValue, wetBulb, r.SerialNumber, "wetbulb"),
+		}
+
+		// WetBulbTemperatureC returns NaN for non-convergent inputs (e.g.
+		// physically impossible humidity/pressure from a malformed report);
+		// skip emitting the metric rather than publishing NaN.
+		if !math.IsNaN(wetBulb) {
+			metrics = append(metrics,
+				prometheus.MustNewConstMetric(tempest.Temperature, prometheus.GaugeValue, wetBulb, r.SerialNumber, "wetbulb"),
+			)
+		}
+
+		metrics = append(metrics,
 			prometheus.MustNewConstMetric(tempest.Humidity, prometheus.GaugeValue, ob[8], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.Illuminance, prometheus.GaugeValue, ob[9], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.UV, prometheus.GaugeValue, ob[10], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.Irradiance, prometheus.GaugeValue, ob[11], r.SerialNumber),
 			prometheus.MustNewConstMetric(tempest.RainRate, prometheus.GaugeValue, ob[12], r.SerialNumber),
-		}
+		)
 
 		// Lightning metrics (fields 14 and 15)
 		if len(ob) >= 16 {

--- a/internal/tempestudp/report.go
+++ b/internal/tempestudp/report.go
@@ -257,12 +257,21 @@ type HubStatusReport struct {
 }
 
 func (r HubStatusReport) Metrics() []prometheus.Metric {
-	return withTime(r.Timestamp, []prometheus.Metric{
+	metrics := []prometheus.Metric{
 		prometheus.MustNewConstMetric(tempest.Uptime, prometheus.CounterValue, r.Uptime, r.SerialNumber),
 		prometheus.MustNewConstMetric(tempest.Rssi, prometheus.GaugeValue, r.Rssi, r.SerialNumber),
-		prometheus.MustNewConstMetric(tempest.Reboots, prometheus.CounterValue, r.RadioStats[1], r.SerialNumber),
-		prometheus.MustNewConstMetric(tempest.BusErrors, prometheus.CounterValue, r.RadioStats[2], r.SerialNumber),
-	})
+	}
+
+	// radio_stats[1] and [2] (reboots, bus errors) are only present on a
+	// well-formed hub_status broadcast; a malformed/short array must not panic.
+	if len(r.RadioStats) >= 3 {
+		metrics = append(metrics,
+			prometheus.MustNewConstMetric(tempest.Reboots, prometheus.CounterValue, r.RadioStats[1], r.SerialNumber),
+			prometheus.MustNewConstMetric(tempest.BusErrors, prometheus.CounterValue, r.RadioStats[2], r.SerialNumber),
+		)
+	}
+
+	return withTime(r.Timestamp, metrics)
 }
 
 func withTime(unix int64, metrics []prometheus.Metric) []prometheus.Metric {

--- a/internal/tempestudp/report_test.go
+++ b/internal/tempestudp/report_test.go
@@ -142,6 +142,56 @@ func Test_hubStatusReport_Metrics(t *testing.T) {
 	})
 }
 
+func TestHubStatusReport_ShortRadioStats(t *testing.T) {
+	metricsTest(t, []metricsTestcase{
+		{
+			"empty",
+			`{"serial_number":"HB-00031344","type":"hub_status","firmware_revision":"171","uptime":64275,"rssi":-44,"timestamp":1688666650,"reset_flags":"BOR,PIN,POR","seq":6419,"fs":[1,0,15675411,524288],"radio_stats":[],"mqtt_stats":[1,4]}`,
+			"HB-00031344", 1688666650,
+			[]simpleMetric{
+				{
+					desc:  tempest.Uptime,
+					value: 64275,
+				},
+				{
+					desc:  tempest.Rssi,
+					value: -44,
+				},
+			},
+		},
+		{
+			"null",
+			`{"serial_number":"HB-00031344","type":"hub_status","firmware_revision":"171","uptime":64275,"rssi":-44,"timestamp":1688666650,"reset_flags":"BOR,PIN,POR","seq":6419,"fs":[1,0,15675411,524288],"radio_stats":null,"mqtt_stats":[1,4]}`,
+			"HB-00031344", 1688666650,
+			[]simpleMetric{
+				{
+					desc:  tempest.Uptime,
+					value: 64275,
+				},
+				{
+					desc:  tempest.Rssi,
+					value: -44,
+				},
+			},
+		},
+		{
+			"short",
+			`{"serial_number":"HB-00031344","type":"hub_status","firmware_revision":"171","uptime":64275,"rssi":-44,"timestamp":1688666650,"reset_flags":"BOR,PIN,POR","seq":6419,"fs":[1,0,15675411,524288],"radio_stats":[1],"mqtt_stats":[1,4]}`,
+			"HB-00031344", 1688666650,
+			[]simpleMetric{
+				{
+					desc:  tempest.Uptime,
+					value: 64275,
+				},
+				{
+					desc:  tempest.Rssi,
+					value: -44,
+				},
+			},
+		},
+	})
+}
+
 type simpleMetric struct {
 	desc   *prometheus.Desc
 	value  float64

--- a/internal/tempestudp/wetbulb.go
+++ b/internal/tempestudp/wetbulb.go
@@ -25,7 +25,7 @@ func WetBulbTemperatureC(temperatureC float64, humidityPercent float64, stationP
 	// matches the vapor pressure implied by the relative humidity
 	step := 8.0
 	wetBulbC := temperatureC - step*2
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		eWetBulb := wetBulbVaporPressure(temperatureC, wetBulbC, stationPressureHpa)
 
 		delta := eHumidity - eWetBulb
@@ -44,5 +44,7 @@ func WetBulbTemperatureC(temperatureC float64, humidityPercent float64, stationP
 		}
 		wetBulbC += step
 	}
-	panic("failed to converge")
+	// Non-convergent input (e.g. physically impossible humidity/pressure)
+	// — report unknown rather than panicking.
+	return math.NaN()
 }

--- a/internal/tempestudp/wetbulb_test.go
+++ b/internal/tempestudp/wetbulb_test.go
@@ -29,3 +29,19 @@ func TestWetBulbTemperatureC(t *testing.T) {
 		})
 	}
 }
+
+// TestWetBulb_NonConvergentReturnsNaN verifies that inputs which never
+// satisfy the convergence tolerance return NaN instead of panicking.
+//
+// humidityPercent = -500 is physically impossible (relative humidity cannot
+// be negative), but a malformed/corrupt UDP broadcast could still deliver an
+// out-of-range value here. It drives eHumidity strongly negative while
+// eWetBulb stays positive, so the search's overshoot-correction step shrinks
+// toward zero without ever bringing |delta| under the 0.001 tolerance within
+// 10000 iterations.
+func TestWetBulb_NonConvergentReturnsNaN(t *testing.T) {
+	got := WetBulbTemperatureC(25, -500, 900)
+	if !math.IsNaN(got) {
+		t.Errorf("WetBulbTemperatureC(25, -500, 900) = %v, want NaN", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,28 @@ func signalContext(parent context.Context, notify notifyFunc) (context.Context, 
 	return notify(parent, os.Interrupt, syscall.SIGTERM)
 }
 
+// Mode identifies which operational mode main is running in, since the
+// "at least one writer" invariant differs between them (see requireWriters).
+type Mode int
+
+const (
+	ModeUDP       Mode = iota // UDP listener (no TOKEN)
+	ModeAPIExport             // historical export (TOKEN set)
+)
+
+// requireWriters enforces the "at least one writer" invariant, but only where
+// it applies: UDP mode always needs a writer; API-export mode is satisfied by a
+// DB writer OR KEEP_EXPORT_FILES (fixes A-H2 — gzip-only export was unreachable).
+func requireWriters(mode Mode, writerCount int, keepFiles bool) error {
+	if writerCount > 0 {
+		return nil
+	}
+	if mode == ModeAPIExport && keepFiles {
+		return nil
+	}
+	return fmt.Errorf("no writers configured: set ENABLE_POSTGRES / ENABLE_OTEL / ENABLE_PROMETHEUS_* (or KEEP_EXPORT_FILES in API-export mode)")
+}
+
 func main() {
 	ctx, done := signalContext(context.Background(), signal.NotifyContext)
 	defer done()
@@ -109,9 +131,17 @@ func main() {
 		metricsSink.AddWriter(pgWriter)
 	}
 
-	// Require at least one writer
-	if metricsSink.WriterCount() == 0 {
-		log.Fatal("no writers configured - set ENABLE_PROMETHEUS_PUSHGATEWAY, ENABLE_PROMETHEUS_METRICS, and/or ENABLE_POSTGRES")
+	// Require at least one writer (relaxed for gzip-only API-export mode; see requireWriters)
+	mode := ModeUDP
+	if token != "" {
+		mode = ModeAPIExport
+	}
+	keepFiles, err := config.ParseBoolEnv("KEEP_EXPORT_FILES")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := requireWriters(mode, metricsSink.WriterCount(), keepFiles); err != nil {
+		log.Fatal(err)
 	}
 
 	// Choose operational mode
@@ -273,7 +303,7 @@ func writeMetricsToFile(filename string, metrics []promclient.Metric) error {
 	}
 
 	log.Printf("writing %s", filename)
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644) //nolint:gosec // file permissions and open flags (O_TRUNC) revisited in Task 0.11
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //nolint:gosec // G302/G304: 0o644 perms and export filename are intentional, not user-controlled in a way that risks traversal
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -78,12 +78,12 @@ func main() {
 	if token == "" {
 		enablePushgateway, err := config.ParseBoolEnv("ENABLE_PROMETHEUS_PUSHGATEWAY")
 		if err != nil {
-			log.Fatal(err) //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Task 0.8
+			log.Fatal(err) //nolint:gocritic // log.Fatal on a startup config error exits before any writer buffers data, so the skipped deferred sink Close is harmless
 		}
 		if enablePushgateway {
 			pushURL := os.Getenv("PROMETHEUS_PUSHGATEWAY_URL")
 			if pushURL == "" {
-				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true") //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Task 0.8
+				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true") //nolint:gocritic // log.Fatal on a startup config error exits before any writer buffers data, so the skipped deferred sink Close is harmless
 			}
 			jobName := os.Getenv("JOB_NAME")
 			if jobName == "" {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	// Initialize sink for both modes
 	metricsSink := sink.NewMetricsSink(ctx)
-	defer metricsSink.Close()
+	defer metricsSink.Close() //nolint:errcheck // Close signature/error handling revisited in Task 0.7 (sink Close(ctx) + error aggregation)
 
 	// Configure Prometheus writer (UDP mode only)
 	token := os.Getenv("TOKEN")
@@ -40,7 +40,7 @@ func main() {
 		if enablePushgateway {
 			pushURL := os.Getenv("PROMETHEUS_PUSHGATEWAY_URL")
 			if pushURL == "" {
-				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true")
+				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true") //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Tasks 0.7/0.8
 			}
 			jobName := os.Getenv("JOB_NAME")
 			if jobName == "" {
@@ -131,7 +131,7 @@ func listen(ctx context.Context, rx func([]byte, *net.UDPAddr) error) error {
 	if err != nil {
 		return err
 	}
-	defer sock.Close()
+	defer sock.Close() //nolint:errcheck // UDP listener teardown revisited under graceful shutdown in Task 0.8
 	log.Printf("listening on UDP :50222")
 
 	readErr := make(chan error, 1)
@@ -199,7 +199,7 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 				log.Printf("fetching %s starting %s", station.Name, cur.Format(time.RFC3339))
 				stationMetrics, err := client.GetObservations(ctx, station, cur, next)
 				if err != nil {
-					log.Fatalf("error fetching %#v for %d-%d: %v", station, cur.Unix(), next.Unix(), err)
+					log.Fatalf("error fetching %#v for %d-%d: %v", station, cur.Unix(), next.Unix(), err) //nolint:gosec // pre-existing: station/error data logged unsanitized; deferred as follow-up hardening, not owned by a current task
 				}
 				metrics = append(metrics, stationMetrics...)
 			}
@@ -210,7 +210,7 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 		}
 
 		// Send to sink (Postgres)
-		log.Printf("sending %d metrics to sink", len(metrics))
+		log.Printf("sending %d metrics to sink", len(metrics)) //nolint:gosec // pre-existing: logs a count derived from tainted input, not raw content; deferred as follow-up hardening, not owned by a current task
 		if err := metricsSink.SendMetrics(ctx, metrics); err != nil {
 			log.Printf("error sending metrics: %v", err)
 		}
@@ -240,14 +240,14 @@ func writeMetricsToFile(filename string, metrics []promclient.Metric) error {
 	}
 
 	log.Printf("writing %s", filename)
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644) //nolint:gosec // file permissions and open flags (O_TRUNC) revisited in Task 0.11
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck // Close handling for export writers revisited in Task 0.11
 
 	gzw := gzip.NewWriter(f)
-	defer gzw.Close()
+	defer gzw.Close() //nolint:errcheck // Close handling for export writers revisited in Task 0.11
 
 	enc := expfmt.NewEncoder(gzw, expfmt.NewFormat(expfmt.TypeTextPlain))
 	for _, family := range families {

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strconv"
 	"time"
 
 	"tempestwx-utilities/internal/config"
@@ -36,7 +35,10 @@ func main() {
 	// Configure Prometheus writer (UDP mode only)
 	token := os.Getenv("TOKEN")
 	if token == "" {
-		enablePushgateway, _ := strconv.ParseBool(os.Getenv("ENABLE_PROMETHEUS_PUSHGATEWAY"))
+		enablePushgateway, err := config.ParseBoolEnv("ENABLE_PROMETHEUS_PUSHGATEWAY")
+		if err != nil {
+			log.Fatal(err) //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Tasks 0.7/0.8
+		}
 		if enablePushgateway {
 			pushURL := os.Getenv("PROMETHEUS_PUSHGATEWAY_URL")
 			if pushURL == "" {
@@ -51,7 +53,10 @@ func main() {
 		}
 
 		// Configure Prometheus metrics server (scrape endpoint)
-		enableMetrics, _ := strconv.ParseBool(os.Getenv("ENABLE_PROMETHEUS_METRICS"))
+		enableMetrics, err := config.ParseBoolEnv("ENABLE_PROMETHEUS_METRICS")
+		if err != nil {
+			log.Fatal(err)
+		}
 		if enableMetrics {
 			port := os.Getenv("PROMETHEUS_METRICS_PORT")
 			if port == "" {
@@ -66,7 +71,10 @@ func main() {
 	}
 
 	// Configure Postgres writer (both modes)
-	enablePostgres, _ := strconv.ParseBool(os.Getenv("ENABLE_POSTGRES"))
+	enablePostgres, err := config.ParseBoolEnv("ENABLE_POSTGRES")
+	if err != nil {
+		log.Fatal(err)
+	}
 	if enablePostgres {
 		dbConfig, err := config.GetDatabaseConfig()
 		if err != nil {
@@ -96,7 +104,10 @@ func main() {
 }
 
 func listenAndPushWithSink(ctx context.Context, metricsSink *sink.MetricsSink) {
-	logUDP, _ := strconv.ParseBool(os.Getenv("LOG_UDP"))
+	logUDP, err := config.ParseBoolEnv("LOG_UDP")
+	if err != nil {
+		log.Fatal(err)
+	}
 	log.Printf("starting UDP listener mode")
 
 	if err := listen(ctx, func(b []byte, addr *net.UDPAddr) error {
@@ -184,7 +195,10 @@ func exportWithSink(ctx context.Context, token string, metricsSink *sink.Metrics
 		}
 	}
 
-	keepFiles, _ := strconv.ParseBool(os.Getenv("KEEP_EXPORT_FILES"))
+	keepFiles, err := config.ParseBoolEnv("KEEP_EXPORT_FILES")
+	if err != nil {
+		log.Fatal(err)
+	}
 	fileNum := 1
 
 	var next time.Time

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -29,20 +30,26 @@ func main() {
 	defer done()
 
 	// Initialize sink for both modes
-	metricsSink := sink.NewMetricsSink(ctx)
-	defer metricsSink.Close() //nolint:errcheck // Close signature/error handling revisited in Task 0.7 (sink Close(ctx) + error aggregation)
+	metricsSink := sink.NewMetricsSink()
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := metricsSink.Close(cleanupCtx); err != nil {
+			slog.Error("sink close", "err", err)
+		}
+	}()
 
 	// Configure Prometheus writer (UDP mode only)
 	token := os.Getenv("TOKEN")
 	if token == "" {
 		enablePushgateway, err := config.ParseBoolEnv("ENABLE_PROMETHEUS_PUSHGATEWAY")
 		if err != nil {
-			log.Fatal(err) //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Tasks 0.7/0.8
+			log.Fatal(err) //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Task 0.8
 		}
 		if enablePushgateway {
 			pushURL := os.Getenv("PROMETHEUS_PUSHGATEWAY_URL")
 			if pushURL == "" {
-				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true") //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Tasks 0.7/0.8
+				log.Fatal("PROMETHEUS_PUSHGATEWAY_URL is required when ENABLE_PROMETHEUS_PUSHGATEWAY is true") //nolint:gocritic // log.Fatal skipping the deferred sink Close is addressed by the graceful-shutdown rework in Task 0.8
 			}
 			jobName := os.Getenv("JOB_NAME")
 			if jobName == "" {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"tempestwx-utilities/internal/config"
@@ -25,8 +26,19 @@ import (
 
 // Old collector implementation removed - now using MetricsSink
 
+// notifyFunc matches signal.NotifyContext's signature so tests can inject a
+// fake and assert on the exact signal set without sending real signals.
+type notifyFunc func(parent context.Context, sig ...os.Signal) (context.Context, context.CancelFunc)
+
+// signalContext derives a context that is canceled on SIGINT or SIGTERM,
+// giving deferred cleanup (e.g. sink.Close, PostgresWriter.Close) a chance to
+// run on graceful shutdown (resolves A-H1: SIGTERM was not handled).
+func signalContext(parent context.Context, notify notifyFunc) (context.Context, context.CancelFunc) {
+	return notify(parent, os.Interrupt, syscall.SIGTERM)
+}
+
 func main() {
-	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, done := signalContext(context.Background(), signal.NotifyContext)
 	defer done()
 
 	// Initialize sink for both modes

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"os"
+	"slices"
+	"syscall"
+	"testing"
+)
+
+func TestSignalContext_RegistersInterruptAndSIGTERM(t *testing.T) {
+	var gotSigs []os.Signal
+	fakeNotify := func(parent context.Context, sig ...os.Signal) (context.Context, context.CancelFunc) {
+		gotSigs = sig
+		return context.WithCancel(parent)
+	}
+
+	_, cancel := signalContext(context.Background(), fakeNotify)
+	defer cancel()
+
+	// os.Signal(syscall.SIGTERM): slices.Contains infers E from both arguments;
+	// without this explicit conversion to the slice's element type, Go's generic
+	// type inference fails to unify os.Signal (interface, from gotSigs) with
+	// syscall.Signal (concrete, from syscall.SIGTERM) and the call doesn't compile.
+	if !slices.Contains(gotSigs, os.Interrupt) || !slices.Contains(gotSigs, os.Signal(syscall.SIGTERM)) {
+		t.Fatalf("signalContext must register SIGINT+SIGTERM, got %v", gotSigs)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -26,3 +26,27 @@ func TestSignalContext_RegistersInterruptAndSIGTERM(t *testing.T) {
 		t.Fatalf("signalContext must register SIGINT+SIGTERM, got %v", gotSigs)
 	}
 }
+
+func TestRequireWriters(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        Mode
+		writerCount int
+		keepFiles   bool
+		wantErr     bool
+	}{
+		{"udp no writers", ModeUDP, 0, false, true},
+		{"udp one writer", ModeUDP, 1, false, false},
+		{"api no writers no files", ModeAPIExport, 0, false, true},
+		{"api no writers keep files", ModeAPIExport, 0, true, false},
+		{"api db writer", ModeAPIExport, 1, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireWriters(tc.mode, tc.writerCount, tc.keepFiles)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("requireWriters(%v,%d,%v) err=%v want err=%v", tc.mode, tc.writerCount, tc.keepFiles, err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Workstream 0 — Foundation: lifecycle & review-fix bedrock

First workstream of the [Unified Weather Platform plan](docs/plans/2026-07-17-unified-weather-platform-implementation.md). W0 fixes the CRITICAL/HIGH lifecycle & correctness findings from the two source code reviews **before** any feature work, so later workstreams (embedded UI, radar, SQLite+Litestream, OTel, dashboard, UX) inherit correct shutdown, panic isolation, and context handling.

Executed task-by-task with TDD; each task per-task-reviewed, then the whole branch got an independent cold review by a senior Go engineer.

### Findings resolved

| Severity | Findings |
|---|---|
| **CRITICAL** | `C-1` — guard `RadioStats` index (remote panic on malformed `hub_status`) |
| **HIGH** | `B-HIGH` DSN credential escaping · `F-H1..H4` API-client hardening (bearer header, status check, timeout, no `log.Fatalf`) · `A-H1` SIGTERM handling · `A-H2` reachable gzip-only export · `A-H3`/`D-H2` metrics-server bind errors surface synchronously · `C-H1` drain buffered rows on shutdown · `C-H2` honor `POSTGRES_BATCH_SIZE`/`FLUSH_INTERVAL`/`MAX_RETRIES` · `C-H3`/`D-H1` idempotent panic-free `Close` (postgres **and** prometheus) · `G-H1`/`G-H3` CI/supply-chain (docker action inputs, least-privilege permissions, SHA-pinned actions, goreleaser, actionlint) |
| **MEDIUM** | `A-MEDIUM` fail-loud bool env parse · gzip `O_TRUNC` · sink panic recovery + `errors.Join` aggregation · `E-MEDIUM` wet-bulb returns `NaN` instead of panicking |

### Foundation lifecycle rework

- `MetricsWriter.Close(ctx)` interface change rippled to every implementer + call site (no stale callers).
- Both writers made shutdown-safe with a `done`-gate + `sync.Once` — send-on-closed is structurally eliminated; the postgres drain converts range-over-closed-channel → non-blocking `select`.
- Full shutdown path is `main` (30s cleanup ctx) → `sink.Close(ctx)` (per-writer panic recovery) → postgres (drain under live ctx) + prometheus (bounded push, no un-timeout'd network stall on a dead gateway).
- **Cross-task bug caught by the whole-branch review and fixed:** `rapid_wind`/`hub_status` in-flight local batches were dropped on SIGTERM because the batch workers flushed with `w.ctx` (= the already-canceled signal context). `Close` now stores the live cleanup ctx and is the single shutdown authority; a RED test proves in-flight rows survive a canceled `w.ctx`.

Preserved-correct code (UDP field-index mapping, wet-bulb Bolton math, the four SQL column mappings) is verified untouched.

### Verification
`go build ./...` · `go vet ./...` · `gofmt -l .` · `golangci-lint run ./...` (0 issues) · `go test -race ./...` — all clean across every package.

### Documented follow-ups (do not block W0)
- **Backpressure shared-fate** (by design): a Postgres DB outage that fills the 1000-buffer blocks the single UDP read goroutine and degrades the other sinks. The durable per-writer timeout bound is planned as **Task 3.3** (WS3).
- Minor carries tracked for later: pre-existing `isRetryable` both-branches-true; `GetObservations` envelope check; `ENABLE_OTEL` mentioned in an error string (activates in WS6); two orphan `main.go` gosec G706 `//nolint`s; retry-during-shutdown gates on `w.ctx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
