### PR TITLE
docs(readme): SQLite default store + correct stale env-var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,29 @@ Container Registry](https://github.com/jacaudi/tempestwx-utilities/pkgs/containe
 
 ```bash
 $ docker run -it --rm --net=host \
-  -e PUSH_URL=http://victoriametrics:8429/api/v1/import/prometheus \
+  -v tempest-data:/data \
   ghcr.io/jacaudi/tempestwx-utilities
 
-2023/07/06 20:18:55 pushing to "0.0.0.0" with job name "tempest"
-2023/07/06 20:18:55 listening on UDP :50222
+starting UDP listener mode
+listening on UDP :50222
 ```
+
+By default this persists observations to a local SQLite database at `/data/tempest.db`, so a writable `/data` is required (mounted above as a named volume). Prometheus and/or PostgreSQL outputs are opt-in — see [Exporter configuration](#exporter-configuration).
 
 Note that `--net=host` is used here because UDP broadcasts are link-local and therefore cannot be received from typical
 (routed) container networks.
 
 ## Exporter configuration
 
-Minimal, via environment variables:
+Via environment variables. SQLite is the default store (below); Prometheus and PostgreSQL are opt-in.
 
-* `PUSH_URL`: the URL of the [Prometheus Pushgateway](https://github.com/prometheus/pushgateway) or other [compatible
-  service](https://docs.victoriametrics.com/?highlight=exposition#how-to-import-data-in-prometheus-exposition-format)
+**Prometheus (optional)** — push and/or scrape:
 
-* `JOB_NAME`: the value for the `job` label, defaulting to `"tempest"`
+* `ENABLE_PROMETHEUS_PUSHGATEWAY`: set to `true`/`1` to push metrics to a [Pushgateway](https://github.com/prometheus/pushgateway) or [compatible service](https://docs.victoriametrics.com/?highlight=exposition#how-to-import-data-in-prometheus-exposition-format) (e.g. VictoriaMetrics)
+* `PROMETHEUS_PUSHGATEWAY_URL`: the Pushgateway URL (required when `ENABLE_PROMETHEUS_PUSHGATEWAY` is set)
+* `JOB_NAME`: the value for the `job` label (default: `"tempest"`)
+* `ENABLE_PROMETHEUS_METRICS`: set to `true`/`1` to expose a `/metrics` scrape endpoint
+* `PROMETHEUS_METRICS_PORT`: scrape endpoint port (default: `9000`)
 
 ### SQLite Storage (default)
 
@@ -43,12 +48,12 @@ In UDP mode the exporter persists observations to a local **SQLite** database by
 
 ### PostgreSQL Storage (Optional)
 
-The exporter can optionally write metrics to PostgreSQL in addition to (or instead of) Prometheus. Configure using either:
+The exporter can optionally write to PostgreSQL in addition to (or instead of) SQLite/Prometheus. Set `ENABLE_POSTGRES=true`/`1`, then configure using either:
 
-* `DATABASE_URL`: Full PostgreSQL connection string (e.g., `postgresql://user:pass@host:5432/dbname`)
-* Or individual components: `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_NAME`
+* `POSTGRES_URL`: Full PostgreSQL connection string (e.g., `postgresql://user:pass@host:5432/dbname`)
+* Or individual components: `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD`, `POSTGRES_NAME`, `POSTGRES_SSLMODE`
 
-When configured, the exporter automatically creates and maintains typed tables for observations, rapid wind data, hub status, and events.
+When enabled, the exporter automatically creates and maintains typed tables for observations, rapid wind data, hub status, and events.
 
 See `CLAUDE.md` for detailed configuration options and Docker Compose examples
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Multi-backend data utilities for [Tempest weather stations](https://weatherflow.com/tempest-home-weather-system/).
 
 This tool provides:
-- **UDP Mode**: Listens for [Tempest UDP broadcasts](https://weatherflow.github.io/Tempest/api/udp.html) and forwards to Prometheus push gateway and/or PostgreSQL
+- **UDP Mode**: Listens for [Tempest UDP broadcasts](https://weatherflow.github.io/Tempest/api/udp.html) and persists to a local **SQLite** database by default, with an optional Prometheus push gateway / scrape endpoint and/or PostgreSQL
 - **API Export Mode**: Fetches historical data via REST API and stores to PostgreSQL and/or compressed files
 
 ## Quickstart
@@ -31,6 +31,15 @@ Minimal, via environment variables:
   service](https://docs.victoriametrics.com/?highlight=exposition#how-to-import-data-in-prometheus-exposition-format)
 
 * `JOB_NAME`: the value for the `job` label, defaulting to `"tempest"`
+
+### SQLite Storage (default)
+
+In UDP mode the exporter persists observations to a local **SQLite** database by default (pure-Go `modernc.org/sqlite`, no CGO), in WAL mode suited to [Litestream](https://litestream.io/) streaming backup.
+
+* `SQLITE_PATH`: path to the database file (default: `/data/tempest.db`)
+* Optional tuning: `SQLITE_BATCH_SIZE` (default `100`), `SQLITE_FLUSH_INTERVAL` (default `10s`), `SQLITE_BUSY_TIMEOUT` in ms (default `5000`)
+
+`/data` must be a writable mount — if the database cannot be opened, the process exits on startup. Set `ENABLE_POSTGRES=true` to use PostgreSQL instead; both can run together (fan-out). SQLite is not written in API-export mode. See `CLAUDE.md` for the full schema and a Litestream sidecar example.
 
 ### PostgreSQL Storage (Optional)
 


### PR DESCRIPTION
## README refresh for the SQLite-default store (+ stale env-var fixes)

Follow-up to Workstream 3 (#53), which made **SQLite + Litestream the default store** but left the root `README.md` describing storage as only "Prometheus push gateway and/or PostgreSQL".

**Changes:**
1. **SQLite as default** — updated the UDP-mode summary and added a **SQLite Storage (default)** section (`SQLITE_PATH` + `SQLITE_*` tunables, the writable-`/data` requirement, `ENABLE_POSTGRES` opt-in), mirroring `CLAUDE.md`.
2. **Corrected stale env-var names** (pre-existing bugs — the code never read the documented names; verified against the `os.Getenv` call sites):
   - Pushgateway: `PUSH_URL` → `ENABLE_PROMETHEUS_PUSHGATEWAY` + `PROMETHEUS_PUSHGATEWAY_URL`; also documented the `ENABLE_PROMETHEUS_METRICS` scrape endpoint + `PROMETHEUS_METRICS_PORT`.
   - PostgreSQL: `DATABASE_URL` / `DATABASE_*` → `ENABLE_POSTGRES` + `POSTGRES_URL` / `POSTGRES_*`.
3. **Refreshed the Quickstart** — the old example used the non-working `PUSH_URL` and fabricated 2023 log output. Replaced with a working SQLite-default run (named `/data` volume) and the **actual** startup output captured from the built binary.

Docs-only; no code change.

> Note: running the binary during this work surfaced a real code bug (the SQLite driver was registered only in test files, so the default store was dead in the shipped binary) — fixed separately in #55, which should merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
