### PR TITLE
feat: Workstream 5 (UX.1) — UI P2 polish: memoization, dialog a11y, theme-var leak fix, viewport/transition CSS (§14 P2)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6,6 +6,7 @@
 .app {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 0 0 2rem;
 }
 
@@ -70,7 +71,7 @@
   border: 1px solid var(--border-color);
   border-radius: var(--card-radius);
   padding: 1.25rem;
-  transition: all 0.3s ease;
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
   overflow: hidden;
   text-shadow: var(--text-shadow);
 }
@@ -233,7 +234,7 @@
   background: var(--bg-secondary);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
   backdrop-filter: blur(10px);
 }
 
@@ -734,7 +735,7 @@
 @keyframes rainfall {
   0% { transform: translateY(-10px); opacity: 0; }
   20% { opacity: 0.4; }
-  100% { transform: translateY(calc(100vh)); opacity: 0; }
+  100% { transform: translateY(calc(100dvh)); opacity: 0; }
 }
 
 /* --- Lightning card ------------------------------------------ */
@@ -1199,6 +1200,7 @@
   justify-content: center;
   gap: 1.5rem;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 2rem;
   text-align: center;
   color: var(--text-secondary);
@@ -1225,6 +1227,7 @@
   justify-content: center;
   gap: 1rem;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 2rem;
   text-align: center;
   color: var(--text-primary);
@@ -1255,7 +1258,7 @@
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .glass-btn:hover {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -735,7 +735,7 @@
 @keyframes rainfall {
   0% { transform: translateY(-10px); opacity: 0; }
   20% { opacity: 0.4; }
-  100% { transform: translateY(calc(100dvh)); opacity: 0; }
+  100% { transform: translateY(100vh); transform: translateY(100dvh); opacity: 0; }
 }
 
 /* --- Lightning card ------------------------------------------ */
@@ -1401,8 +1401,9 @@
 }
 
 .toggle-group button.active {
-  background: var(--accent-color);
-  color: var(--bg-primary);
+  background: var(--accent-glow);
+  color: var(--text-primary);
+  border-color: var(--accent-color);
   box-shadow: inset 0 0 0 1px var(--accent-glow);
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1267,6 +1267,201 @@
   transform: translateY(-1px);
 }
 
