### PR TITLE
fix(sqlite): register modernc driver in production (default store was dead in the binary)

### DIFF
--- a/internal/sqlite/db.go
+++ b/internal/sqlite/db.go
@@ -6,6 +6,13 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	// Register the pure-Go SQLite driver (CGO-free) under the name "sqlite".
+	// This blank import MUST live in production code, not only in _test.go
+	// files: without it the compiled binary panics at runtime with
+	// `sql: unknown driver "sqlite"` even though tests pass (test files can
+	// register it themselves). Do not remove.
+	_ "modernc.org/sqlite"
 )
 
 const driverName = "sqlite" // modernc.org/sqlite registers this name

--- a/internal/sqlite/db_test.go
+++ b/internal/sqlite/db_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	_ "modernc.org/sqlite"
 )
 
 func TestOpen_SetsPragmas(t *testing.T) {

--- a/internal/sqlite/litestream_test.go
+++ b/internal/sqlite/litestream_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"tempestwx-utilities/internal/tempestudp"
-
-	_ "modernc.org/sqlite"
 )
 
 // selectAllObservationsSQL mirrors selectLatestObservationSQL's column list

--- a/internal/sqlite/schema_test.go
+++ b/internal/sqlite/schema_test.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
-
-	_ "modernc.org/sqlite"
 )
 
 func TestMigrate_CreatesTablesAndVersion(t *testing.T) {

--- a/internal/sqlite/writer_test.go
+++ b/internal/sqlite/writer_test.go
@@ -10,7 +10,6 @@ import (
 	"tempestwx-utilities/internal/tempestudp"
 
 	"github.com/google/uuid"
-	_ "modernc.org/sqlite"
 )
 
 // newTestDB opens a fresh, migrated SQLite DB in a t.TempDir() for use by


### PR DESCRIPTION
## Critical: SQLite (the default store) was dead in the shipped binary

**Symptom (real binary, not tests):**
```
failed to open sqlite: open sqlite: sql: unknown driver "sqlite" (forgotten import?)
```

**Root cause:** the `modernc.org/sqlite` driver registers via a blank-import side effect, but that blank import existed **only** in the package's `_test.go` files — never in production code. So the compiled binary had no `"sqlite"` driver registered, and `sqlite.Open` fatally failed at startup. Since WS3 (#53) made SQLite the **default** store, the shipped binary could not persist any UDP data.

**Why every check stayed green** — nothing ran the binary:
- `go build ./...` links fine (registration is a runtime concern, not a compile one).
- `go test` passed because the test files registered the driver via *their own* blank imports.
- The gate ran build + `go test -race` + lint — none exercise the binary's `sql.Open("sqlite")` path.

**Fix:**
- Add the blank import to production `internal/sqlite/db.go` (with a "do not remove" comment).
- **Remove** the now-redundant blank imports from the four `package sqlite` `_test.go` files, so the tests rely on the production registration. Removing them first reproduced the exact failure (`unknown driver`) across the suite — the tests now **guard** this regression instead of masking it.

**Verification (the step that was missing):** built and actually ran the binary — it starts, opens the DB, runs migrations (all four tables + `schema_version` created), and reaches `listening on UDP :50222` with no driver error. Full gate green: `CGO_ENABLED=0 go build`, `go vet`, `gofmt -l`, `golangci-lint`, `go test -race ./...`.

Follows #53. Recommend merging ahead of the docs PR (#54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
