### PR TITLE
feat: Workstream 4 — Grafana "Weather Nerd" dashboard + OTel→Prometheus name-translation test (§13, Contract B)

### DIFF
--- a/deploy/grafana/dashboards/weather-nerd.json
+++ b/deploy/grafana/dashboards/weather-nerd.json
@@ -1,0 +1,425 @@
+{
+  "uid": "tempest-weather-nerd",
+  "title": "Weather Nerd",
+  "tags": ["tempest", "weather"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "serial",
+        "type": "query",
+        "label": "Station",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "tempest-prometheus"
+        },
+        "query": "label_values(tempest_temperature_c, serial)",
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Current conditions",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 101,
+      "type": "stat",
+      "title": "Temperature",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_temperature_c{kind=\"air\", serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "stat",
+      "title": "Dew Point",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_dewpoint_c{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 103,
+      "type": "stat",
+      "title": "Heat Index",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_heat_index_c{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 104,
+      "type": "stat",
+      "title": "Wet Bulb",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_wetbulb_c{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 105,
+      "type": "stat",
+      "title": "Humidity",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_humidity_percent{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 106,
+      "type": "stat",
+      "title": "Pressure",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "pressurembar" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_pressure_mb{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 107,
+      "type": "stat",
+      "title": "Wind (avg / gust)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "velocityms" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}", "legendFormat": "avg" },
+        { "refId": "B", "expr": "tempest_wind_meters_per_second{kind=\"gust\", serial=\"$serial\"}", "legendFormat": "gust" }
+      ]
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Trends (24h)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "panels": []
+    },
+    {
+      "id": 201,
+      "type": "timeseries",
+      "title": "Temperature vs Dew Point vs Wet Bulb",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_temperature_c{kind=\"air\", serial=\"$serial\"}", "legendFormat": "temperature" },
+        { "refId": "B", "expr": "tempest_dewpoint_c{serial=\"$serial\"}", "legendFormat": "dew point" },
+        { "refId": "C", "expr": "tempest_wetbulb_c{serial=\"$serial\"}", "legendFormat": "wet bulb" }
+      ]
+    },
+    {
+      "id": 202,
+      "type": "timeseries",
+      "title": "Pressure Tendency",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "pressurembar" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_pressure_mb{serial=\"$serial\"}", "legendFormat": "pressure" },
+        { "refId": "B", "expr": "deriv(tempest_pressure_mb{serial=\"$serial\"}[3h])", "legendFormat": "tendency (mb/3h)" }
+      ]
+    },
+    {
+      "id": 203,
+      "type": "timeseries",
+      "title": "Humidity Trend",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_humidity_percent{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "Wind",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "panels": []
+    },
+    {
+      "id": 301,
+      "type": "heatmap",
+      "title": "Wind Rose (direction vs speed)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "targets": [
+        { "refId": "A", "expr": "tempest_wind_direction_degrees{serial=\"$serial\"}", "legendFormat": "direction" },
+        { "refId": "B", "expr": "tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}", "legendFormat": "speed" }
+      ]
+    },
+    {
+      "id": 302,
+      "type": "timeseries",
+      "title": "Gust Factor",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_wind_meters_per_second{kind=\"gust\", serial=\"$serial\"} / tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "Rain",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "panels": []
+    },
+    {
+      "id": 401,
+      "type": "timeseries",
+      "title": "Rain Rate",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "velocitymms" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_rain_rate_mm_min{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 402,
+      "type": "timeseries",
+      "title": "Rain Accumulation (24h)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "lengthmm" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "increase(tempest_rainfall_mm_total{serial=\"$serial\"}[24h])" }
+      ]
+    },
+    {
+      "id": 500,
+      "type": "row",
+      "title": "Lightning",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "panels": []
+    },
+    {
+      "id": 501,
+      "type": "timeseries",
+      "title": "Strike Rate (1h)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "increase(tempest_lightning_strike_count_total{serial=\"$serial\"}[1h])" }
+      ]
+    },
+    {
+      "id": 502,
+      "type": "stat",
+      "title": "Nearest Strike Distance (1h)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "lengthkm" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "min_over_time(tempest_lightning_distance_km{serial=\"$serial\"}[1h])" }
+      ]
+    },
+    {
+      "id": 600,
+      "type": "row",
+      "title": "Solar / UV",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "panels": []
+    },
+    {
+      "id": 601,
+      "type": "stat",
+      "title": "UV Index",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 42 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_uv_index{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 602,
+      "type": "stat",
+      "title": "Solar Irradiance",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 42 },
+      "fieldConfig": { "defaults": { "unit": "watt" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_irradiance_w_m2{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 603,
+      "type": "stat",
+      "title": "Illuminance",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 42 },
+      "fieldConfig": { "defaults": { "unit": "lux" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_illuminance_lux{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 700,
+      "type": "row",
+      "title": "Station health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 },
+      "panels": []
+    },
+    {
+      "id": 701,
+      "type": "stat",
+      "title": "Battery",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 47 },
+      "fieldConfig": { "defaults": { "unit": "volt" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_battery_volts{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 702,
+      "type": "stat",
+      "title": "RSSI",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 47 },
+      "fieldConfig": { "defaults": { "unit": "dBm" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_rssi_dbm{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 703,
+      "type": "stat",
+      "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 10, "y": 47 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "tempest_uptime_seconds{serial=\"$serial\"}" }
+      ]
+    },
+    {
+      "id": 704,
+      "type": "stat",
+      "title": "Reboots (24h)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 15, "y": 47 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "increase(tempest_reboots_total{serial=\"$serial\"}[24h])" }
+      ]
+    },
+    {
+      "id": 705,
+      "type": "stat",
+      "title": "Bus Errors (24h)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 47 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "increase(tempest_bus_errors_total{serial=\"$serial\"}[24h])" }
+      ]
+    },
+    {
+      "id": 800,
+      "type": "row",
+      "title": "Records / Almanac",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "panels": []
+    },
+    {
+      "id": 801,
+      "type": "stat",
+      "title": "High Temp ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "max_over_time(tempest_temperature_c{kind=\"air\", serial=\"$serial\"}[$__range])" }
+      ]
+    },
+    {
+      "id": 802,
+      "type": "stat",
+      "title": "Low Temp ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "celsius" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "min_over_time(tempest_temperature_c{kind=\"air\", serial=\"$serial\"}[$__range])" }
+      ]
+    },
+    {
+      "id": 803,
+      "type": "stat",
+      "title": "Peak Gust ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "velocityms" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "max_over_time(tempest_wind_meters_per_second{kind=\"gust\", serial=\"$serial\"}[$__range])" }
+      ]
+    },
+    {
+      "id": 804,
+      "type": "stat",
+      "title": "Max UV ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "max_over_time(tempest_uv_index{serial=\"$serial\"}[$__range])" }
+      ]
+    },
+    {
+      "id": 805,
+      "type": "stat",
+      "title": "Total Rain ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "lengthmm" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "increase(tempest_rainfall_mm_total{serial=\"$serial\"}[$__range])" }
+      ]
+    },
+    {
+      "id": 806,
+      "type": "stat",
+      "title": "Closest Lightning ($__range)",
+      "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 52 },
+      "fieldConfig": { "defaults": { "unit": "lengthkm" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "min_over_time(tempest_lightning_distance_km{serial=\"$serial\"}[$__range])" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/weather-nerd.json
+++ b/deploy/grafana/dashboards/weather-nerd.json
@@ -145,7 +145,7 @@
       "fieldConfig": { "defaults": { "unit": "pressurembar" }, "overrides": [] },
       "targets": [
         { "refId": "A", "expr": "tempest_pressure_mb{serial=\"$serial\"}", "legendFormat": "pressure" },
-        { "refId": "B", "expr": "deriv(tempest_pressure_mb{serial=\"$serial\"}[3h])", "legendFormat": "tendency (mb/3h)" }
+        { "refId": "B", "expr": "deriv(tempest_pressure_mb{serial=\"$serial\"}[3h]) * 10800", "legendFormat": "tendency (mb/3h)" }
       ]
     },
     {
@@ -185,7 +185,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
       "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
       "targets": [
-        { "refId": "A", "expr": "tempest_wind_meters_per_second{kind=\"gust\", serial=\"$serial\"} / tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}" }
+        { "refId": "A", "expr": "tempest_wind_meters_per_second{kind=\"gust\", serial=\"$serial\"} / ignoring(kind) tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}" }
       ]
     },
     {

--- a/deploy/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: tempest
+    orgId: 1
+    folder: Tempest
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      # Container path where the dashboards/ directory (this repo's
+      # deploy/grafana/dashboards) is mounted inside the Grafana image.
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/grafana/provisioning/datasources/prometheus.yaml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: tempest-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/grafana/validate_test.go
+++ b/deploy/grafana/validate_test.go
@@ -1,0 +1,168 @@
+// Package grafana validates the provisioned "Weather Nerd" dashboard JSON
+// against Contract B (design §13 / the OTel writer's exact tempest_* metric
+// names). It has no runtime dependency on the dashboard — it is a static
+// guard so the JSON can never silently drift from the metric names the
+// collector actually emits.
+package grafana
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"slices"
+	"testing"
+)
+
+// contractBMetrics is the authoritative set of tempest_* metric names the
+// OTel writer emits (Contract B, right column; mirrors design §13 and
+// internal/otel/promnames_test.go from Task 4.1). Any token extracted from a
+// panel's PromQL expr that starts with "tempest_" and is not in this set is
+// a defect: the dashboard is referencing a metric name the exporter does not
+// produce.
+var contractBMetrics = []string{
+	"tempest_temperature_c",
+	"tempest_dewpoint_c",
+	"tempest_heat_index_c",
+	"tempest_wetbulb_c",
+	"tempest_humidity_percent",
+	"tempest_pressure_mb",
+	"tempest_wind_meters_per_second",
+	"tempest_wind_direction_degrees",
+	"tempest_uv_index",
+	"tempest_irradiance_w_m2",
+	"tempest_illuminance_lux",
+	"tempest_rain_rate_mm_min",
+	"tempest_rainfall_mm_total",
+	"tempest_lightning_distance_km",
+	"tempest_lightning_strike_count_total",
+	"tempest_battery_volts",
+	"tempest_rssi_dbm",
+	"tempest_uptime_seconds",
+	"tempest_reboots_total",
+	"tempest_bus_errors_total",
+}
+
+// tempestTokenRE extracts every tempest_* identifier from a PromQL expr.
+var tempestTokenRE = regexp.MustCompile(`tempest_[a-z0-9_]+`)
+
+// dashboard is a deliberately loose model of the Grafana dashboard JSON
+// schema: only the fields the validator needs to inspect.
+type dashboard struct {
+	Panels     []panel `json:"panels"`
+	Templating struct {
+		List []templateVar `json:"list"`
+	} `json:"templating"`
+}
+
+// panel models a single Grafana panel. Panels may nest (Grafana row-type
+// panels carry their child panels in their own "panels" array when
+// collapsed), so the walker recurses into Panels wherever present.
+type panel struct {
+	Title   string   `json:"title"`
+	Type    string   `json:"type"`
+	Targets []target `json:"targets"`
+	Panels  []panel  `json:"panels"`
+}
+
+type target struct {
+	Expr  string `json:"expr"`
+	RefID string `json:"refId"`
+}
+
+type templateVar struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+const dashboardPath = "dashboards/weather-nerd.json"
+
+func loadDashboard(t *testing.T) dashboard {
+	t.Helper()
+	raw, err := os.ReadFile(dashboardPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dashboardPath, err)
+	}
+	var d dashboard
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatalf("unmarshaling %s: %v", dashboardPath, err)
+	}
+	return d
+}
+
+// walkPanels calls fn for every panel in the tree, including panels nested
+// inside row-type panels.
+func walkPanels(panels []panel, fn func(panel)) {
+	for _, p := range panels {
+		fn(p)
+		if len(p.Panels) > 0 {
+			walkPanels(p.Panels, fn)
+		}
+	}
+}
+
+// TestDashboardExprsReferenceOnlyContractBMetrics walks every panel's
+// targets and asserts every tempest_* token extracted from expr is a member
+// of Contract B. A metric name outside the set means the dashboard queries a
+// series the exporter never produces.
+func TestDashboardExprsReferenceOnlyContractBMetrics(t *testing.T) {
+	d := loadDashboard(t)
+
+	found := false
+	walkPanels(d.Panels, func(p panel) {
+		for _, tgt := range p.Targets {
+			if tgt.Expr == "" {
+				continue
+			}
+			for _, tok := range tempestTokenRE.FindAllString(tgt.Expr, -1) {
+				found = true
+				if !slices.Contains(contractBMetrics, tok) {
+					t.Errorf("panel %q (target %s): expr references metric %q, which is not in Contract B\n  expr: %s",
+						p.Title, tgt.RefID, tok, tgt.Expr)
+				}
+			}
+		}
+	})
+
+	if !found {
+		t.Fatal("no tempest_* metric tokens found in any panel expr — dashboard has no queries")
+	}
+}
+
+// TestSerialTemplateVariableExists asserts the $serial template variable is
+// defined as a query variable, per design §13.
+func TestSerialTemplateVariableExists(t *testing.T) {
+	d := loadDashboard(t)
+
+	for _, v := range d.Templating.List {
+		if v.Name == "serial" && v.Type == "query" {
+			return
+		}
+	}
+	t.Fatal(`templating.list does not contain a "serial" query variable`)
+}
+
+// TestRangeBuiltinUsedInPanelExpr asserts $__range (Grafana's built-in
+// dashboard-range global — it must NOT appear in templating.list as a
+// defined variable) is actually referenced by at least one panel expr, per
+// the Row 8 records/almanac panels in design §13.
+func TestRangeBuiltinUsedInPanelExpr(t *testing.T) {
+	d := loadDashboard(t)
+
+	for _, v := range d.Templating.List {
+		if v.Name == "__range" {
+			t.Fatal(`"__range" must not be a defined templating.list variable — it is a Grafana built-in`)
+		}
+	}
+
+	used := false
+	walkPanels(d.Panels, func(p panel) {
+		for _, tgt := range p.Targets {
+			if regexp.MustCompile(`\$__range\b`).MatchString(tgt.Expr) {
+				used = true
+			}
+		}
+	})
+	if !used {
+		t.Fatal("no panel expr references $__range — expected the Row 8 records/almanac panels to use it")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.9.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.33.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.55.0
 	go.opentelemetry.io/otel/log v0.9.0
 	go.opentelemetry.io/otel/metric v1.33.0
 	go.opentelemetry.io/otel/sdk v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 h1:Vh5HayB/0HHfOQA7Ctx
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 h1:5pojmb1U1AogINhN3SurB+zm/nIcusopeBNp42f45QM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0/go.mod h1:57gTHJSE5S1tqg+EKsLPlTWhpHMsWlVmer+LA926XiA=
+go.opentelemetry.io/otel/exporters/prometheus v0.55.0 h1:sSPw658Lk2NWAv74lkD3B/RSDb+xRFx46GjkrL3VUZo=
+go.opentelemetry.io/otel/exporters/prometheus v0.55.0/go.mod h1:nC00vyCmQixoeaxF6KNyP42II/RHa9UdruK02qBmHvI=
 go.opentelemetry.io/otel/log v0.9.0 h1:0OiWRefqJ2QszpCiqwGO0u9ajMPe17q6IscQvvp3czY=
 go.opentelemetry.io/otel/log v0.9.0/go.mod h1:WPP4OJ+RBkQ416jrFCQFuFKtXKD6mOoYCQm6ykK8VaU=
 go.opentelemetry.io/otel/metric v1.33.0 h1:r+JOocAyeRVXD8lZpjdQjzMadVZp2M4WmQ+5WtEnklQ=

--- a/internal/otel/promnames_test.go
+++ b/internal/otel/promnames_test.go
@@ -95,6 +95,11 @@ func TestPrometheusExporterEmitsContractBNames(t *testing.T) {
 	// comment names exactly this use ("a temporary assignment to LegacyValidation... to aid
 	// in debugging unforeseen results of the [UTF8Validation] change") — this test needs the
 	// legacy scheme to reproduce a production Collector's default translation.
+	// Production counterpart: DOC.1 (the OTel Collector config) must enable
+	// legacy/underscore naming for its prometheusexporter. This override only
+	// proves the instrument names are correct — it does not prove that a
+	// default-configured Collector would emit these underscored names on its
+	// own; that behavior is DOC.1's responsibility, not this test's.
 	prevScheme := model.NameValidationScheme
 	model.NameValidationScheme = model.LegacyValidation           //nolint:staticcheck // see above
 	t.Cleanup(func() { model.NameValidationScheme = prevScheme }) //nolint:staticcheck // see above
@@ -167,6 +172,10 @@ var oldNames = []string{
 // per-instrument by writer_test.go's "instance" absence checks — no need to
 // duplicate that assertion here.
 func TestMetricMigrationList(t *testing.T) {
+	// Count-only guard: catches an add/remove drift in metrics.go, but not a
+	// same-count rename. Acceptable here because metrics.go is the frozen
+	// legacy contract being replaced, not a list this test needs to track
+	// element-for-element going forward.
 	if len(oldNames) != len(tempest.All) {
 		t.Fatalf("oldNames has %d entries but tempest.All has %d — a descriptor was added/removed in metrics.go without updating this test's oldNames list", len(oldNames), len(tempest.All))
 	}

--- a/internal/otel/promnames_test.go
+++ b/internal/otel/promnames_test.go
@@ -1,0 +1,236 @@
+package otel
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"tempestwx-utilities/internal/tempest"
+	"tempestwx-utilities/internal/tempestudp"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// contractBNames is Contract B's right column: the exact tempest_* Prometheus
+// family names the OTel writer's instruments must translate to via the real
+// Collector (and, per this test, the real in-process otelprom exporter).
+// Both tests below share this literal — it's the same knowledge (the target
+// contract), so it lives in one place rather than two copies that could
+// drift apart.
+var contractBNames = []string{
+	"tempest_temperature_c", "tempest_dewpoint_c", "tempest_heat_index_c",
+	"tempest_wetbulb_c", "tempest_humidity_percent", "tempest_pressure_mb",
+	"tempest_wind_meters_per_second", "tempest_wind_direction_degrees",
+	"tempest_uv_index", "tempest_irradiance_w_m2", "tempest_illuminance_lux",
+	"tempest_rain_rate_mm_min", "tempest_rainfall_mm_total",
+	"tempest_lightning_distance_km", "tempest_lightning_strike_count_total",
+	"tempest_battery_volts", "tempest_rssi_dbm", "tempest_uptime_seconds",
+	"tempest_reboots_total", "tempest_bus_errors_total",
+}
+
+// fullSampleReport returns a TempestObservationReport with physically valid
+// field values (temp ~20C, RH ~60%, pressure ~1013mb) so the finite-only
+// derived gauges (dewpoint, heat_index, wetbulb — see writer.go's
+// isNonFinite guards) actually emit a data point, in addition to every other
+// obs-derived instrument.
+func fullSampleReport() *tempestudp.TempestObservationReport {
+	return &tempestudp.TempestObservationReport{
+		SerialNumber: "SAMPLE-001",
+		Obs: [][]float64{
+			{
+				0,       // 0 time epoch
+				1.5,     // 1 wind lull
+				2.5,     // 2 wind avg
+				3.5,     // 3 wind gust
+				180,     // 4 wind direction
+				60,      // 5 wind sample interval
+				1013.25, // 6 station pressure mb
+				20,      // 7 air temp C
+				60,      // 8 humidity %
+				1000,    // 9 illuminance lux
+				5,       // 10 uv index
+				400,     // 11 irradiance w/m2
+				0.2,     // 12 rain amount mm (previous minute)
+				0,       // 13 precip type
+				2.0,     // 14 lightning distance km
+				3,       // 15 lightning strike count
+				2.75,    // 16 battery volts
+				1,       // 17 report interval minutes
+			},
+		},
+	}
+}
+
+// fullSampleHubStatusReport returns a HubStatusReport with RadioStats long
+// enough (len >= 3) to populate the reboots/bus_errors ObservableCounters,
+// plus Uptime/Rssi, so the 4 hub-status-only instruments are populated.
+func fullSampleHubStatusReport() *tempestudp.HubStatusReport {
+	return &tempestudp.HubStatusReport{
+		SerialNumber: "SAMPLE-001",
+		Uptime:       12345,
+		Rssi:         -60,
+		RadioStats:   []float64{1, 4, 2},
+	}
+}
+
+// TestPrometheusExporterEmitsContractBNames drives the OTel writer through
+// the REAL in-process Prometheus exporter (go.opentelemetry.io/otel/exporters/prometheus),
+// which performs the exact OTLP->Prometheus normalization the Collector uses
+// (dotted->underscore, unit suffixes, _total for monotonic counters).
+// Gathering the registry and asserting the emitted family names is a genuine
+// translation check — not a comparison of two hand-written maps.
+func TestPrometheusExporterEmitsContractBNames(t *testing.T) {
+	// The otelprom exporter's dot->underscore sanitization is gated on the
+	// prometheus/common package-level model.NameValidationScheme, which
+	// defaults to UTF8Validation (the pinned github.com/prometheus/common
+	// version supports UTF-8 metric names and skips legacy sanitization by
+	// default). A production Collector's prometheusexporter must be run in
+	// legacy (underscore) naming mode to reproduce Contract B's tempest_*
+	// names, so this test forces that same mode to genuinely exercise the
+	// translation Contract B depends on, restoring the prior value after.
+	//nolint:staticcheck // SA1019: model.NameValidationScheme is deprecated but its own doc
+	// comment names exactly this use ("a temporary assignment to LegacyValidation... to aid
+	// in debugging unforeseen results of the [UTF8Validation] change") — this test needs the
+	// legacy scheme to reproduce a production Collector's default translation.
+	prevScheme := model.NameValidationScheme
+	model.NameValidationScheme = model.LegacyValidation           //nolint:staticcheck // see above
+	t.Cleanup(func() { model.NameValidationScheme = prevScheme }) //nolint:staticcheck // see above
+
+	reg := prom.NewRegistry()
+	exporter, err := otelprom.New(otelprom.WithRegisterer(reg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+
+	w, err := NewWriter(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+	// Two reports are required: the observation report emits the 16
+	// obs-derived families; the hub-status report emits the remaining 4
+	// (uptime, rssi, reboots, bus_errors) — see handleHubStatusReport.
+	if err := w.WriteReport(ctx, fullSampleReport()); err != nil {
+		t.Fatalf("WriteReport(observation) returned unexpected error: %v", err)
+	}
+	if err := w.WriteReport(ctx, fullSampleHubStatusReport()); err != nil {
+		t.Fatalf("WriteReport(hub status) returned unexpected error: %v", err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, mf := range mfs {
+		got[mf.GetName()] = true
+	}
+
+	for _, n := range contractBNames {
+		if !got[n] {
+			t.Errorf("missing Prometheus metric %q (got %v)", n, slices.Sorted(maps.Keys(got)))
+		}
+	}
+	// Negative guards: the OLD names must NOT appear (the intended breaks).
+	for _, old := range []string{"tempest_wind_ms", "tempest_uptime_seconds_total", "tempest_rainfall_total"} {
+		if got[old] {
+			t.Errorf("stale metric name %q still emitted", old)
+		}
+	}
+}
+
+// oldNames is the CURRENT descriptor set in internal/tempest/metrics.go
+// (Contract B's left column) as of this task. *prometheus.Desc has no
+// exported name accessor, so this mirrors metrics.go's fqName literals
+// directly rather than parsing its unexported internals; the length check
+// in TestMetricMigrationList below guards against this list silently going
+// stale if a descriptor is added to or removed from tempest.All.
+var oldNames = []string{
+	"tempest_uptime_seconds_total", "tempest_rssi_dbm", "tempest_reboots_total",
+	"tempest_bus_errors_total", "tempest_illuminance_lux", "tempest_uv_index",
+	"tempest_rain_rate_mm_min", "tempest_wind_ms", "tempest_wind_direction_degrees",
+	"tempest_battery_volts", "tempest_report_interval_minutes", "tempest_irradiance_w_m2",
+	"tempest_rainfall_total", "tempest_pressure_mb", "tempest_temperature_c",
+	"tempest_humidity_percent", "tempest_lightning_distance_km", "tempest_lightning_strike_count",
+}
+
+// TestMetricMigrationList diffs Contract B's right column (contractBNames)
+// against the CURRENT descriptor names in internal/tempest/metrics.go
+// (oldNames) and asserts the diff is EXACTLY the documented break set:
+// 4 renames, 1 drop, 3 adds, plus the (not name-diffable) instance->serial
+// label rename, which is logged here for DOC.2 but already asserted
+// per-instrument by writer_test.go's "instance" absence checks — no need to
+// duplicate that assertion here.
+func TestMetricMigrationList(t *testing.T) {
+	if len(oldNames) != len(tempest.All) {
+		t.Fatalf("oldNames has %d entries but tempest.All has %d — a descriptor was added/removed in metrics.go without updating this test's oldNames list", len(oldNames), len(tempest.All))
+	}
+
+	renamed := map[string]string{
+		"tempest_wind_ms":                "tempest_wind_meters_per_second",
+		"tempest_uptime_seconds_total":   "tempest_uptime_seconds",
+		"tempest_rainfall_total":         "tempest_rainfall_mm_total",
+		"tempest_lightning_strike_count": "tempest_lightning_strike_count_total",
+	}
+	dropped := map[string]bool{
+		"tempest_report_interval_minutes": true,
+	}
+	added := map[string]bool{
+		"tempest_dewpoint_c":   true,
+		"tempest_heat_index_c": true,
+		"tempest_wetbulb_c":    true,
+	}
+
+	oldSet := map[string]bool{}
+	for _, n := range oldNames {
+		oldSet[n] = true
+	}
+	newSet := map[string]bool{}
+	for _, n := range contractBNames {
+		newSet[n] = true
+	}
+
+	// Every old name must be explained: unchanged (present in both sets),
+	// a documented rename source, or a documented drop.
+	for _, old := range oldNames {
+		switch {
+		case newSet[old]:
+			// unchanged
+		case renamed[old] != "":
+			if !newSet[renamed[old]] {
+				t.Errorf("renamed[%q] = %q, but %q is not in Contract B", old, renamed[old], renamed[old])
+			}
+		case dropped[old]:
+			// documented drop
+		default:
+			t.Errorf("old name %q changed but is not in the documented rename/drop set", old)
+		}
+	}
+
+	// Every new name must be explained: unchanged, a documented rename
+	// target, or a documented addition.
+	renameTargets := map[string]bool{}
+	for _, to := range renamed {
+		renameTargets[to] = true
+	}
+	for _, n := range contractBNames {
+		switch {
+		case oldSet[n]:
+			// unchanged
+		case renameTargets[n]:
+			// documented rename target
+		case added[n]:
+			// documented addition
+		default:
+			t.Errorf("new name %q is not in the old set and is not a documented rename target or addition", n)
+		}
+	}
+
+	t.Logf("metric migration (Contract B): renamed=%v dropped=%v added=%v", renamed, slices.Sorted(maps.Keys(dropped)), slices.Sorted(maps.Keys(added)))
+	t.Log(`label migration: the "instance" label (every old descriptor's sole/shared variable label) is replaced by "serial" on every Contract B instrument (see writer.go's serialAttrs) — asserted per-instrument in writer_test.go's TestWriter_RecordsInstruments`)
+}

--- a/internal/otel/promnames_test.go
+++ b/internal/otel/promnames_test.go
@@ -142,7 +142,7 @@ func TestPrometheusExporterEmitsContractBNames(t *testing.T) {
 		}
 	}
 	// Negative guards: the OLD names must NOT appear (the intended breaks).
-	for _, old := range []string{"tempest_wind_ms", "tempest_uptime_seconds_total", "tempest_rainfall_total"} {
+	for _, old := range []string{"tempest_wind_ms", "tempest_uptime_seconds_total", "tempest_rainfall_total", "tempest_lightning_strike_count", "tempest_report_interval_minutes"} {
 		if got[old] {
 			t.Errorf("stale metric name %q still emitted", old)
 		}


### PR DESCRIPTION
## Workstream 4 — Grafana "Weather Nerd" dashboard

Implements the plan's Workstream 4 (Tasks 4.1–4.2). Test + config only — no production Go logic changes.

### Task 4.1 — OTel→Prometheus name-translation assertion (real exporter)
`internal/otel/promnames_test.go`:
- `TestPrometheusExporterEmitsContractBNames` drives the W6 OTel writer through the **real in-process Prometheus exporter** (`go.opentelemetry.io/otel/exporters/prometheus@v0.55.0`, version-matched to the repo's otel core `v1.33.0`) + `reg.Gather()`, and asserts all **20 Contract B `tempest_*` family names** are emitted — with negative guards that all 5 retired names (`tempest_wind_ms`, `tempest_uptime_seconds_total`, `tempest_rainfall_total`, `tempest_lightning_strike_count`, `tempest_report_interval_minutes`) are gone. Not a hand-map comparison.
- `TestMetricMigrationList` diffs Contract B against the current `internal/tempest/metrics.go` descriptors and asserts the **complete** rename/add/drop break set (incl. `instance`→`serial`). Its `t.Log` output is the authoritative migration list **DOC.2** will consume for the README.

### Task 4.2 — Grafana dashboard JSON + provisioning + validator
`deploy/grafana/`:
- `dashboards/weather-nerd.json` — all **8 design §13 rows** (current conditions, trends incl. pressure tendency, wind, rain, lightning, solar/UV, station health, records/almanac over `$__range`). PromQL references **only** Contract B names + the `serial` label.
- `provisioning/datasources/prometheus.yaml`, `provisioning/dashboards/dashboards.yaml`.
- `validate_test.go` — stdlib Go validator: parses the JSON, extracts every `tempest_` token from panel exprs and asserts membership in the 20-name Contract B set, asserts `$serial` query var exists and `$__range` is used-but-not-defined, recurses nested row panels. Anti-tautology proven (bogus-metric injection → FAIL → revert).

### Review
Subagent-driven-development: per-task Opus reviews + a fresh cold whole-branch Opus review. The cold review caught **one real bug** the validator and both per-task reviews missed: the Gust Factor panel divided `{kind="gust"} / {kind="avg"}` across differing labels → permanent "No data". Fixed (`50f7e79`): `/ ignoring(kind)`; also corrected pressure-tendency units to real mb/3h (`deriv[3h] * 10800`) and completed the negative-guard list.

### Gates (all green)
`gofmt -l` empty · `CGO_ENABLED=0 go build ./...` · `go vet ./...` · `golangci-lint run ./...` 0 issues · `go test -race ./...` 230 pass / 14 pkgs (new `deploy/grafana` pkg).

### ⚠️ DOC.1 obligation (carry forward)
The pinned `prometheus/common@v0.67.5` defaults to **UTF8 name validation** (preserves dots → `tempest.temperature.c`). The 4.1 test forces `LegacyValidation` (`t.Cleanup`-restored) to reproduce Contract B's underscore names. **DOC.1's OTel Collector config MUST enable Prometheus-backward-compatible (legacy/underscore) naming**, or live metric names won't match the dashboard's PromQL. (Design §12/§257 already require underscore translation; this is a config obligation for the compose stack.)

### Deferred follow-ups
- Wind-rose panel is a heatmap placeholder (design §13 explicitly permits the heatmap form; a true wind-rose needs a Grafana plugin) — verify at DOC.1 manual dashboard-load smoke.
- Validator could additionally assert the exact `$serial` query string and guard against `instance`-label reintroduction (optional hardening).
- Live compose smoke-load of the dashboard against real metrics happens at DOC.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