+/* --- Settings panel (modal overlay, toggle groups, theme grid) --- */
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.settings-panel {
+  width: min(480px, 92vw);
+  max-height: 85dvh;
+  overflow-y: auto;
+  padding: 1.5rem;
+  backdrop-filter: blur(var(--glass-blur-heavy)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur-heavy)) saturate(var(--glass-saturate));
+  box-shadow: 0 16px 48px var(--shadow-heavy);
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.settings-header h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-shadow: var(--text-shadow);
+}
+
+.settings-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.settings-close:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+.settings-close:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.settings-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.settings-section:first-of-type {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.settings-section h3 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin-bottom: 0.85rem;
+}
+
+.setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+}
+
+.setting-row label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.toggle-group {
+  display: inline-flex;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.toggle-group button {
+  min-height: 36px;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle-group button:first-child {
+  border-left: none;
+}
+
+.toggle-group button:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+.toggle-group button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+}
+
+.toggle-group button.active {
+  background: var(--accent-color);
+  color: var(--bg-primary);
+  box-shadow: inset 0 0 0 1px var(--accent-glow);
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.theme-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  text-align: left;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-option:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--border-highlight);
+}
+
+.theme-option:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.theme-option.active {
+  border-color: var(--border-highlight);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.theme-swatch {
+  display: block;
+  width: 100%;
+  height: 40px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background-size: cover;
+}
+
+.theme-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.theme-desc {
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
 /* --- Radar card ------------------------------------------------ */
 .radar-card {
   min-height: 320px;
@@ -1301,6 +1496,20 @@
   .card-span-2,
   .card-span-3 {
     grid-column: span 1;
+  }
+
+  .settings-overlay {
+    padding: 0.75rem;
+    align-items: flex-end;
+  }
+
+  .settings-panel {
+    width: 100%;
+    max-height: 90dvh;
+  }
+
+  .theme-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
 }
 

--- a/web/src/components/AlmanacCard.tsx
+++ b/web/src/components/AlmanacCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { StationAlmanac, TemperatureUnit } from '../types/weather';
 import { formatTemp } from '../hooks/useUnits';
 import { GlassCard } from './GlassCard';
@@ -94,13 +95,13 @@ function daylightDuration(sunrise: number, sunset: number): string {
 }
 
 /* ---- Main card ---- */
-export function AlmanacCard({ almanac, unit }: AlmanacCardProps) {
+function AlmanacCardImpl({ almanac, unit }: AlmanacCardProps) {
   return (
     <GlassCard span={3}>
       <div className="card-header">
         {/* Book / almanac icon */}
         <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none"
-          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
           <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
         </svg>
@@ -175,3 +176,5 @@ export function AlmanacCard({ almanac, unit }: AlmanacCardProps) {
     </GlassCard>
   );
 }
+
+export const AlmanacCard = memo(AlmanacCardImpl);

--- a/web/src/components/ForecastStrip.tsx
+++ b/web/src/components/ForecastStrip.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { ForecastDay, TemperatureUnit } from '../types/weather';
 import { formatTemp } from '../hooks/useUnits';
 import { GlassCard } from './GlassCard';
@@ -18,11 +19,11 @@ function getDayName(sunriseEpoch: number): string {
   return DAY_NAMES[date.getDay()];
 }
 
-export function ForecastStrip({ forecast, unit }: ForecastStripProps) {
+function ForecastStripImpl({ forecast, unit }: ForecastStripProps) {
   return (
     <GlassCard className="forecast-card" span={3}>
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
           <line x1="16" y1="2" x2="16" y2="6" />
           <line x1="8" y1="2" x2="8" y2="6" />
@@ -59,3 +60,5 @@ export function ForecastStrip({ forecast, unit }: ForecastStripProps) {
     </GlassCard>
   );
 }
+
+export const ForecastStrip = memo(ForecastStripImpl);

--- a/web/src/components/HumidityCard.tsx
+++ b/web/src/components/HumidityCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { CurrentObservation, TemperatureUnit } from '../types/weather';
 import { formatTemp } from '../hooks/useUnits';
 import { GlassCard } from './GlassCard';
@@ -14,7 +15,7 @@ function humidityLevel(rh: number): string {
   return 'Very Humid';
 }
 
-export function HumidityCard({ current, tempUnit }: HumidityCardProps) {
+function HumidityCardImpl({ current, tempUnit }: HumidityCardProps) {
   const pct = current.relativeHumidity;
   const circumference = 2 * Math.PI * 40;
   const offset = circumference - (pct / 100) * circumference;
@@ -22,7 +23,7 @@ export function HumidityCard({ current, tempUnit }: HumidityCardProps) {
   return (
     <GlassCard className="humidity-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" />
         </svg>
         <span className="card-title">Humidity</span>
@@ -60,3 +61,5 @@ export function HumidityCard({ current, tempUnit }: HumidityCardProps) {
     </GlassCard>
   );
 }
+
+export const HumidityCard = memo(HumidityCardImpl);

--- a/web/src/components/LightningCard.tsx
+++ b/web/src/components/LightningCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { CurrentObservation } from '../types/weather';
 import { GlassCard } from './GlassCard';
 
@@ -5,13 +6,13 @@ interface LightningCardProps {
   current: CurrentObservation;
 }
 
-export function LightningCard({ current }: LightningCardProps) {
+function LightningCardImpl({ current }: LightningCardProps) {
   const hasStrikes = current.lightningStrikeCount > 0;
 
   return (
     <GlassCard className={`lightning-card ${hasStrikes ? 'lightning-active' : ''}`}>
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
         </svg>
         <span className="card-title">Lightning</span>
@@ -59,3 +60,5 @@ export function LightningCard({ current }: LightningCardProps) {
     </GlassCard>
   );
 }
+
+export const LightningCard = memo(LightningCardImpl);

--- a/web/src/components/PressureCard.tsx
+++ b/web/src/components/PressureCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { CurrentObservation, PressureUnit } from '../types/weather';
 import { formatPressure } from '../hooks/useUnits';
 import { PressureTrend } from '../types/weather';
@@ -24,11 +25,11 @@ function trendLabel(trend: PressureTrend): string {
   }
 }
 
-export function PressureCard({ current, unit }: PressureCardProps) {
+function PressureCardImpl({ current, unit }: PressureCardProps) {
   return (
     <GlassCard className="pressure-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="10" />
           <path d="M12 6v6l4 2" />
         </svg>
@@ -58,3 +59,5 @@ export function PressureCard({ current, unit }: PressureCardProps) {
     </GlassCard>
   );
 }
+
+export const PressureCard = memo(PressureCardImpl);

--- a/web/src/components/RadarCard.tsx
+++ b/web/src/components/RadarCard.tsx
@@ -260,7 +260,7 @@ export function RadarCard({ station, site }: RadarCardProps) {
 function RadarCardHeader() {
   return (
     <div className="card-header">
-      <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <circle cx="12" cy="12" r="2" />
         <path d="M12 2a10 10 0 0 1 10 10" />
         <path d="M12 6a6 6 0 0 1 6 6" />

--- a/web/src/components/RainCard.test.tsx
+++ b/web/src/components/RainCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { RainCard } from './RainCard';
+import { PrecipitationType, PressureTrend, type CurrentObservation } from '../types/weather';
+
+const baseCurrent: CurrentObservation = {
+  timestamp: 1700000000,
+  windLull: 1,
+  windAvg: 2,
+  windGust: 3,
+  windDirection: 180,
+  windSampleInterval: 3,
+  stationPressure: 1013,
+  airTemperature: 20,
+  relativeHumidity: 55,
+  illuminance: 1000,
+  uvIndex: 2,
+  solarRadiation: 100,
+  rainAccumulated: 0.5,
+  precipitationType: PrecipitationType.Rain,
+  lightningStrikeAvgDistance: 0,
+  lightningStrikeCount: 0,
+  battery: 2.6,
+  reportInterval: 1,
+  localDayRainAccumulation: 1.2,
+  feelsLike: 20,
+  dewPoint: 12,
+  wetBulbTemperature: 15,
+  heatIndex: 20,
+  windChill: 20,
+  pressureTrend: PressureTrend.Steady,
+};
+
+describe('RainCard raindrop stability (P2.13)', () => {
+  it('keeps raindrop positions stable across a re-render with new (still-raining) props', () => {
+    const { container, rerender } = render(<RainCard current={baseCurrent} unit="in" />);
+
+    const before = Array.from(container.querySelectorAll<HTMLElement>('.raindrop')).map(
+      (el) => el.style.left
+    );
+    expect(before).toHaveLength(12);
+
+    rerender(
+      <RainCard
+        current={{ ...baseCurrent, localDayRainAccumulation: 2.4 }}
+        unit="in"
+      />
+    );
+
+    const after = Array.from(container.querySelectorAll<HTMLElement>('.raindrop')).map(
+      (el) => el.style.left
+    );
+
+    expect(after).toEqual(before);
+  });
+});

--- a/web/src/components/RainCard.tsx
+++ b/web/src/components/RainCard.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import type { CurrentObservation, RainUnit } from '../types/weather';
 import { PrecipitationType } from '../types/weather';
 import { formatRain } from '../hooks/useUnits';
@@ -6,6 +7,14 @@ import { GlassCard } from './GlassCard';
 interface RainCardProps {
   current: CurrentObservation;
   unit: RainUnit;
+}
+
+const RAINDROP_COUNT = 12;
+
+interface RaindropStyle {
+  left: string;
+  animationDelay: string;
+  animationDuration: string;
 }
 
 function precipLabel(type: PrecipitationType): string {
@@ -17,13 +26,25 @@ function precipLabel(type: PrecipitationType): string {
   }
 }
 
-export function RainCard({ current, unit }: RainCardProps) {
+function RainCardImpl({ current, unit }: RainCardProps) {
   const isRaining = current.precipitationType !== PrecipitationType.None;
+
+  // Computed once per mount (empty deps) so positions don't reshuffle on
+  // every 3s data tick re-render (P2.13).
+  const raindropStyles = useMemo<RaindropStyle[]>(
+    () =>
+      Array.from({ length: RAINDROP_COUNT }, () => ({
+        left: `${8 + Math.random() * 84}%`,
+        animationDelay: `${Math.random() * 1}s`,
+        animationDuration: `${0.5 + Math.random() * 0.5}s`,
+      })),
+    []
+  );
 
   return (
     <GlassCard className="rain-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M20 17.58A5 5 0 0 0 18 8h-1.26A8 8 0 1 0 4 16.25" />
           <line x1="8" y1="16" x2="8" y2="20" />
           <line x1="12" y1="18" x2="12" y2="22" />
@@ -47,19 +68,13 @@ export function RainCard({ current, unit }: RainCardProps) {
 
       {isRaining && (
         <div className="rain-animation">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <div
-              key={i}
-              className="raindrop"
-              style={{
-                left: `${8 + Math.random() * 84}%`,
-                animationDelay: `${Math.random() * 1}s`,
-                animationDuration: `${0.5 + Math.random() * 0.5}s`,
-              }}
-            />
+          {raindropStyles.map((style, i) => (
+            <div key={i} className="raindrop" style={style} />
           ))}
         </div>
       )}
     </GlassCard>
   );
 }
+
+export const RainCard = memo(RainCardImpl);

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -140,4 +140,23 @@ describe('SettingsPanel dialog semantics (P2.14)', () => {
 
     expect(document.activeElement).toBe(last);
   });
+
+  it('traps Shift+Tab when focus is still on the dialog container itself (just-opened state)', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const last = focusable[focusable.length - 1];
+
+    // On open, focus lands on the dialog container itself (not first/last).
+    expect(document.activeElement).toBe(dialog);
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
 });

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -41,6 +41,18 @@ describe('SettingsPanel', () => {
     expect(screen.getByText('°F')).toBeInTheDocument();
     expect(screen.getByText('Theme')).toBeInTheDocument();
   });
+
+  it('renders each theme swatch with a non-empty inline background-image (§14)', () => {
+    const { container } = render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const swatches = container.querySelectorAll<HTMLElement>('.theme-swatch');
+    expect(swatches.length).toBeGreaterThan(0);
+    swatches.forEach((swatch) => {
+      expect(swatch.style.backgroundImage).not.toBe('');
+    });
+  });
 });
 
 describe('SettingsPanel dialog semantics (P2.14)', () => {

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SettingsPanel } from './SettingsPanel';
 import type { UserPreferences } from '../types/weather';
 
@@ -40,5 +40,92 @@ describe('SettingsPanel', () => {
     expect(screen.getByText('Temperature')).toBeInTheDocument();
     expect(screen.getByText('°F')).toBeInTheDocument();
     expect(screen.getByText('Theme')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsPanel dialog semantics (P2.14)', () => {
+  it('exposes role="dialog", aria-modal="true", and an accessible name from the h2', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAccessibleName('Settings');
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={onClose} />
+    );
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus into the dialog on open', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it('restores focus to the previously focused element when the dialog closes', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(document.activeElement).not.toBe(trigger);
+
+    rerender(
+      <SettingsPanel isOpen={false} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+
+  it('traps Tab: pressing Tab on the last focusable element wraps focus to the first', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    last.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('traps Shift+Tab: pressing Shift+Tab on the first focusable element wraps focus to the last', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    first.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
   });
 });

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -46,11 +46,17 @@ export function SettingsPanel({ isOpen, prefs, onPrefsChange, onClose }: Setting
     if (focusable.length === 0) return;
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    // The dialog container itself is focused on open (tabIndex={-1}), and is
+    // not part of the trap's focusable list. Treat "active element is the
+    // container, or isn't one of the trap's focusable elements at all" as a
+    // boundary too, so Shift+Tab from the just-opened dialog can't escape.
+    const atBoundary = active === dialog || !dialog.contains(active);
 
-    if (e.shiftKey && document.activeElement === first) {
+    if (e.shiftKey && (active === first || atBoundary)) {
       e.preventDefault();
       last.focus();
-    } else if (!e.shiftKey && document.activeElement === last) {
+    } else if (!e.shiftKey && active === last) {
       e.preventDefault();
       first.focus();
     }

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -141,7 +141,11 @@ export function SettingsPanel({ isOpen, prefs, onPrefsChange, onClose }: Setting
                 className={`theme-option ${prefs.theme === t.name ? 'active' : ''}`}
                 onClick={() => onPrefsChange({ theme: t.name })}
               >
-                <span className="theme-swatch" data-theme={t.name} />
+                <span
+                  className="theme-swatch"
+                  data-theme={t.name}
+                  style={{ backgroundImage: t.backgroundImage }}
+                />
                 <span className="theme-name">{t.label}</span>
                 <span className="theme-desc">{t.description}</span>
               </button>

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type { UserPreferences } from '../types/weather';
 import { getThemeList } from '../themes/themes';
 
@@ -8,18 +9,69 @@ interface SettingsPanelProps {
   onClose: () => void;
 }
 
+const SETTINGS_TITLE_ID = 'settings-title';
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 export function SettingsPanel({ isOpen, prefs, onPrefsChange, onClose }: SettingsPanelProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Focus management (P2.14): on open, remember what was focused and move
+  // focus into the dialog; the cleanup (fired when isOpen flips to false,
+  // or on unmount) restores focus to whatever triggered the dialog.
+  useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      previouslyFocusedRef.current?.focus();
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const themeList = getThemeList();
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
   return (
     <div className="settings-overlay" onClick={onClose}>
-      <div className="settings-panel glass-card" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="settings-panel glass-card"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={SETTINGS_TITLE_ID}
+        tabIndex={-1}
+      >
         <div className="settings-header">
-          <h2>Settings</h2>
+          <h2 id={SETTINGS_TITLE_ID}>Settings</h2>
           <button className="settings-close" onClick={onClose} aria-label="Close settings">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>

--- a/web/src/components/SolarUVCard.tsx
+++ b/web/src/components/SolarUVCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { CurrentObservation } from '../types/weather';
 import { GlassCard } from './GlassCard';
 import { formatX } from '../utils/format';
@@ -30,13 +31,13 @@ function solarIntensity(radiation: number): string {
   return 'Very High';
 }
 
-export function SolarUVCard({ current }: SolarUVCardProps) {
+function SolarUVCardImpl({ current }: SolarUVCardProps) {
   const uvPct = Math.min(100, (current.uvIndex / 11) * 100);
 
   return (
     <GlassCard className="solar-uv-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="5" />
           <line x1="12" y1="1" x2="12" y2="3" />
           <line x1="12" y1="21" x2="12" y2="23" />
@@ -88,3 +89,5 @@ export function SolarUVCard({ current }: SolarUVCardProps) {
     </GlassCard>
   );
 }
+
+export const SolarUVCard = memo(SolarUVCardImpl);

--- a/web/src/components/StationHealth.tsx
+++ b/web/src/components/StationHealth.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { StationStatus } from '../types/weather';
 import { GlassCard } from './GlassCard';
 
@@ -25,14 +26,14 @@ function timeSince(epochSeconds: number): string {
   return `${Math.floor(diff / 3600)}h ago`;
 }
 
-export function StationHealth({ status }: StationHealthProps) {
+function StationHealthImpl({ status }: StationHealthProps) {
   const battery = batteryLevel(status.batteryLevel);
   const bars = signalBars(status.signalStrength);
 
   return (
     <GlassCard className="station-health-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <rect x="1" y="6" width="18" height="12" rx="2" ry="2" />
           <line x1="23" y1="10" x2="23" y2="14" />
         </svg>
@@ -86,3 +87,5 @@ export function StationHealth({ status }: StationHealthProps) {
     </GlassCard>
   );
 }
+
+export const StationHealth = memo(StationHealthImpl);

--- a/web/src/components/TemperatureHero.tsx
+++ b/web/src/components/TemperatureHero.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { CurrentObservation, TemperatureUnit } from '../types/weather';
 import { formatTemp } from '../hooks/useUnits';
 import { GlassCard } from './GlassCard';
@@ -29,7 +30,7 @@ function getConditionIcon(obs: CurrentObservation): string {
   return 'clear-night';
 }
 
-export function TemperatureHero({ current, unit, precipProbability }: TemperatureHeroProps) {
+function TemperatureHeroImpl({ current, unit, precipProbability }: TemperatureHeroProps) {
   const condition = getConditionLabel(current);
   const icon = getConditionIcon(current);
 
@@ -66,3 +67,5 @@ export function TemperatureHero({ current, unit, precipProbability }: Temperatur
     </GlassCard>
   );
 }
+
+export const TemperatureHero = memo(TemperatureHeroImpl);

--- a/web/src/components/WindCard.tsx
+++ b/web/src/components/WindCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { memo, useState, useEffect, useRef } from 'react';
 import type { CurrentObservation, WindUnit } from '../types/weather';
 import { formatWind } from '../hooks/useUnits';
 import { GlassCard } from './GlassCard';
@@ -14,7 +14,7 @@ function degToCompass(deg: number): string {
   return dirs[Math.round(deg / 22.5) % 16];
 }
 
-export function WindCard({ current, unit }: WindCardProps) {
+function WindCardImpl({ current, unit }: WindCardProps) {
   const compassDir = degToCompass(current.windDirection);
 
   // Track accumulated rotation so the needle always takes the shortest arc
@@ -33,7 +33,7 @@ export function WindCard({ current, unit }: WindCardProps) {
   return (
     <GlassCard className="wind-card">
       <div className="card-header">
-        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg className="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2" />
         </svg>
         <span className="card-title">Wind</span>
@@ -71,3 +71,5 @@ export function WindCard({ current, unit }: WindCardProps) {
     </GlassCard>
   );
 }
+
+export const WindCard = memo(WindCardImpl);

--- a/web/src/hooks/useWeatherData.test.ts
+++ b/web/src/hooks/useWeatherData.test.ts
@@ -256,4 +256,43 @@ describe('useWeatherData - isLoading with polling', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.current).toEqual(baseObs);
   });
+
+  it('keeps the current object reference stable across a poll that returns a new object with the same timestamp (§14 P2.13)', async () => {
+    // Two distinct object instances with an identical timestamp -- mirrors a
+    // poll tick that refetches the same underlying reading. The guard in
+    // pollCurrent's setCurrent should retain the prior reference instead of
+    // swapping in the new (but equivalent) object, so memoized current-
+    // consuming cards don't re-render for a no-op tick.
+    const firstObs: CurrentObservation = { ...baseObs };
+    const secondObs: CurrentObservation = { ...baseObs };
+    mockedApi.fetchCurrentObservation
+      .mockResolvedValueOnce(firstObs)
+      .mockResolvedValueOnce(secondObs);
+    mockedApi.fetchStationMeta.mockResolvedValue(baseStation);
+    mockedApi.fetchForecast.mockResolvedValue([]);
+    mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
+    mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+
+    const { result } = renderHook(() => useWeatherData());
+
+    // Flush the initial (non-poll) load's microtasks. Fake timers are active
+    // in this describe block, so `waitFor` would hang; flush directly instead
+    // (matching the sibling test above).
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.current).toBe(firstObs);
+    const refAfterInitialLoad = result.current.current;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    });
+
+    expect(mockedApi.fetchCurrentObservation).toHaveBeenCalledTimes(2);
+    expect(result.current.current).toBe(refAfterInitialLoad);
+    expect(result.current.current).not.toBe(secondObs);
+  });
 });

--- a/web/src/hooks/useWeatherData.ts
+++ b/web/src/hooks/useWeatherData.ts
@@ -147,7 +147,11 @@ export function useWeatherData(stationId?: number): WeatherData {
     try {
       const obs = await fetchCurrentObservation(stationId, signal);
       if (signal.aborted) return;
-      setCurrent(obs);
+      // Reference-stability guard (§14 P2.13): an unchanged observation
+      // (same timestamp -- unique per reading, UNIQUE(serial,timestamp))
+      // keeps the same object reference so React.memo on the current-
+      // consuming cards can skip re-rendering on ticks with no new data.
+      setCurrent((prev) => (prev && prev.timestamp === obs.timestamp ? prev : obs));
       setIsStale(false);
       setError(null);
       setLastUpdated(new Date());

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -43,15 +43,16 @@
 
 body {
   min-height: 100vh;
+  min-height: 100dvh;
   min-width: 320px;
   background-image: linear-gradient(160deg, #0a0a2e 0%, #1a1a4e 30%, #0d3b3b 60%, #1a0a2e 100%);
-  background-attachment: fixed;
   overflow-x: hidden;
 }
 
 #root {
   width: 100%;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 a {

--- a/web/src/themes/themes.test.ts
+++ b/web/src/themes/themes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { applyTheme, themes } from './themes';
+
+afterEach(() => {
+  // Reset any inline custom properties the tests apply, so themes.ts's
+  // own leak fix (not a leftover from a previous test) is what's asserted.
+  document.documentElement.removeAttribute('style');
+});
+
+describe('applyTheme (P2.15 — theme-var leak)', () => {
+  it('does not leak a previous theme value: nord then desert-sunset ends with desert-sunset\'s --text-shadow', () => {
+    applyTheme('nord');
+    expect(document.documentElement.style.getPropertyValue('--text-shadow')).toBe(
+      themes.nord.vars['--text-shadow']
+    );
+
+    applyTheme('desert-sunset');
+
+    expect(document.documentElement.style.getPropertyValue('--text-shadow')).toBe(
+      themes['desert-sunset'].vars['--text-shadow']
+    );
+    expect(document.documentElement.style.getPropertyValue('--text-shadow')).not.toBe(
+      themes.nord.vars['--text-shadow']
+    );
+  });
+
+  it('removes a synthetic prior var value the incoming theme does not redefine', () => {
+    document.documentElement.style.setProperty('--text-shadow', 'LEAKED');
+
+    applyTheme('desert-sunset');
+
+    expect(document.documentElement.style.getPropertyValue('--text-shadow')).toBe(
+      themes['desert-sunset'].vars['--text-shadow']
+    );
+    expect(document.documentElement.style.getPropertyValue('--text-shadow')).not.toBe('LEAKED');
+  });
+
+  it('every theme defines --text-shadow', () => {
+    for (const theme of Object.values(themes)) {
+      expect(theme.vars['--text-shadow']).toBeTruthy();
+    }
+  });
+});

--- a/web/src/themes/themes.test.ts
+++ b/web/src/themes/themes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { applyTheme, themes } from './themes';
+import { applyTheme, themes, getThemeList } from './themes';
 
 afterEach(() => {
   // Reset any inline custom properties the tests apply, so themes.ts's
@@ -52,6 +52,17 @@ describe('applyTheme (P2.15 — theme-var leak)', () => {
   it('every theme defines --text-shadow', () => {
     for (const theme of Object.values(themes)) {
       expect(theme.vars['--text-shadow']).toBeTruthy();
+    }
+  });
+});
+
+describe('getThemeList (§14 — theme-swatch backgroundImage wiring)', () => {
+  it('includes a truthy backgroundImage for every entry, matching the source theme', () => {
+    const list = getThemeList();
+    expect(list.length).toBe(Object.keys(themes).length);
+    for (const entry of list) {
+      expect(entry.backgroundImage).toBeTruthy();
+      expect(entry.backgroundImage).toBe(themes[entry.name].backgroundImage);
     }
   });
 });

--- a/web/src/themes/themes.test.ts
+++ b/web/src/themes/themes.test.ts
@@ -24,7 +24,10 @@ describe('applyTheme (P2.15 — theme-var leak)', () => {
     );
   });
 
-  it('removes a synthetic prior var value the incoming theme does not redefine', () => {
+  it('overwrites a leaked value when the incoming theme redefines the var', () => {
+    // A stale value for a var the incoming theme DOES define is corrected by
+    // the setProperty pass (the removeProperty pass never fires for it, since
+    // every current theme defines the full var set).
     document.documentElement.style.setProperty('--text-shadow', 'LEAKED');
 
     applyTheme('desert-sunset');
@@ -33,6 +36,17 @@ describe('applyTheme (P2.15 — theme-var leak)', () => {
       themes['desert-sunset'].vars['--text-shadow']
     );
     expect(document.documentElement.style.getPropertyValue('--text-shadow')).not.toBe('LEAKED');
+  });
+
+  it('clears only theme-owned vars, leaving unrelated inline custom properties intact', () => {
+    // The leak-clearing pass must scope its removeProperty calls to the union
+    // of theme vars — it must NOT nuke arbitrary inline custom properties set
+    // by other code. (This exercises the removeProperty pass's key guard.)
+    document.documentElement.style.setProperty('--not-a-theme-var', 'KEEP');
+
+    applyTheme('nord');
+
+    expect(document.documentElement.style.getPropertyValue('--not-a-theme-var')).toBe('KEEP');
   });
 
   it('every theme defines --text-shadow', () => {

--- a/web/src/themes/themes.ts
+++ b/web/src/themes/themes.ts
@@ -250,9 +250,10 @@ export function applyTheme(name: ThemeName) {
 }
 
 export function getThemeList() {
-  return Object.values(themes).map(({ name, label, description }) => ({
+  return Object.values(themes).map(({ name, label, description, backgroundImage }) => ({
     name,
     label,
     description,
+    backgroundImage,
   }));
 }

--- a/web/src/themes/themes.ts
+++ b/web/src/themes/themes.ts
@@ -84,6 +84,7 @@ export const themes: Record<ThemeName, ThemeDefinition> = {
       '--text-primary': '#fff0e6',
       '--text-secondary': 'rgba(255, 240, 230, 0.8)',
       '--text-muted': 'rgba(255, 240, 230, 0.5)',
+      '--text-shadow': '0 1px 3px rgba(0, 0, 0, 0.45)',
       '--accent-color': '#f7a072',
       '--accent-glow': 'rgba(247, 160, 114, 0.3)',
       '--shadow-color': 'rgba(0, 0, 0, 0.2)',
@@ -220,11 +221,27 @@ export const themes: Record<ThemeName, ThemeDefinition> = {
   },
 };
 
+// Union of every CSS custom property any theme defines, derived from
+// `themes` itself (not hand-listed) so a var added to one theme's `vars`
+// automatically becomes known here too (P2.15).
+const ALL_THEME_VAR_KEYS: ReadonlySet<string> = new Set(
+  Object.values(themes).flatMap((theme) => Object.keys(theme.vars))
+);
+
 export function applyTheme(name: ThemeName) {
   const theme = themes[name];
   if (!theme) return;
 
   const root = document.documentElement;
+
+  // Clear any theme-owned var the incoming theme doesn't define, so a
+  // property set by a previously-applied theme can't leak into this one.
+  ALL_THEME_VAR_KEYS.forEach((key) => {
+    if (!(key in theme.vars)) {
+      root.style.removeProperty(key);
+    }
+  });
+
   Object.entries(theme.vars).forEach(([key, value]) => {
     root.style.setProperty(key, value);
   });


### PR DESCRIPTION
## Workstream 5 — Task UX.1: UI P2 polish batch (design §14 P2.13–P2.16)

The final UI-polish batch for the embedded weather dashboard. Pure TypeScript/React — no Go touched, no new npm dependencies.

### What changed
- **P2.13 — Memoization.** `React.memo` on the ten pure leaf cards (Wind, Pressure, Humidity, SolarUV, Rain, Lightning, StationHealth, Almanac, TemperatureHero, ForecastStrip) so they no longer re-render on every 3-second data tick; `useMemo` on the RainCard raindrops so drop positions stop reshuffling each render. Named exports/prop types preserved; RadarCard/Header/GlassCard/WeatherIcon/SettingsPanel intentionally excluded.
- **P2.14 — Settings-modal dialog a11y.** `role="dialog"`, `aria-modal="true"`, `aria-labelledby` → the "Settings" heading; Escape closes; explicit focus-trap; focus moves into the dialog on open and restores to the trigger on close. (Hooks reordered ahead of the `if (!isOpen) return null` early-return since the panel is always mounted — Rules-of-Hooks safe.)
- **P2.15 — Theme-var leak fix + a11y.** Added the missing `--text-shadow` to `desert-sunset`; `applyTheme` now clears any theme-owned CSS var the incoming theme omits (union of keys derived from `themes`, DRY) so switching themes can't leak a stale value; `aria-hidden="true"` on decorative `card-icon` SVGs + the settings close icon (meaningful `WeatherIcon` left labeled).
- **P2.16 — Viewport + transitions.** `100dvh` (with `100vh` fallback) over bare `100vh`; dropped `background-attachment: fixed`; replaced every `transition: all` with an enumerated property list matching what each selector actually animates.

### Verification
- `cd web && npm test` → **66 passing** (baseline was 55; +11 new tests incl. RED-first coverage for the dialog semantics and theme-var leak).
- `npm run build` clean; `npx tsc --noEmit` clean. (Pre-existing >500 kB chunk-size warning only.)

### Review
- Per-task review (Opus): Spec ✅ / Approved.
- Cold whole-branch review (Fable): **Ready to merge — 0 Critical, 0 Important.** Confirmed memo isn't silently defeated (App.tsx passes only stable refs/scalars), focus management respects hook rules, and no animated CSS property was dropped.
- The one convergent Minor (theme removal-branch test fidelity) is addressed in `536f1cd`: renamed the misleading test to describe the overwrite guarantee and added a genuine test that the leak-clearing pass touches only theme-owned vars.

### Deferred (out of §14 P2 scope — follow-up)
- Decorative data-viz SVGs (humidity ring, pressure gauge) lack ARIA labels — candidate for a future a11y pass.

Plan: `docs/plans/2026-07-17-unified-weather-platform-implementation.md` (Task UX.1). Design: §14 P2.13–P2.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — also in this PR (beyond the §14 P2 batch)

**Fix: missing Settings-panel CSS (pre-existing bug, discovered by running the UI).** The `SettingsPanel` referenced `.settings-overlay`/`.settings-panel`/`.toggle-group`/`.theme-grid`/`.theme-option`… but those classes were defined nowhere on `main`, so the settings modal rendered unstyled. Added the CSS (frosted-glass modal overlay, segmented toggle groups, theme grid) using the per-theme CSS custom properties (no hardcoded colors), with `:focus-visible`, reduced-motion, and enumerated transitions; theme-swatch gradients are single-sourced from `themes.ts` via `getThemeList()`.

**Cold-review fixes (Fable, whole-branch):**
- Focus-trap: Shift+Tab from the just-opened dialog (focus on the container) no longer escapes the modal — added the boundary case + a test.
- Active-toggle contrast: `.toggle-group button.active` no longer uses a translucent background var as text color (WCAG-failed on `desert-sunset`/`midnight-aurora`); it now uses `--text-primary` on an accent-tinted highlight — verified legible in-browser across themes.
- `@keyframes rainfall`: restored the `100vh` fallback alongside `100dvh`.
- Memoization: `pollCurrent` now keeps a stable `current` reference when the observation timestamp is unchanged, so memoized cards actually skip re-render on identical polls (completes P2.13's intent).

**Verification:** `npm test` **70 passing** (up from 55), `npm run build` clean, `npx tsc --noEmit` clean. The settings modal and theme switching were verified in a real browser (Go binary embedding this UI, fed live data via a UDP packet) across themes including `desert-sunset` and `the-grid`.
