### PR TITLE
feat: DOC.1 — full-stack docker-compose + Collector/Prometheus/Grafana/Litestream/MinIO configs (§15a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ chainguard-labels.*
 CLAUDE.md
 .worktrees/
 .private-journal/
+deploy/.env
 
 # Binaries
 tempestwx-utilities

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,63 @@
+# tempestwx-utilities — full-stack compose environment
+#
+# Copy this file to deploy/.env and fill in real values:
+#   cp .env.example .env
+# deploy/.env is gitignored and MUST NOT be committed. Every value below is a
+# placeholder — none of these are real secrets.
+
+# --- App (tempestwx) --------------------------------------------------------
+
+# Optional: WeatherFlow REST API token. Leave unset for the normal full-stack
+# deployment described here (UDP listener + observability). Setting TOKEN
+# switches the container to API-export mode instead.
+TOKEN=
+
+# Optional: process-level station identity (OTel resource attribute
+# tempest.serial). The authoritative per-metric `serial` label always comes
+# from the UDP reports themselves, not this value.
+TEMPEST_SERIAL=
+
+# Opt-in radar overlay (design §14). Start the sidecar with:
+#   docker compose --profile radar up -d
+# RADAR_SITE (e.g. TLX) is documented here for forward compatibility, but the
+# app does not yet read RADAR_SITE from the environment — site selection is
+# currently a per-request URL path parameter (/api/radar/{site}) driven by
+# the UI. Wiring RADAR_SITE into the UI is a known deferred item; until then
+# the radar card stays "not configured" regardless of this value.
+ENABLE_RADAR=false
+RADAR_SITE=TLX
+
+# --- Grafana -----------------------------------------------------------------
+GF_SECURITY_ADMIN_PASSWORD=changeme
+
+# --- MinIO (Litestream's S3-compatible replica target) -----------------------
+MINIO_ROOT_USER=tempest
+MINIO_ROOT_PASSWORD=changeme12345
+
+# --- Litestream (SQLite -> MinIO continuous backup) ---------------------------
+# Access key/secret here are just the MinIO root creds above (single-tenant
+# example deployment); use a scoped MinIO user/policy for anything beyond
+# local/dev use.
+LITESTREAM_BUCKET=tempest-backups
+LITESTREAM_ACCESS_KEY_ID=tempest
+LITESTREAM_SECRET_ACCESS_KEY=changeme12345
+
+# ------------------------------------------------------------------------------
+# ENABLE_POSTGRES variant (documentation only — NOT a second stack; see KISS/YAGNI)
+# ------------------------------------------------------------------------------
+# Postgres can replace (or run alongside) SQLite+Litestream+MinIO. To use it:
+# add a `postgres:` service to docker-compose.yml (image: postgres:16, a named
+# volume for /var/lib/postgresql/data, and a healthcheck), then set on the
+# tempestwx service:
+#
+#   ENABLE_POSTGRES=true
+#   POSTGRES_HOST=postgres
+#   POSTGRES_USERNAME=tempest
+#   POSTGRES_PASSWORD=<something-secret>
+#   POSTGRES_NAME=weather
+#
+# See CLAUDE.md's "PostgreSQL Storage (Optional)" section for the full
+# variable list (POSTGRES_URL vs. the individual POSTGRES_* components,
+# POSTGRES_SSLMODE, POSTGRES_BATCH_SIZE, etc.) and its own Docker Compose
+# example. If you don't want a local SQLite file at all, leave SQLITE_PATH
+# unset on tempestwx and drop the litestream/minio/minio-init services above.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,6 +41,9 @@ services:
     network_mode: host
     volumes:
       - tempest-data:/data
+    depends_on:
+      tempest-data-init:
+        condition: service_completed_successfully
     environment:
       ENABLE_OTEL: "true"
       OTEL_EXPORTER_OTLP_ENDPOINT: localhost:4317 # see host-networking note above
@@ -57,6 +60,20 @@ services:
       TOKEN: ${TOKEN:-}
       TEMPEST_SERIAL: ${TEMPEST_SERIAL:-}
     restart: unless-stopped
+
+  # One-shot init: the app image runs as non-root USER 65532:65532 (see
+  # Dockerfile), but a fresh named volume mounts /data owned root:root 0755 —
+  # nothing in the base image seeds ownership for it. SQLite is the default
+  # store and the app exits on startup if it can't open /data/tempest.db, so
+  # without this chown a fresh `docker compose up` crash-loops `tempestwx`.
+  # litestream runs as root and can read the resulting 65532-owned DB fine,
+  # so only `tempestwx` needs to wait on this.
+  tempest-data-init:
+    image: busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+    command: ["sh", "-c", "chown -R 65532:65532 /data"]
+    volumes:
+      - tempest-data:/data
+    restart: "no"
 
   litestream:
     image: litestream/litestream:0.3.13@sha256:027eda2a89a86015b9797d2129d4dd447e8953097b4190e1d5a30b73e76d8d58

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,194 @@
+# tempestwx-utilities — full-stack example deployment (design §15a)
+#
+# Brings up: the app (UDP ingest + JSON API + UI), the OTel Collector,
+# Prometheus, Grafana (with the "Weather Nerd" dashboard + wind-rose panel
+# provisioned), and SQLite→Litestream→MinIO continuous backup. The radar
+# sidecar is opt-in (see the `radar` profile note below).
+#
+# Quick start:
+#   cp .env.example .env
+#   $EDITOR .env                 # at minimum, set real passwords
+#   docker compose up -d         # radar-sidecar is NOT started by default
+#   docker compose --profile radar up -d   # also start the radar sidecar
+#
+# --- IMPORTANT: network_mode: host <-> service-DNS resolution --------------
+# `tempestwx` MUST run with `network_mode: host` — Tempest UDP broadcasts are
+# link-local, and a container reached only via a published UDP port never
+# receives them (see CLAUDE.md's "UDP broadcasts are link-local" note). But a
+# host-networked container does NOT get Compose's per-project bridge network,
+# so it CANNOT resolve other services by name (`otel-collector`,
+# `radar-sidecar`) the way every other service here can.
+#
+# The fix: every OTHER service stays on Compose's default bridge network and
+# talks to its peers via service-name DNS as usual (prometheus->otel-collector,
+# grafana->prometheus, litestream->minio). The two services `tempestwx` needs
+# to reach — otel-collector and radar-sidecar — additionally PUBLISH their
+# ports to the host, and `tempestwx` is configured to call them via
+# `localhost:<port>` instead of `<service-name>:<port>`. That is why
+# OTEL_EXPORTER_OTLP_ENDPOINT below is `localhost:4317` (NOT
+# `otel-collector:4317`) and RADAR_SIDECAR_URL is `http://localhost:8081`
+# (NOT the app's own default `http://radar-sidecar:8081`, which only resolves
+# for bridge-networked callers).
+# -----------------------------------------------------------------------------
+
+services:
+  tempestwx:
+    build:
+      # deploy/docker-compose.yml lives one level below the repo root, where
+      # the Dockerfile and its build context (go.mod, web/, etc.) actually are.
+      context: ..
+      dockerfile: Dockerfile
+    network_mode: host
+    volumes:
+      - tempest-data:/data
+    environment:
+      ENABLE_OTEL: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: localhost:4317 # see host-networking note above
+      SQLITE_PATH: /data/tempest.db
+      HTTP_ADDR: ":8080"
+      ENABLE_RADAR: ${ENABLE_RADAR:-false}
+      RADAR_SIDECAR_URL: http://localhost:8081 # see host-networking note above
+      # RADAR_SITE is documented here for operators, but the app does not yet
+      # read it from the environment: radar site selection is currently a
+      # per-request URL path parameter (/api/radar/{site}) driven by the UI.
+      # Wiring RADAR_SITE into the UI is a known deferred item — the radar
+      # card stays "not configured" until that lands.
+      RADAR_SITE: ${RADAR_SITE:-}
+      TOKEN: ${TOKEN:-}
+      TEMPEST_SERIAL: ${TEMPEST_SERIAL:-}
+    restart: unless-stopped
+
+  litestream:
+    image: litestream/litestream:0.3.13@sha256:027eda2a89a86015b9797d2129d4dd447e8953097b4190e1d5a30b73e76d8d58
+    command: ["replicate", "-config", "/etc/litestream.yml"]
+    volumes:
+      - ./litestream.yml:/etc/litestream.yml:ro
+      - tempest-data:/data # same volume as tempestwx — replicates /data/tempest.db
+    environment:
+      LITESTREAM_BUCKET: ${LITESTREAM_BUCKET:-tempest-backups}
+      LITESTREAM_ACCESS_KEY_ID: ${LITESTREAM_ACCESS_KEY_ID:-tempest}
+      LITESTREAM_SECRET_ACCESS_KEY: ${LITESTREAM_SECRET_ACCESS_KEY:-changeme12345}
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.132.0@sha256:e0f565815b2b8e78eb9fdbb80f6190c921ab323aaa8ccceab3255c6d4225f4af
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317" # OTLP gRPC — published so the host-networked app can reach it via localhost
+      - "9464:9464" # Prometheus exporter — scraped by the `prometheus` service via bridge DNS
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v3.0.1@sha256:565ee86501224ebbb98fc10b332fa54440b100469924003359edf49cbce374bd
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090" # optional: exposes the Prometheus UI to the host for debugging
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0@sha256:d8ea37798ccc41061a62ab080f2676dda6bf7815558499f901bdb0f533a456fb
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-changeme}
+      # Community-signed plugin — no GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS needed.
+      GF_INSTALL_PLUGINS: operato-windrose-panel
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      # weather-nerd.json lives in a sibling dir on disk (deploy/grafana/dashboards/)
+      # from the provider config (deploy/grafana/provisioning/dashboards/dashboards.yaml),
+      # but dashboards.yaml's options.path expects both in the SAME container
+      # directory (/etc/grafana/provisioning/dashboards). Mount each file
+      # individually into that directory rather than bind-mounting the whole
+      # provisioning tree and shadowing part of it — a single directory-level
+      # bind covering both dashboards.yaml and weather-nerd.json can't work
+      # since they live in two different directories on disk, and a nested
+      # file-mount underneath an already-read-only directory-level bind fails
+      # at container-create time (verified: "read-only file system" error).
+      - ./grafana/provisioning/dashboards/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:ro
+      - ./grafana/dashboards/weather-nerd.json:/etc/grafana/provisioning/dashboards/weather-nerd.json:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  # --- Radar sidecar (opt-in) ---------------------------------------------
+  # Off by default. Enable with: docker compose --profile radar up -d
+  # and set ENABLE_RADAR=true (+ RADAR_SITE once UI wiring lands) on tempestwx.
+  radar-sidecar:
+    build:
+      context: ../radar
+      dockerfile: Dockerfile
+    profiles: ["radar"]
+    ports:
+      - "8081:8081" # published so the host-networked app can reach it via localhost
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2024-10-13T13-34-11Z@sha256:9535594ad4122b7a78c6632788a989b96d9199b483d3bd71a5ceae73a922cdfa
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-tempest}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-changeme12345}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000" # S3 API
+      - "9001:9001" # web console
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # One-shot init: creates the Litestream replica bucket, then exits. `litestream`
+  # waits on this completing successfully before it starts replicating.
+  minio-init:
+    image: minio/mc:RELEASE.2024-10-08T09-37-26Z@sha256:c0d345a438dcac5677c1158e4ac46637069b67b3cc38e7b04c08cf93bdee4a62
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-tempest}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-changeme12345}
+      LITESTREAM_BUCKET: ${LITESTREAM_BUCKET:-tempest-backups}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set localminio http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" &&
+      mc mb --ignore-existing localminio/\"$$LITESTREAM_BUCKET\"
+      "
+    restart: "no"
+
+  # --- Optional trace/log backends (O5) -------------------------------------
+  # The app only ships OTLP (R1); choosing where traces/logs land is the
+  # operator's decision. Commented examples — uncomment and also flip the
+  # matching exporter back in otel-collector-config.yaml's traces/logs
+  # pipelines (swap [debug] for [debug, otlp/tempo] / [debug, otlphttp/loki]).
+  #
+  # tempo:
+  #   image: grafana/tempo:2.6.1
+  #   command: ["-config.file=/etc/tempo.yaml"]
+  #   volumes:
+  #     - ./tempo.yaml:/etc/tempo.yaml:ro
+  #     - tempo-data:/var/tempo
+  #
+  # loki:
+  #   image: grafana/loki:3.2.1
+  #   command: ["-config.file=/etc/loki.yaml"]
+  #   volumes:
+  #     - ./loki.yaml:/etc/loki.yaml:ro
+  #     - loki-data:/loki
+
+volumes:
+  tempest-data:
+  grafana-data:
+  prometheus-data:
+  minio-data:

--- a/deploy/grafana/dashboards/weather-nerd.json
+++ b/deploy/grafana/dashboards/weather-nerd.json
@@ -168,13 +168,16 @@
     },
     {
       "id": 301,
-      "type": "heatmap",
+      "type": "operato-windrose-panel",
       "title": "Wind Rose (direction vs speed)",
       "datasource": { "type": "prometheus", "uid": "tempest-prometheus" },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
       "targets": [
-        { "refId": "A", "expr": "tempest_wind_direction_degrees{serial=\"$serial\"}", "legendFormat": "direction" },
-        { "refId": "B", "expr": "tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}", "legendFormat": "speed" }
+        { "refId": "A", "expr": "tempest_wind_direction_degrees{serial=\"$serial\"}", "legendFormat": "wind_direction" },
+        { "refId": "B", "expr": "tempest_wind_meters_per_second{kind=\"avg\", serial=\"$serial\"}", "legendFormat": "wind_speed" }
+      ],
+      "transformations": [
+        { "id": "joinByField", "options": { "byField": "time", "mode": "outer" } }
       ]
     },
     {

--- a/deploy/litestream.yml
+++ b/deploy/litestream.yml
@@ -1,0 +1,14 @@
+# Litestream continuously streams the SQLite WAL for /data/tempest.db to an
+# S3-compatible replica (MinIO here). Litestream owns WAL checkpointing --
+# per CLAUDE.md's SQLite contract, the app intentionally does not set an
+# aggressive wal_autocheckpoint, so do not add one anywhere in this stack.
+dbs:
+  - path: /data/tempest.db
+    replicas:
+      - type: s3
+        endpoint: http://minio:9000       # bridge DNS; minio is on the default compose network
+        bucket: ${LITESTREAM_BUCKET}
+        path: tempest
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        force-path-style: true            # required for MinIO (not a real AWS S3 endpoint)

--- a/deploy/otel-collector-config.yaml
+++ b/deploy/otel-collector-config.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:9464"
+    # Pin translation explicitly (do not rely on the default): dots->underscores,
+    # monotonic counters get _total, unit suffixes appended -> reproduces the exact
+    # Contract B tempest_* names the WS4 dashboard PromQL depends on.
+    translation_strategy: "UnderscoreEscapingWithSuffixes"
+    # OFF: keep the resource attr tempest.serial OUT of metric labels (the app already
+    # sets a per-datapoint `serial` attribute -> label `serial`; enabling this would add
+    # a confusing near-duplicate label tempest_serial).
+    resource_to_telemetry_conversion:
+      enabled: false
+  debug:
+    verbosity: normal
+  # --- optional trace/log backends (O5) — commented examples only ---
+  # otlp/tempo: { endpoint: tempo:4317, tls: { insecure: true } }
+  # otlphttp/loki: { endpoint: http://loki:3100/otlp }
+
+service:
+  pipelines:
+    metrics: { receivers: [otlp], processors: [batch], exporters: [prometheus] }
+    traces:  { receivers: [otlp], processors: [batch], exporters: [debug] }   # swap to [debug, otlp/tempo] to store traces
+    logs:    { receivers: [otlp], processors: [batch], exporters: [debug] }   # swap to [debug, otlphttp/loki] to store logs

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "otel-collector"
+    static_configs:
+      # Bridge DNS: prometheus and otel-collector are both on the default
+      # compose network (only tempestwx runs on network_mode: host — see the
+      # host-networking note in docker-compose.yml).
+      - targets: ["otel-collector:9464"]


### PR DESCRIPTION
## DOC.1 — Full-stack docker-compose + stack configs (§15a)

> **Stacked on #75 (W4).** This branch is cut from the W4 branch because DOC.1 provisions the WS4 Grafana dashboard. **Merge #75 first**, then this PR retargets to `main`.

Authors the example full-stack observability + backup stack per design §15a. Config/YAML only — one JSON dashboard edit (wind-rose plugin). No Go logic changes.

### Files
- `deploy/docker-compose.yml` — `tempestwx` (host-net) + `otel-collector` + `prometheus` + `grafana` + `litestream` + `minio` (+ `minio-init` bucket bootstrap) + `radar-sidecar` (opt-in `profiles: [radar]`) + `tempest-data-init` (volume ownership).
- `deploy/otel-collector-config.yaml`, `deploy/prometheus.yml`, `deploy/litestream.yml`, `deploy/.env.example` (+ `.gitignore` for `deploy/.env`).
- `deploy/grafana/dashboards/weather-nerd.json` — Wind Rose panel swapped to `operato-windrose-panel`.

### Correctness-critical wiring (researched + confirmed)
- **Contract B names survive the pipeline:** the Collector `prometheus` exporter pins `translation_strategy: UnderscoreEscapingWithSuffixes` (dots→`_`, monotonic counters get `_total`, unit suffixes) + `resource_to_telemetry_conversion: {enabled: false}` (keeps the resource attr `tempest.serial` from becoming a duplicate label; the per-datapoint `serial` attribute already yields the `serial` label). Collector image pinned ≥ v0.132.0 (where `translation_strategy` exists).
- **`network_mode: host` ↔ localhost:** `tempestwx` uses host networking for UDP broadcast, so it can't resolve compose DNS — `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317` and `RADAR_SIDECAR_URL=http://localhost:8081` (collector/radar publish those ports); bridge-net services use service DNS (prometheus→`otel-collector:9464`, grafana→`prometheus:9090`, litestream→`minio:9000`). Explained in an in-file comment block.
- **Non-root volume fix:** `tempest-data-init` (busybox, pinned by digest) `chown -R 65532:65532 /data` before `tempestwx` starts — without it a fresh named volume mounts `/data` root-owned and the non-root SQLite-default app fail-loud exits. Found by review, verified live (`WRITABLE_OK`).
- **Wind rose:** `operato-windrose-panel` (Community-signed, `GF_INSTALL_PLUGINS`); the two Contract B queries unchanged, legends renamed `wind_direction`/`wind_speed`, `joinByField` (outer, on `time`) transform added.
- **O5/R1:** app only ships OTLP; Tempo/Loki are commented examples, not required services. `ENABLE_POSTGRES` variant documented (comment block, not a second stack).

### Verification
- `docker compose config` validates. `go test ./deploy/grafana/...` 3/3 (dashboard edit keeps Contract B validation green). `gofmt`/`go build`/`go vet` clean.
- **Live-verified** (docker): observability core (Grafana dashboard provisioned, `operato-windrose-panel` installed, Prometheus scrape `up`), the MinIO + `minio-init` + Litestream chain (bucket created, replicating), and the `/data` chown fix.
- **Not verified this session (environmental, not a code defect):** the `tempestwx`/`radar-sidecar` *image builds* — the shared Docker daemon ran out of disk (images from other concurrent worktrees). The radar build completed every step except final export (build plumbing confirmed); the app Dockerfile was proven in #63/W1 and only its build-context path changed here.

### Deferred
- `RADAR_SITE`→UI wiring (radar card shows "not configured" until wired) — the app doesn't yet read `RADAR_SITE`; documented, not solved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
