### PR TITLE
Records summary card (windowed observation aggregates)

### DIFF
--- a/docs/designs/2026-07-21-records-summary-design.md
+++ b/docs/designs/2026-07-21-records-summary-design.md
@@ -1,0 +1,117 @@
+# Design — Records summary card (windowed observation aggregates)
+
+**Type:** design
+**Date:** 2026-07-21
+**Feature:** Records summary card
+**Status:** approved (visual validated in-browser across all 7 themes); ready for implementation planning.
+
+## 1. Goal
+
+Add a **Records** card to the dashboard, full-width directly above the 7-Day Forecast, showing aggregate weather records over a user-selected rolling window (7 / 30 / 180 / 365 days). Metrics:
+
+| Tile | Aggregate | Source column |
+|------|-----------|---------------|
+| Temperature | max & min | `air_temperature` |
+| Humidity | max & min | `relative_humidity` |
+| Pressure | max & min | `station_pressure` |
+| Wind | max sustained & max gust (one tile) | `wind_avg`, `wind_gust` |
+| Rain total | sum | `rain_rate` (per-interval accumulation, mm) |
+| Lightning | sum (total strikes) | `lightning_strike_count` |
+
+The values are computed from the local SQLite observation store (the same store the dashboard already reads), **not** from the token-gated WeatherFlow almanac.
+
+## 2. Why a new backend endpoint (not the existing history read)
+
+The existing `HistoryPoints(field, from, to)` returns raw samples of **one** field, capped at `maxHistoryPoints = 10000`, with no aggregation. Computing min/max/sum over up to 365 days (~525k rows) × multiple fields client-side is both **incorrect** (the 10k cap truncates) and **infeasible** (payload). A single server-side SQL aggregation query returns one small object correctly and cheaply, so the feature adds a dedicated summary endpoint. (This does not touch or change `HistoryPoints`; storage is unaffected — no data is lost or pruned.)
+
+## 3. Backend
+
+### 3.1 SQLite aggregation method
+New method on the SQLite reader (`internal/sqlite`), sibling to `LatestObservation`/`HistoryPoints`:
+
+```
+SummarizeObservations(ctx, from, to int64) (Summary, error)
+```
+
+One query over `tempest_observations WHERE timestamp BETWEEN ? AND ?`:
+- `MIN`/`MAX` of `air_temperature`, `relative_humidity`, `station_pressure`
+- `MAX` of `wind_avg`, `wind_gust`
+- `SUM` of `rain_rate` (window rain total, mm) and `lightning_strike_count` (total strikes)
+- `COUNT(*)` and `MIN(timestamp)`/`MAX(timestamp)` — so the UI knows actual coverage (partial-data awareness)
+
+The range scan is index-backed by the existing `UNIQUE(serial_number, timestamp)`. Aggregation runs on the single writer connection (`SetMaxOpenConns(1)`); this is acceptable because the endpoint is called on load and on window change, **not** on the 3s/30s tick (not a hot path). `rain_rate` holds the Tempest `ob[12]` per-interval rain accumulation (mm), so `SUM` is the correct window total — documented at the query.
+
+`Summary` fields are nullable/zero-aware: an empty window (no rows) yields a well-formed "no data" result (counts 0), not an error.
+
+### 3.2 HTTP handler
+New route in `internal/httpserver`:
+
+```
+GET /api/observations/summary?days=N
+```
+
+- Validate `N ∈ {7, 30, 180, 365}`; otherwise `400`.
+- `to = now`, `from = now − N·86400` (rolling window, UTC seconds).
+- Response: Contract-C JSON in **SI units** (°C, mb, m/s, mm) — consistent with `/current` and `/history`; the frontend formats to the user's unit prefs. Shape includes each metric's aggregate plus `count`, `coveredFrom`, `coveredTo`.
+- Reuses the existing `Observations` dependency seam on the server (extend it with `SummarizeObservations`).
+
+### 3.3 Contract-C shape (illustrative)
+```json
+{
+  "window": { "days": 7, "from": 1719000000, "to": 1719604800 },
+  "count": 9720,
+  "coveredFrom": 1719000600, "coveredTo": 1719604700,
+  "temperature": { "max": 25.6, "min": 5.0 },
+  "humidity":    { "max": 94.0, "min": 38.0 },
+  "pressure":    { "max": 1023.4, "min": 1003.8 },
+  "windMax":     15.2,
+  "gustMax":     22.1,
+  "rainTotal":   31.5,
+  "lightningTotal": 12
+}
+```
+(Exact field names finalized in the plan; frontend `types/weather.ts` is the single source, mirrored by the Go struct's JSON tags — same discipline as Contract C elsewhere.)
+
+## 4. Frontend
+
+### 4.1 RecordsCard component
+- New `web/src/components/RecordsCard.tsx`, `React.memo` (consistent with the W5 memoization pass).
+- Full-width in the dashboard grid (`grid-column: 1 / -1`), inserted in `App.tsx` immediately **before** `<ForecastStrip>`.
+- Layout (validated in-browser across all 7 themes):
+  - Header: "Records" title + a right-aligned **window pill** ("Last 7 days", reflecting the selected window).
+  - Responsive tile grid (`repeat(auto-fit, minmax(150px, 1fr))`), 6 tiles: **Temperature · Humidity · Pressure · Wind · Rain total · Lightning**.
+  - Paired tiles (Temp/Humidity/Pressure, and Wind) render **two rows**: label on the left, value **right-aligned with `font-variant-numeric: tabular-nums`** so digits line up. No ▲▼ arrows.
+  - **Labels (`High`/`Low`/`Sustained`/`Gust`) use `var(--text-secondary)`, NOT semantic `--danger`/`--info`** — the theme matrix proved red/blue labels wash out on the light themes (desert-sunset, liquid-glass). This is a hard requirement (same contrast trap as the W5 toggle bug).
+  - Single-value tiles (Rain total, Lightning) show the value + a muted unit suffix. Every value carries its unit (including pressure).
+  - CSS lives in `web/src/App.css` reusing the existing per-theme custom properties + `.glass-card`; enumerated transitions, `:focus-visible` where interactive, dvh where a viewport height is used — matching the W5 conventions.
+- Values format to the user's unit prefs via the existing `useUnits` helpers (temp F/C, wind mph/kph/ms/kts, pressure inHg/mb/hPa, rain in/mm).
+
+### 4.2 Data
+- Fetched in `useWeatherData` (or a small dedicated hook) keyed on the selected window pref: `GET /api/observations/summary?days=<pref>`. Re-fetches when the window pref changes. AbortController + failure handling consistent with the existing fetch layer (retain prior data on transient failure).
+
+### 4.3 Settings — window selector
+- New "Records window" segmented control in `SettingsPanel` (7 / 30 / 180 / 365 days), reusing the W5 `.toggle-group` styling.
+- Persisted in `UserPreferences` (localStorage), new field `recordsWindowDays`, **default 7**.
+
+## 5. Edge cases
+- **Partial data** (fresh DB with < window of history): aggregates over what exists; the header may indicate real coverage from `coveredFrom`/`coveredTo` (e.g. still labeled "Last 7 days" but data may be shorter). No error.
+- **No data** (`count == 0`): tiles render em-dashes / "No data yet".
+- **Loading**: placeholder/skeleton; on fetch failure, retain last good summary if present.
+- **NaN/valid guards**: skip/represent missing aggregates safely (mirrors the existing null-safe formatting).
+
+## 6. Testing
+- **Go:** `SummarizeObservations` SQL correctness (seed rows spanning a window, assert min/max/sum/count/coverage; empty-window case) + handler param validation (`days` allowlist, 400s) + Contract-C JSON shape.
+- **TS:** RecordsCard rendering (paired vs single tiles, unit formatting, window-pill label), Settings window control (persist + re-fetch), empty/partial states. RED-first for behavior-bearing bits.
+- **In-browser gate:** build the binary embedding the UI, seed a spread of observations, confirm the card renders real aggregates and switches with the window selector — and re-run the theme matrix for label legibility.
+
+## 7. Out of scope (YAGNI / follow-ups)
+- Multi-station serial scoping (single-station assumption today; add a serial filter when a real multi-station need arrives).
+- Per-metric independent windows (one global window controls the whole card).
+- Calculated-value records (e.g. max wet-bulb) — could be added as tiles later; the derived-values work is tracked in issue #78.
+- Historical drill-down charts (separate feature).
+
+## 8. Principles check
+- **DRY:** unit formatting reuses `useUnits`; the summary JSON shape is single-sourced (TS types ↔ Go tags); the aggregation is one query, one place.
+- **KISS:** one endpoint, one SQL query, one card; no client-side aggregation, no caching layer (not needed at this call frequency).
+- **No-Wall:** the summary endpoint is additive (new handler + new sqlite method + new component), siblings untouched; a future metric is a new column in the query + a new tile.
+- **YAGNI:** rolling window only; no per-metric windows, no multi-station, no export.

--- a/docs/designs/2026-07-21-records-summary-design.md
+++ b/docs/designs/2026-07-21-records-summary-design.md
@@ -3,28 +3,43 @@
 **Type:** design
 **Date:** 2026-07-21
 **Feature:** Records summary card
-**Status:** approved (visual validated in-browser across all 7 themes); ready for implementation planning.
+**Status:** approved (visual validated in-browser across all 7 themes) + SGE (Fable) backend review folded in — "ready with changes" resolved below. Ready for implementation planning.
 
 ## 1. Goal
 
 Add a **Records** card to the dashboard, full-width directly above the 7-Day Forecast, showing aggregate weather records over a user-selected rolling window (7 / 30 / 180 / 365 days). Metrics:
 
-| Tile | Aggregate | Source column |
-|------|-----------|---------------|
-| Temperature | max & min | `air_temperature` |
-| Humidity | max & min | `relative_humidity` |
-| Pressure | max & min | `station_pressure` |
+| Tile | Aggregate | DB column (`tempest_observations`) |
+|------|-----------|-------------------------------------|
+| Temperature | max & min | `temp_air` |
+| Humidity | max & min | `humidity` |
+| Pressure | max & min | `pressure` |
 | Wind | max sustained & max gust (one tile) | `wind_avg`, `wind_gust` |
-| Rain total | sum | `rain_rate` (per-interval accumulation, mm) |
+| Rain total | sum | `rain_rate` (Tempest `obs_st[12]` = per-interval accumulation, mm) |
 | Lightning | sum (total strikes) | `lightning_strike_count` |
 
-The values are computed from the local SQLite observation store (the same store the dashboard already reads), **not** from the token-gated WeatherFlow almanac.
+> Column names are the **actual DB columns** (verified in `migrations/0001_init.sql` / `observationRow` in `writer.go`), not the Contract-C wire names — the SQL must use these.
+
+The values are computed from the local SQLite observation store (the same store the dashboard already reads), **not** from the token-gated WeatherFlow almanac. (Keep the new type/naming clearly distinct from the existing `StationAlmanac`/`TempRecord` almanac types in `weather.ts`.)
 
 ## 2. Why a new backend endpoint (not the existing history read)
 
-The existing `HistoryPoints(field, from, to)` returns raw samples of **one** field, capped at `maxHistoryPoints = 10000`, with no aggregation. Computing min/max/sum over up to 365 days (~525k rows) × multiple fields client-side is both **incorrect** (the 10k cap truncates) and **infeasible** (payload). A single server-side SQL aggregation query returns one small object correctly and cheaply, so the feature adds a dedicated summary endpoint. (This does not touch or change `HistoryPoints`; storage is unaffected — no data is lost or pruned.)
+`HistoryPoints(field, from, to)` returns raw samples of **one** field, capped at `maxHistoryPoints = 10000`, no aggregation. Computing min/max/sum over up to 365 days (~525k rows) × multiple fields client-side is both **incorrect** (the 10k cap truncates) and **infeasible** (payload). One server-side SQL aggregation returns a small object correctly and cheaply. This does not touch `HistoryPoints`; storage is unaffected (no data lost or pruned).
 
 ## 3. Backend
+
+### 3.0 Read path & writer-starvation mitigation (resolved from SGE review — REQUIRED)
+
+The aggregation is a deliberately heavy read, and the design must not starve the ingest writer. Three points, in priority order:
+
+1. **Timestamp index (required, new migration `0002`).** The existing indexes (`UNIQUE(serial_number, timestamp)` on observations and rapid_wind) lead with `serial_number`; a `WHERE timestamp BETWEEN ?` query with **no** `serial_number` predicate cannot use them, so it would full-scan the table on *every* call (even 7-day windows). Add, via the embedded `schema_version`/`Migrate` path:
+   ```sql
+   -- 0002_obs_timestamp_index.sql
+   CREATE INDEX IF NOT EXISTS idx_obs_timestamp ON tempest_observations(timestamp);
+   ```
+   so 7/30-day windows scan only their slice.
+2. **Dedicated read-only `*sql.DB` for reads (chosen approach).** The ingest path opens the DB with `SetMaxOpenConns(1)` (`db.go`) to serialize *writes*; reads currently share that one connection (so `/current`'s `LatestObservation` + 3h `HistoryPoints`, and this new summary, all queue behind the writer). Open a **second, read-only `*sql.DB`** (WAL journal mode — already set — supports one writer concurrent with many readers without `SQLITE_BUSY`) and route `SummarizeObservations` (and, additively, the other reads) through it. This decouples heavy reads from ingest entirely and de-risks the existing `/current`+`/history` fan-out too. It removes coupling — a clean seam, not speculative structure. *(Lighter fallback if we choose not to add the read handle now: keep the single connection but rely on the index + the deadline below. The read handle is the recommended fix.)*
+3. **Context deadline (required regardless of 1–2).** `SummarizeObservations` runs under a `context` with a few-second deadline; a timeout maps to `503`/`500` so a pathological scan can never stall ingest unboundedly.
 
 ### 3.1 SQLite aggregation method
 New method on the SQLite reader (`internal/sqlite`), sibling to `LatestObservation`/`HistoryPoints`:
@@ -34,26 +49,24 @@ SummarizeObservations(ctx, from, to int64) (Summary, error)
 ```
 
 One query over `tempest_observations WHERE timestamp BETWEEN ? AND ?`:
-- `MIN`/`MAX` of `air_temperature`, `relative_humidity`, `station_pressure`
+- `MIN`/`MAX` of `temp_air`, `humidity`, `pressure`
 - `MAX` of `wind_avg`, `wind_gust`
-- `SUM` of `rain_rate` (window rain total, mm) and `lightning_strike_count` (total strikes)
-- `COUNT(*)` and `MIN(timestamp)`/`MAX(timestamp)` — so the UI knows actual coverage (partial-data awareness)
+- `SUM` of `rain_rate` (window rain total, mm — correct because `obs_st[12]` is per-interval accumulation and rows are deduped by `ON CONFLICT(serial_number,timestamp) DO NOTHING`) and `lightning_strike_count` (total strikes)
+- `COUNT(*)` and `MIN(timestamp)`/`MAX(timestamp)` — actual coverage (partial-data awareness)
 
-The range scan is index-backed by the existing `UNIQUE(serial_number, timestamp)`. Aggregation runs on the single writer connection (`SetMaxOpenConns(1)`); this is acceptable because the endpoint is called on load and on window change, **not** on the 3s/30s tick (not a hot path). `rain_rate` holds the Tempest `ob[12]` per-interval rain accumulation (mm), so `SUM` is the correct window total — documented at the query.
-
-`Summary` fields are nullable/zero-aware: an empty window (no rows) yields a well-formed "no data" result (counts 0), not an error.
+**NULL handling is explicit, not implicit.** Over 0 rows (or all-NULL columns) `MIN/MAX/SUM` return `NULL`, not 0. The Go scan therefore uses `sql.NullFloat64`/`sql.NullInt64` for every aggregate and nullable `coveredFrom`/`coveredTo`, and treats `COUNT(*) == 0` as the empty-window signal. `lightning_strike_count` is itself a nullable column, so a partial-NULL window is a real case (covered by a test).
 
 ### 3.2 HTTP handler
-New route in `internal/httpserver`:
+New route in `internal/httpserver`, extending the existing **`ObservationReader`** interface (the `Deps.Observations` seam) with `SummarizeObservations` — additive, implemented by `*sqlite.Writer`, test fake updated (No-Wall):
 
 ```
 GET /api/observations/summary?days=N
 ```
 
-- Validate `N ∈ {7, 30, 180, 365}`; otherwise `400`.
-- `to = now`, `from = now − N·86400` (rolling window, UTC seconds).
-- Response: Contract-C JSON in **SI units** (°C, mb, m/s, mm) — consistent with `/current` and `/history`; the frontend formats to the user's unit prefs. Shape includes each metric's aggregate plus `count`, `coveredFrom`, `coveredTo`.
-- Reuses the existing `Observations` dependency seam on the server (extend it with `SummarizeObservations`).
+- Validate `N ∈ {7, 30, 180, 365}`. **Missing or invalid `days` → `400`** (deliberately stricter than `/history`, which degrades to defaults — called out so it's intentional, not an oversight).
+- `to = now`, `from = now − N·86400` (rolling window; UTC epoch seconds — TZ-independent, no DST/calendar pitfalls).
+- **Error/HTTP mapping** (matching existing handlers): reader `nil` → `503`; query error/timeout → `500`/`503`; empty window (`count == 0`) → `200` with a well-formed zero/no-data body.
+- Response: Contract-C JSON in **SI units** (°C, mb, m/s, mm) — consistent with `/current`; the frontend formats to the user's unit prefs.
 
 ### 3.3 Contract-C shape (illustrative)
 ```json
@@ -70,7 +83,7 @@ GET /api/observations/summary?days=N
   "lightningTotal": 12
 }
 ```
-(Exact field names finalized in the plan; frontend `types/weather.ts` is the single source, mirrored by the Go struct's JSON tags — same discipline as Contract C elsewhere.)
+The **TS type is the single source**: the plan adds a `RecordsSummary` interface to `web/src/types/weather.ts` first, and the Go struct's JSON tags mirror it. Note the nested `{max,min}` objects are a new pattern vs `/current`'s flat fields — a deliberate choice, not accidental. Missing aggregates (empty/partial window) serialize as `null` and the UI renders them safely. Exact field names finalized in the plan.
 
 ## 4. Frontend
 
@@ -78,12 +91,12 @@ GET /api/observations/summary?days=N
 - New `web/src/components/RecordsCard.tsx`, `React.memo` (consistent with the W5 memoization pass).
 - Full-width in the dashboard grid (`grid-column: 1 / -1`), inserted in `App.tsx` immediately **before** `<ForecastStrip>`.
 - Layout (validated in-browser across all 7 themes):
-  - Header: "Records" title + a right-aligned **window pill** ("Last 7 days", reflecting the selected window).
+  - Header: "Records" title + right-aligned **window pill** ("Last 7 days", reflecting the selected window).
   - Responsive tile grid (`repeat(auto-fit, minmax(150px, 1fr))`), 6 tiles: **Temperature · Humidity · Pressure · Wind · Rain total · Lightning**.
   - Paired tiles (Temp/Humidity/Pressure, and Wind) render **two rows**: label on the left, value **right-aligned with `font-variant-numeric: tabular-nums`** so digits line up. No ▲▼ arrows.
-  - **Labels (`High`/`Low`/`Sustained`/`Gust`) use `var(--text-secondary)`, NOT semantic `--danger`/`--info`** — the theme matrix proved red/blue labels wash out on the light themes (desert-sunset, liquid-glass). This is a hard requirement (same contrast trap as the W5 toggle bug).
-  - Single-value tiles (Rain total, Lightning) show the value + a muted unit suffix. Every value carries its unit (including pressure).
-  - CSS lives in `web/src/App.css` reusing the existing per-theme custom properties + `.glass-card`; enumerated transitions, `:focus-visible` where interactive, dvh where a viewport height is used — matching the W5 conventions.
+  - **Labels (`High`/`Low`/`Sustained`/`Gust`) use `var(--text-secondary)`, NOT semantic `--danger`/`--info`** — the theme matrix proved red/blue labels wash out on the light themes (desert-sunset, liquid-glass). Hard requirement (same contrast trap as the W5 toggle bug).
+  - Single-value tiles (Rain total, Lightning) show value + muted unit suffix. Every value carries its unit (including pressure).
+  - CSS in `web/src/App.css` reusing the per-theme custom properties + `.glass-card`; enumerated transitions, `:focus-visible` where interactive, dvh where a viewport height is used — matching W5 conventions.
 - Values format to the user's unit prefs via the existing `useUnits` helpers (temp F/C, wind mph/kph/ms/kts, pressure inHg/mb/hPa, rain in/mm).
 
 ### 4.2 Data
@@ -94,24 +107,24 @@ GET /api/observations/summary?days=N
 - Persisted in `UserPreferences` (localStorage), new field `recordsWindowDays`, **default 7**.
 
 ## 5. Edge cases
-- **Partial data** (fresh DB with < window of history): aggregates over what exists; the header may indicate real coverage from `coveredFrom`/`coveredTo` (e.g. still labeled "Last 7 days" but data may be shorter). No error.
+- **Partial data** (fresh DB with < window of history): aggregates over what exists; header may indicate real coverage from `coveredFrom`/`coveredTo`. No error.
 - **No data** (`count == 0`): tiles render em-dashes / "No data yet".
 - **Loading**: placeholder/skeleton; on fetch failure, retain last good summary if present.
-- **NaN/valid guards**: skip/represent missing aggregates safely (mirrors the existing null-safe formatting).
+- **NULL aggregates**: `sql.Null*` scan + `null` JSON → UI renders em-dash (mirrors existing null-safe formatting).
 
 ## 6. Testing
-- **Go:** `SummarizeObservations` SQL correctness (seed rows spanning a window, assert min/max/sum/count/coverage; empty-window case) + handler param validation (`days` allowlist, 400s) + Contract-C JSON shape.
-- **TS:** RecordsCard rendering (paired vs single tiles, unit formatting, window-pill label), Settings window control (persist + re-fetch), empty/partial states. RED-first for behavior-bearing bits.
-- **In-browser gate:** build the binary embedding the UI, seed a spread of observations, confirm the card renders real aggregates and switches with the window selector — and re-run the theme matrix for label legibility.
+- **Go:** `SummarizeObservations` correctness (seed rows spanning a window; assert min/max/sum/count/coverage); **empty-window (0 rows) → all-null result**; **partial-NULL `lightning_strike_count` window** and an all-NULL-column window (prove `sql.Null*` handling); a **large-seed** case to sanity-check the `0002` index actually restricts the scan. Handler param validation (`days` allowlist incl. missing/invalid → 400) + Contract-C JSON shape + error mapping (nil reader → 503).
+- **TS:** RecordsCard rendering (paired vs single tiles, unit formatting, window-pill label), Settings window control (persist + re-fetch), empty/partial/loading states. RED-first for behavior-bearing bits.
+- **In-browser gate:** build the binary embedding the UI, seed a spread of observations across the window, confirm the card renders real aggregates and switches with the window selector — and re-run the theme matrix for label legibility.
 
 ## 7. Out of scope (YAGNI / follow-ups)
-- Multi-station serial scoping (single-station assumption today; add a serial filter when a real multi-station need arrives).
+- Multi-station serial scoping (single-station assumption today, consistent with `LatestObservationAny`; add a serial filter when a real multi-station need arrives).
 - Per-metric independent windows (one global window controls the whole card).
-- Calculated-value records (e.g. max wet-bulb) — could be added as tiles later; the derived-values work is tracked in issue #78.
+- Calculated-value records (e.g. max wet-bulb) — could be added as tiles later; derived-values work tracked in issue #78.
 - Historical drill-down charts (separate feature).
 
 ## 8. Principles check
-- **DRY:** unit formatting reuses `useUnits`; the summary JSON shape is single-sourced (TS types ↔ Go tags); the aggregation is one query, one place.
-- **KISS:** one endpoint, one SQL query, one card; no client-side aggregation, no caching layer (not needed at this call frequency).
-- **No-Wall:** the summary endpoint is additive (new handler + new sqlite method + new component), siblings untouched; a future metric is a new column in the query + a new tile.
+- **DRY:** unit formatting reuses `useUnits`; summary JSON shape single-sourced (TS types ↔ Go tags); one aggregation query, one place.
+- **KISS:** one endpoint, one SQL query, one card; no client-side aggregation, no caching. The one under-KISS spot the SGE flagged — reusing the writer's single connection for a heavy read — is fixed by §3.0 (the read handle *removes* coupling, it doesn't add speculative structure).
+- **No-Wall:** additive throughout (new handler + new reader method + new component + new migration); a future metric is a new column in the query + a new tile; the read-only `*sql.DB` is a clean seam.
 - **YAGNI:** rolling window only; no per-metric windows, no multi-station, no export.

--- a/docs/plans/2026-07-21-records-summary-implementation.md
+++ b/docs/plans/2026-07-21-records-summary-implementation.md
@@ -1,0 +1,502 @@
+# Records Summary Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **For Claude:** REQUIRED EXECUTION WORKFLOW (follow in order):
+> 1. `superpowers:using-git-worktrees` — already in worktree `.claude/worktrees/records-summary` (branch `worktree-records-summary`, off `origin/main` eee1153).
+> 2. `superpowers:subagent-driven-development` — fresh subagent per task; model topology: Go tasks → **sr-go-engineer/Sonnet**, TS tasks → **general-purpose/Sonnet**; per-task review **general-purpose/Opus**; final cold whole-branch review **general-purpose/Fable**.
+> 3. `superpowers:test-driven-development` — every task RED-first.
+> 4. `superpowers:verification-before-completion` — per task.
+> 5. After all tasks: cold whole-branch review + **in-browser gate** (build the binary, seed observations across a window, confirm the card renders/aggregates/switches; re-run the theme matrix).
+> 6. `superpowers:finishing-a-development-branch` — USER-GATED (jacaudi's own repo; merge-commit precedent).
+> Skills carry their own model/effort settings. Do not override them.
+
+**Goal:** Add a full-width "Records" card above the 7-day forecast showing windowed observation aggregates (max/min temp/humidity/pressure, combined sustained+gust wind, rain total, lightning total) over a 7/30/180/365-day rolling window selectable in Settings.
+
+**Architecture:** A new server-side SQL aggregation endpoint (`GET /api/observations/summary?days=N`) reading SQLite through a **dedicated read-only `*sql.DB`** (WAL enables readers concurrent with the single ingest writer, decoupling the heavy scan from the write connection); the timestamp index `idx_obs_time` (migration `0002`, already on main) serves the range. Contract-C SI-unit JSON, formatted to the user's unit prefs client-side; a memoized `RecordsCard` React component + a Settings window selector.
+
+**Tech Stack:** Go 1.25 (`modernc.org/sqlite`, `database/sql`, `net/http`, `CGO_ENABLED=0`); Vite + React 18 + TypeScript + Vitest/RTL.
+
+## Global Constraints
+
+- CGO-free: `CGO_ENABLED=0` stays buildable — pure-Go `modernc.org/sqlite` only, never `mattn/go-sqlite3`.
+- Contract C: `web/src/types/weather.ts` is the **single source** of JSON field names; the Go wire struct's `json:` tags mirror it exactly. Backend emits **SI units** (°C, mb, m/s, mm); the frontend formats to prefs via `useUnits`. New type is `RecordsSummary`, kept distinct from the existing `StationAlmanac`/`TempRecord` almanac types.
+- Real DB columns (NOT Contract-C names): `temp_air`, `humidity`, `pressure`, `wind_avg`, `wind_gust`, `rain_rate` (per-interval mm accumulation), `lightning_strike_count`. Timestamps are UTC epoch-second integers.
+- `days` allowlist: exactly `{7, 30, 180, 365}`; missing/invalid → HTTP 400 (deliberately stricter than `/history`).
+- NULL discipline: `MIN/MAX/SUM` over 0 rows (or all-NULL columns) return SQL `NULL`, not 0; scan with `sql.Null*`; `COUNT(*)==0` is the empty signal; absent aggregates serialize as JSON `null` and render as em-dash.
+- Records-window labels (`High`/`Low`/`Sustained`/`Gust`) use `var(--text-secondary)`, never `--danger`/`--info` (theme-contrast requirement; verified across all 7 themes).
+- The read-only handle uses `mode=ro` and **must not** set `journal_mode` (a read-only connection can't run that write PRAGMA; the DB is already WAL). It is opened AFTER the write handle (whose `Open` runs migrations and creates the `-wal`/`-shm` files).
+
+## File Structure
+
+- `internal/sqlite/db.go` — add `OpenReadOnly`.
+- `internal/sqlite/writer.go` — add `readDB` field + `WithReadDB` option; route reads through `readDB`; add `Summary` + `SummarizeObservations`.
+- `internal/sqlite/summary_test.go` — new; `SummarizeObservations` tests.
+- `internal/httpserver/observations.go` — extend `ObservationReader`; add `summaryResponse` wire shape + `handleSummary`; register route.
+- `internal/httpserver/observations_test.go` — extend `fakeObservationReader`; handler tests.
+- `main.go` — open the read-only handle, pass `WithReadDB`, close it on shutdown.
+- `web/src/types/weather.ts` — add `RecordsSummary`; add `recordsWindowDays` to `UserPreferences`.
+- `web/src/api/tempestApi.ts` — add `ENDPOINTS.summary` + `fetchRecordsSummary`.
+- `web/src/hooks/useWeatherData.ts` — fetch the summary keyed on the window pref.
+- `web/src/hooks/usePreferences.ts` (or wherever prefs default lives) — default `recordsWindowDays: 7`.
+- `web/src/components/RecordsCard.tsx` (+ `RecordsCard.test.tsx`) — new component.
+- `web/src/components/SettingsPanel.tsx` (+ test) — window selector.
+- `web/src/App.tsx` — render `<RecordsCard>` before `<ForecastStrip>`.
+- `web/src/App.css` — Records card CSS.
+
+---
+
+## Task 1: Read-only SQLite handle + route reads through it
+
+**Files:**
+- Modify: `internal/sqlite/db.go` (add `OpenReadOnly`), `internal/sqlite/writer.go` (`readDB` field, `WithReadDB`, route reads), `main.go` (wire + close).
+- Test: `internal/sqlite/db_test.go` (or `writer_test.go`).
+
+**Interfaces:**
+- Produces: `func OpenReadOnly(ctx context.Context, path string, cfg Config) (*sql.DB, error)`; `type WriterOption func(*Writer)`; `func WithReadDB(db *sql.DB) WriterOption`; `NewWriter(ctx, db, cfg, opts ...WriterOption)` (variadic — existing callers unchanged).
+- Consumes: existing `Open`, `Config` (has `BusyTimeout`), `driverName`.
+
+- [ ] **Step 1: Write the failing test** — `internal/sqlite/db_test.go`:
+```go
+func TestOpenReadOnly_ReadsWriterData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	cfg := Config{BusyTimeout: 5000, BatchSize: 1, FlushInterval: time.Second}
+	ctx := context.Background()
+
+	wdb, err := Open(ctx, path, cfg) // runs migrations, creates WAL
+	if err != nil { t.Fatal(err) }
+	defer wdb.Close()
+
+	// seed one observation row directly
+	_, err = wdb.ExecContext(ctx, `INSERT INTO tempest_observations
+		(id, serial_number, timestamp, temp_air) VALUES ('a','ST-1',100,21.5)`)
+	if err != nil { t.Fatal(err) }
+
+	rdb, err := OpenReadOnly(ctx, path, cfg)
+	if err != nil { t.Fatalf("OpenReadOnly: %v", err) }
+	defer rdb.Close()
+
+	var got float64
+	if err := rdb.QueryRowContext(ctx, `SELECT temp_air FROM tempest_observations WHERE id='a'`).Scan(&got); err != nil {
+		t.Fatalf("read via read-only handle: %v", err)
+	}
+	if got != 21.5 { t.Fatalf("got %v want 21.5", got) }
+}
+```
+- [ ] **Step 2: Run — expect FAIL** (`OpenReadOnly` undefined). `go test ./internal/sqlite/ -run TestOpenReadOnly -v`
+- [ ] **Step 3: Implement `OpenReadOnly`** in `db.go`:
+```go
+// OpenReadOnly opens a read-only handle to an existing SQLite database for
+// query-side work. It must be opened AFTER Open (which creates/migrates the
+// DB and its WAL files). WAL journaling lets these read connections run
+// concurrently with the single ingest writer without SQLITE_BUSY. It does
+// NOT set journal_mode (a read-only connection can't run that write PRAGMA;
+// the DB is already WAL from Open).
+func OpenReadOnly(ctx context.Context, path string, cfg Config) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)&_pragma=foreign_keys(1)", path, cfg.BusyTimeout)
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite read-only: %w", err)
+	}
+	db.SetMaxOpenConns(4) // concurrent readers alongside the writer (WAL)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping sqlite read-only: %w", err)
+	}
+	return db, nil
+}
+```
+- [ ] **Step 4: Add `readDB` + `WithReadDB`** in `writer.go`. Add field `readDB *sql.DB` to the `Writer` struct. Add:
+```go
+// WriterOption configures a Writer at construction.
+type WriterOption func(*Writer)
+
+// WithReadDB routes read methods (LatestObservation*, HistoryPoints,
+// SummarizeObservations) through a dedicated read-only handle instead of the
+// single write connection, so heavy reads never queue behind ingest.
+func WithReadDB(db *sql.DB) WriterOption {
+	return func(w *Writer) { w.readDB = db }
+}
+```
+In `NewWriter`, change signature to `func NewWriter(ctx context.Context, db *sql.DB, cfg Config, opts ...WriterOption) *Writer`; after building `w`, apply `for _, o := range opts { o(w) }`, then `if w.readDB == nil { w.readDB = db }`. Change the read methods `LatestObservation`, `LatestObservationAny`, `HistoryPoints` to use `w.readDB` instead of `w.db` (writes stay on `w.db`).
+- [ ] **Step 5: Run — expect PASS.** Also `go test ./internal/sqlite/ ./internal/httpserver/ -race` (existing reads still pass; `readDB` defaults to `db`).
+- [ ] **Step 6: Wire in `main.go`.** After `db, err := sqlite.Open(ctx, choice.sqlitePath, sqliteCfg)` (~line 296) and its error check, add:
+```go
+rdb, err := sqlite.OpenReadOnly(ctx, choice.sqlitePath, sqliteCfg)
+if err != nil {
+	return fmt.Errorf("open sqlite read handle: %w", err)
+}
+```
+Change the `sw = sqlite.NewWriter(ctx, db, sqliteCfg)` call to `sw = sqlite.NewWriter(ctx, db, sqliteCfg, sqlite.WithReadDB(rdb))`. Ensure `rdb.Close()` is called on shutdown wherever `db.Close()` is (close `rdb` before/after `db` — order doesn't matter, both after the writer drains).
+- [ ] **Step 7: Verify build + run-the-binary smoke.** `CGO_ENABLED=0 go build ./... && go vet ./...`; then start the binary with a temp `SQLITE_PATH`, confirm it boots + `/healthz` 200 (read handle opens cleanly).
+- [ ] **Step 8: Commit** `feat(sqlite): read-only handle for query-side reads (decouple from ingest writer)`.
+
+---
+
+## Task 2: `SummarizeObservations` aggregation
+
+**Files:**
+- Modify: `internal/sqlite/writer.go`.
+- Test: `internal/sqlite/summary_test.go` (new).
+
+**Interfaces:**
+- Produces: `type Summary struct {…}` and `func (w *Writer) SummarizeObservations(ctx context.Context, from, to int64) (Summary, error)`.
+- Consumes: `w.readDB` (Task 1).
+
+`Summary` (all aggregates nullable; `Count` drives emptiness):
+```go
+type Summary struct {
+	Count          int64
+	CoveredFrom    sql.NullInt64
+	CoveredTo      sql.NullInt64
+	TempMax        sql.NullFloat64
+	TempMin        sql.NullFloat64
+	HumidityMax    sql.NullFloat64
+	HumidityMin    sql.NullFloat64
+	PressureMax    sql.NullFloat64
+	PressureMin    sql.NullFloat64
+	WindMax        sql.NullFloat64
+	GustMax        sql.NullFloat64
+	RainTotal      sql.NullFloat64
+	LightningTotal sql.NullInt64
+}
+```
+
+- [ ] **Step 1: Write the failing test** — `summary_test.go`. Seed rows spanning [100,300]; assert aggregates; assert empty window (no rows) → `Count==0` and all `Valid==false`; assert a window with a NULL `lightning_strike_count` row still sums the non-null ones:
+```go
+func TestSummarizeObservations(t *testing.T) {
+	w, db := newTestWriter(t) // helper: Open + NewWriter (readDB defaults to db)
+	ctx := context.Background()
+	seed := func(id string, ts int64, temp, hum, pres, wavg, wgust, rain float64, ls sql.NullInt64) {
+		_, err := db.ExecContext(ctx, `INSERT INTO tempest_observations
+			(id, serial_number, timestamp, temp_air, humidity, pressure, wind_avg, wind_gust, rain_rate, lightning_strike_count)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			id, "ST-1", ts, temp, hum, pres, wavg, wgust, rain, ls)
+		if err != nil { t.Fatal(err) }
+	}
+	seed("a", 100, 10, 40, 1000, 3, 5, 0.5, sql.NullInt64{Int64: 2, Valid: true})
+	seed("b", 200, 25, 90, 1020, 8, 12, 1.0, sql.NullInt64{}) // NULL lightning
+	seed("c", 300, 18, 60, 1010, 5, 9, 0.25, sql.NullInt64{Int64: 3, Valid: true})
+
+	s, err := w.SummarizeObservations(ctx, 100, 300)
+	if err != nil { t.Fatal(err) }
+	if s.Count != 3 { t.Fatalf("count=%d", s.Count) }
+	if s.TempMax.Float64 != 25 || s.TempMin.Float64 != 10 { t.Fatalf("temp %v/%v", s.TempMax, s.TempMin) }
+	if s.WindMax.Float64 != 8 || s.GustMax.Float64 != 12 { t.Fatalf("wind %v/%v", s.WindMax, s.GustMax) }
+	if math.Abs(s.RainTotal.Float64-1.75) > 1e-9 { t.Fatalf("rain %v", s.RainTotal) }
+	if s.LightningTotal.Int64 != 5 { t.Fatalf("lightning=%d (want 5, NULL row skipped)", s.LightningTotal.Int64) }
+	if s.CoveredFrom.Int64 != 100 || s.CoveredTo.Int64 != 300 { t.Fatalf("coverage %v/%v", s.CoveredFrom, s.CoveredTo) }
+
+	empty, err := w.SummarizeObservations(ctx, 1000, 2000)
+	if err != nil { t.Fatal(err) }
+	if empty.Count != 0 || empty.TempMax.Valid || empty.RainTotal.Valid || empty.CoveredFrom.Valid {
+		t.Fatalf("empty window not all-null: %+v", empty)
+	}
+}
+```
+- [ ] **Step 2: Run — expect FAIL** (`SummarizeObservations` undefined).
+- [ ] **Step 3: Implement.** Add the SQL const and method (uses `w.readDB`):
+```go
+const summarizeObservationsSQL = `
+SELECT
+  COUNT(*),
+  MIN(timestamp), MAX(timestamp),
+  MAX(temp_air),  MIN(temp_air),
+  MAX(humidity),  MIN(humidity),
+  MAX(pressure),  MIN(pressure),
+  MAX(wind_avg),  MAX(wind_gust),
+  SUM(rain_rate),                 -- rain_rate = obs_st[12], per-interval mm accumulation → SUM = total mm
+  SUM(lightning_strike_count)
+FROM tempest_observations
+WHERE timestamp BETWEEN ? AND ?`
+
+// SummarizeObservations aggregates the observations in [from, to] into one
+// Summary. Aggregates over 0 rows (or all-NULL columns) are SQL NULL, surfaced
+// via sql.Null*; Count==0 signals an empty window. Runs on the read-only
+// handle so a wide scan never queues behind the ingest writer.
+func (w *Writer) SummarizeObservations(ctx context.Context, from, to int64) (Summary, error) {
+	var s Summary
+	err := w.readDB.QueryRowContext(ctx, summarizeObservationsSQL, from, to).Scan(
+		&s.Count, &s.CoveredFrom, &s.CoveredTo,
+		&s.TempMax, &s.TempMin, &s.HumidityMax, &s.HumidityMin,
+		&s.PressureMax, &s.PressureMin, &s.WindMax, &s.GustMax,
+		&s.RainTotal, &s.LightningTotal,
+	)
+	if err != nil {
+		return Summary{}, fmt.Errorf("summarize observations: %w", err)
+	}
+	return s, nil
+}
+```
+- [ ] **Step 4: Run — expect PASS.** `go test ./internal/sqlite/ -run TestSummarizeObservations -v`
+- [ ] **Step 5: Commit** `feat(sqlite): SummarizeObservations windowed aggregate`.
+
+---
+
+## Task 3: `GET /api/observations/summary` handler
+
+**Files:**
+- Modify: `internal/httpserver/observations.go`.
+- Test: `internal/httpserver/observations_test.go`.
+
+**Interfaces:**
+- Consumes: `Summary`, `SummarizeObservations` (Task 2); the `Deps.Observations` seam.
+- Produces: `GET /api/observations/summary?days=N` → `summaryResponse` JSON.
+
+Add `SummarizeObservations(ctx, from, to int64) (sqlite.Summary, error)` to the `ObservationReader` interface. Wire shape (mirrors `web/src/types/weather.ts` `RecordsSummary` from Task 4):
+```go
+type summaryMinMax struct {
+	Max *float64 `json:"max"`
+	Min *float64 `json:"min"`
+}
+type summaryWindow struct {
+	Days int   `json:"days"`
+	From int64 `json:"from"`
+	To   int64 `json:"to"`
+}
+type summaryResponse struct {
+	Window         summaryWindow `json:"window"`
+	Count          int64         `json:"count"`
+	CoveredFrom    *int64        `json:"coveredFrom"`
+	CoveredTo      *int64        `json:"coveredTo"`
+	Temperature    summaryMinMax `json:"temperature"`
+	Humidity       summaryMinMax `json:"humidity"`
+	Pressure       summaryMinMax `json:"pressure"`
+	WindMax        *float64      `json:"windMax"`
+	GustMax        *float64      `json:"gustMax"`
+	RainTotal      *float64      `json:"rainTotal"`
+	LightningTotal *int64        `json:"lightningTotal"`
+}
+
+const summaryQueryTimeout = 5 * time.Second
+var allowedSummaryDays = map[int]bool{7: true, 30: true, 180: true, 365: true}
+
+func f64(n sql.NullFloat64) *float64 { if n.Valid { v := n.Float64; return &v }; return nil }
+func i64(n sql.NullInt64) *int64     { if n.Valid { v := n.Int64;   return &v }; return nil }
+```
+
+- [ ] **Step 1: Write the failing test** — extend `fakeObservationReader` with a `SummarizeObservations` field/func, then:
+```go
+func TestHandleSummary_OK(t *testing.T) {
+	reader := &fakeObservationReader{summary: sqlite.Summary{
+		Count: 5, CoveredFrom: sql.NullInt64{Int64: 10, Valid: true}, CoveredTo: sql.NullInt64{Int64: 90, Valid: true},
+		TempMax: sql.NullFloat64{Float64: 25, Valid: true}, TempMin: sql.NullFloat64{Float64: 5, Valid: true},
+		WindMax: sql.NullFloat64{Float64: 8, Valid: true}, GustMax: sql.NullFloat64{Float64: 12, Valid: true},
+		RainTotal: sql.NullFloat64{Float64: 3.5, Valid: true}, LightningTotal: sql.NullInt64{Int64: 4, Valid: true},
+	}}
+	rr := httptest.NewRecorder()
+	newTestServer(reader).ServeHTTP(rr, httptest.NewRequest("GET", "/api/observations/summary?days=7", nil))
+	if rr.Code != 200 { t.Fatalf("code=%d", rr.Code) }
+	var got summaryResponse
+	json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.Window.Days != 7 || got.Count != 5 || *got.Temperature.Max != 25 || *got.RainTotal != 3.5 || *got.LightningTotal != 4 {
+		t.Fatalf("bad body: %+v", got)
+	}
+}
+func TestHandleSummary_BadDays(t *testing.T) {
+	for _, q := range []string{"", "?days=1", "?days=abc", "?days=8"} {
+		rr := httptest.NewRecorder()
+		newTestServer(&fakeObservationReader{}).ServeHTTP(rr, httptest.NewRequest("GET", "/api/observations/summary"+q, nil))
+		if rr.Code != 400 { t.Fatalf("days=%q code=%d want 400", q, rr.Code) }
+	}
+}
+func TestHandleSummary_NilReader(t *testing.T) {
+	rr := httptest.NewRecorder()
+	newTestServerNilObs().ServeHTTP(rr, httptest.NewRequest("GET", "/api/observations/summary?days=7", nil))
+	if rr.Code != 503 { t.Fatalf("code=%d want 503", rr.Code) }
+}
+```
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement `handleSummary`** and register it in `registerObservations`:
+```go
+mux.HandleFunc("GET /api/observations/summary", func(w http.ResponseWriter, r *http.Request) {
+	handleSummary(w, r, deps.Observations)
+})
+```
+```go
+func handleSummary(w http.ResponseWriter, r *http.Request, reader ObservationReader) {
+	if reader == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "observation store not configured")
+		return
+	}
+	days, err := strconv.Atoi(r.URL.Query().Get("days"))
+	if err != nil || !allowedSummaryDays[days] {
+		writeJSONError(w, http.StatusBadRequest, "days must be one of 7, 30, 180, 365")
+		return
+	}
+	to := time.Now().Unix()
+	from := to - int64(days)*86400
+	ctx, cancel := context.WithTimeout(r.Context(), summaryQueryTimeout)
+	defer cancel()
+	s, err := reader.SummarizeObservations(ctx, from, to)
+	if err != nil {
+		slog.ErrorContext(ctx, "httpserver: summarize observations", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to load records summary")
+		return
+	}
+	writeJSON(w, http.StatusOK, summaryResponse{
+		Window:      summaryWindow{Days: days, From: from, To: to},
+		Count:       s.Count,
+		CoveredFrom: i64(s.CoveredFrom), CoveredTo: i64(s.CoveredTo),
+		Temperature: summaryMinMax{Max: f64(s.TempMax), Min: f64(s.TempMin)},
+		Humidity:    summaryMinMax{Max: f64(s.HumidityMax), Min: f64(s.HumidityMin)},
+		Pressure:    summaryMinMax{Max: f64(s.PressureMax), Min: f64(s.PressureMin)},
+		WindMax:     f64(s.WindMax), GustMax: f64(s.GustMax),
+		RainTotal:   f64(s.RainTotal), LightningTotal: i64(s.LightningTotal),
+	})
+}
+```
+(Use the existing `writeJSON`/`writeJSONError` helpers; add imports `strconv`, `context`, `time`, `database/sql` as needed.)
+- [ ] **Step 4: Run — expect PASS.** `go test ./internal/httpserver/ -race -v`
+- [ ] **Step 5: Full backend gate.** `CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race`.
+- [ ] **Step 6: Commit** `feat(httpserver): GET /api/observations/summary endpoint`.
+
+---
+
+## Task 4: Contract-C `RecordsSummary` type + prefs field + API client
+
+**Files:**
+- Modify: `web/src/types/weather.ts`, `web/src/api/tempestApi.ts`, the prefs default (search for the `UserPreferences` default object, likely `web/src/hooks/usePreferences.ts` or `App.tsx`).
+- Test: `web/src/api/tempestApi.test.ts`.
+
+**Interfaces:**
+- Produces: `RecordsSummary`, `RecordsWindowDays`, `fetchRecordsSummary(days, signal)`, `UserPreferences.recordsWindowDays`.
+
+- [ ] **Step 1: Add types** to `weather.ts` (mirror the Go wire tags exactly):
+```ts
+export type RecordsWindowDays = 7 | 30 | 180 | 365;
+
+export interface RecordsMinMax { max: number | null; min: number | null; }
+
+export interface RecordsSummary {
+  window: { days: RecordsWindowDays; from: number; to: number };
+  count: number;
+  coveredFrom: number | null;
+  coveredTo: number | null;
+  temperature: RecordsMinMax;   // °C (SI)
+  humidity: RecordsMinMax;      // %
+  pressure: RecordsMinMax;      // mb (SI)
+  windMax: number | null;       // m/s (SI)
+  gustMax: number | null;       // m/s (SI)
+  rainTotal: number | null;     // mm (SI)
+  lightningTotal: number | null;
+}
+```
+Add `recordsWindowDays: RecordsWindowDays;` to `UserPreferences`.
+- [ ] **Step 2: Failing api test** — `tempestApi.test.ts`: mock `fetch` returning a `RecordsSummary`; assert `fetchRecordsSummary(7, signal)` GETs `/api/observations/summary?days=7` and returns the parsed object.
+- [ ] **Step 3: Run — FAIL.**
+- [ ] **Step 4: Implement** in `tempestApi.ts`: add `summary: '/api/observations/summary'` to `ENDPOINTS`, and:
+```ts
+export async function fetchRecordsSummary(days: RecordsWindowDays, signal?: AbortSignal): Promise<RecordsSummary> {
+  return getJSON<RecordsSummary>(`${ENDPOINTS.summary}?days=${days}`, signal);
+}
+```
+Set the default `recordsWindowDays: 7` in the `UserPreferences` default object (and any localStorage merge/validation so an old stored prefs object without the field falls back to 7).
+- [ ] **Step 5: Run — PASS**; `npx tsc --noEmit`.
+- [ ] **Step 6: Commit** `feat(web): RecordsSummary type + fetchRecordsSummary + recordsWindowDays pref`.
+
+---
+
+## Task 5: Fetch the summary in `useWeatherData`
+
+**Files:** Modify `web/src/hooks/useWeatherData.ts`; Test: `web/src/hooks/useWeatherData.test.ts`.
+
+**Interfaces:** Produces `summary: RecordsSummary | null` (and its loading/error state) on the hook's return, fetched with `fetchRecordsSummary(prefs.recordsWindowDays)`; re-fetches when `recordsWindowDays` changes.
+
+- [ ] **Step 1: Failing test** — render the hook with a mocked `fetchRecordsSummary`; assert it's called with the current `recordsWindowDays` and exposes the resolved `summary`; change the window → assert a re-fetch with the new value.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** — add a `summary` state + an effect keyed on `recordsWindowDays` calling `fetchRecordsSummary` with an `AbortController`, following the existing `applySettled`/stale-retain pattern in this hook (retain last good `summary` on transient failure). Thread `recordsWindowDays` in from wherever prefs enter the hook.
+- [ ] **Step 4: Run — PASS**; `npx tsc --noEmit`.
+- [ ] **Step 5: Commit** `feat(web): fetch records summary keyed on the window pref`.
+
+---
+
+## Task 6: `RecordsCard` component + CSS
+
+**Files:** Create `web/src/components/RecordsCard.tsx`, `web/src/components/RecordsCard.test.tsx`; Modify `web/src/App.css`.
+
+**Interfaces:** Consumes `RecordsSummary | null` + `UserPreferences` units + `recordsWindowDays`. Produces `export const RecordsCard = memo(...)`.
+
+Props: `{ summary: RecordsSummary | null; prefs: UserPreferences }`. Format via `useUnits` helpers (`formatTemp`/`formatWind`/`formatPressure`/`formatRain` — match the exact names used in the existing cards, e.g. `RainCard` uses `formatRain(value, unit)`, `PressureCard` uses `formatPressure`). Render a full-width `.glass-card.records-card` with a header (title + window pill "Last {days} days") and a 6-tile grid: Temperature, Humidity, Pressure (paired High/Low), Wind (paired Sustained/Gust), Rain total, Lightning (single). Null aggregates or `count===0` → em-dash. Labels use the `--text-secondary` classes (see CSS below); values right-aligned with `tabular-nums`.
+
+- [ ] **Step 1: Failing test** — `RecordsCard.test.tsx`: render with a full `RecordsSummary` + prefs (F/mph/inHg/in); assert the tile labels/values appear (e.g. `getByText('High')`, formatted temp appears, "Last 7 days" pill); render with `count: 0` (or null aggregates) → em-dashes; render with `summary={null}` → a loading/empty placeholder (no crash).
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement `RecordsCard.tsx`.** Structure (paired tile = two `.rpair-row`s, label left / value right; single tile = one big value + muted unit). Wrap `export const RecordsCard = memo(function RecordsCard({summary, prefs}: Props) {…})`. Guard nulls with a small `fmt(value, formatter)` that returns `—` when the value is null. Window pill reads `summary?.window.days ?? prefs.recordsWindowDays`.
+- [ ] **Step 4: Add CSS to `App.css`** — the classes validated across all 7 themes (reuse theme custom properties; labels `--text-secondary`; enumerated transitions; no `transition: all`):
+```css
+.records-card { grid-column: 1 / -1; }
+.records-header { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+.records-title { font-size: .82rem; letter-spacing: .08em; text-transform: uppercase; color: var(--text-secondary); font-weight: 600; }
+.records-window { margin-left: auto; font-size: .8rem; color: var(--text-muted); display: inline-flex; align-items: center; gap: 6px; padding: 4px 12px; border: 1px solid var(--border-color); border-radius: 999px; }
+.records-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); align-items: stretch; }
+.rstat { padding: 14px 16px; border-radius: 14px; border: 1px solid var(--border-color); background: rgba(255,255,255,.05); display: flex; flex-direction: column; }
+.rstat-label { font-size: .68rem; letter-spacing: .06em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 10px; }
+.rstat-body { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+.rstat-value { font-size: 1.6rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; }
+.rstat-unit { font-size: .82rem; color: var(--text-muted); font-weight: 500; margin-left: 3px; }
+.rstat-pair { display: flex; flex-direction: column; gap: 8px; }
+.rpair-row { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; }
+.rpair-tag { font-size: .7rem; letter-spacing: .04em; text-transform: uppercase; color: var(--text-secondary); font-weight: 600; }
+.rpair-val { font-size: 1.32rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; text-align: right; }
+.rpair-val .rstat-unit { font-size: .78rem; }
+```
+- [ ] **Step 5: Run — PASS**; `npx tsc --noEmit`.
+- [ ] **Step 6: Commit** `feat(web): RecordsCard component + theme-safe CSS`.
+
+---
+
+## Task 7: Settings — Records window selector
+
+**Files:** Modify `web/src/components/SettingsPanel.tsx`; Test: `web/src/components/SettingsPanel.test.tsx`.
+
+**Interfaces:** Consumes `prefs.recordsWindowDays` + `onPrefsChange`. Produces a "Records window" `.toggle-group` (7/30/180/365) that calls `onPrefsChange({ recordsWindowDays: N })`.
+
+- [ ] **Step 1: Failing test** — render `SettingsPanel` open; assert a "Records window" section with buttons `7 days`/`30 days`/`180 days`/`365 days`; the current pref's button has `active`; clicking `30 days` calls `onPrefsChange` with `{ recordsWindowDays: 30 }`.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** — add a new `.settings-section` after the existing Units section, mirroring the existing unit toggle-group markup:
+```tsx
+<div className="settings-section">
+  <h3>Records</h3>
+  <div className="setting-row">
+    <label>Window</label>
+    <div className="toggle-group">
+      {([7, 30, 180, 365] as const).map((d) => (
+        <button key={d}
+          className={prefs.recordsWindowDays === d ? 'active' : ''}
+          onClick={() => onPrefsChange({ recordsWindowDays: d })}>{d}d</button>
+      ))}
+    </div>
+  </div>
+</div>
+```
+- [ ] **Step 4: Run — PASS** (existing SettingsPanel dialog-a11y/theme tests still green); `npx tsc --noEmit`.
+- [ ] **Step 5: Commit** `feat(web): Settings records-window selector`.
+
+---
+
+## Task 8: Wire `RecordsCard` into the dashboard
+
+**Files:** Modify `web/src/App.tsx`; Test: extend an `App`-level or integration test if one exists, else add a focused render test.
+
+**Interfaces:** Consumes `summary` (Task 5) + `prefs`. Renders `<RecordsCard summary={summary} prefs={prefs} />` immediately before `<ForecastStrip …>` inside `.dashboard-grid`.
+
+- [ ] **Step 1: Failing test** — render `App` (or the dashboard) with a mocked `useWeatherData` returning a `summary`; assert the Records card renders and appears **before** the 7-Day Forecast in DOM order.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** — import `RecordsCard`; pull `summary` from `useWeatherData()`; insert `<RecordsCard summary={summary} prefs={prefs} />` on the line directly above `<ForecastStrip forecast={forecast} unit={prefs.temperatureUnit} />`.
+- [ ] **Step 4: Run — PASS.** Full web gate: `cd web && npm test && npm run build && npx tsc --noEmit`.
+- [ ] **Step 5: Commit** `feat(web): render RecordsCard above the 7-day forecast`.
+
+---
+
+## Final verification (bundle gate, not a task)
+
+- `CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run && go test ./... -race` — all clean.
+- `cd web && npm test && npm run build && npx tsc --noEmit` — clean; test count up.
+- **In-browser gate:** build the binary embedding the UI; run with a temp `SQLITE_PATH`, `SQLITE_BATCH_SIZE=1`, `SQLITE_FLUSH_INTERVAL=1s`, `HTTP_ADDR=127.0.0.1:8087`; feed several `obs_st` UDP packets (varied temp/humidity/pressure/wind/gust/rain/lightning) to `127.0.0.1:50222`; open `:8087`; confirm the Records card shows real aggregates, switching the Settings window re-fetches, and labels are legible (re-run the theme matrix). Confirm `/api/observations/summary?days=7` returns correct JSON and `?days=8`/missing → 400.
+- Cold whole-branch review (Fable) over `git diff origin/main..HEAD`; address findings; then `superpowers:finishing-a-development-branch` (USER-GATED).
+
+## Self-review notes
+- Spec coverage: read-path decoupling (T1), aggregation + NULL/empty (T2), endpoint + validation + deadline + error mapping (T3), Contract-C single-source (T4), data fetch keyed on window (T5), card + theme-safe labels + units (T6), settings selector (T7), placement (T8). Migration: the timestamp index already exists (`0002_add_timestamp_index.sql` on main) — no new migration; T1 relies on it.
+- Type consistency: `SummarizeObservations`/`Summary` names identical across T2/T3; `RecordsSummary` JSON tags (T4) mirror `summaryResponse` (T3) field-for-field; `recordsWindowDays` consistent T4/T5/T7/T8.
+- Flag for the implementer to verify at T1: `modernc.org/sqlite` honoring `mode=ro` + read-only over WAL (covered by T1's test); if `mode=ro` misbehaves, fall back to a normal (read-write-capable) second handle used only for reads — WAL still decouples it from the writer's single-conn pool.

--- a/internal/httpserver/observations.go
+++ b/internal/httpserver/observations.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -51,6 +52,9 @@ type ObservationReader interface {
 	// HistoryPoints returns the allowlisted field's samples in [from, to];
 	// an unknown field is rejected with a non-nil error before any query runs.
 	HistoryPoints(ctx context.Context, field string, from, to int64) ([]sqlite.Point, error)
+	// SummarizeObservations returns the windowed min/max/total aggregates
+	// over [from, to] backing GET /api/observations/summary.
+	SummarizeObservations(ctx context.Context, from, to int64) (sqlite.Summary, error)
 }
 
 // currentObservation is the wire shape for GET /api/observations/current.
@@ -92,6 +96,69 @@ type historyResponse struct {
 	Points []sqlite.Point `json:"points"`
 }
 
+// summaryMinMax is a min/max pair shared by every summaryResponse field that
+// has both. A nil pointer means the underlying SQL aggregate returned NULL
+// (no rows had that column set in-window), not zero.
+type summaryMinMax struct {
+	Max *float64 `json:"max"`
+	Min *float64 `json:"min"`
+}
+
+// summaryWindow echoes the requested window back to the caller, so the UI
+// doesn't need to independently recompute from/to from days.
+type summaryWindow struct {
+	Days int   `json:"days"`
+	From int64 `json:"from"`
+	To   int64 `json:"to"`
+}
+
+// summaryResponse is the wire shape for GET /api/observations/summary:
+// Contract C (design §11), pinned to web/src/types/weather.ts's
+// RecordsSummary interface (Task 4) -- every field there must have a
+// same-named counterpart here. Backend emits SI units unchanged.
+type summaryResponse struct {
+	Window         summaryWindow `json:"window"`
+	Count          int64         `json:"count"`
+	CoveredFrom    *int64        `json:"coveredFrom"`
+	CoveredTo      *int64        `json:"coveredTo"`
+	Temperature    summaryMinMax `json:"temperature"`
+	Humidity       summaryMinMax `json:"humidity"`
+	Pressure       summaryMinMax `json:"pressure"`
+	WindMax        *float64      `json:"windMax"`
+	GustMax        *float64      `json:"gustMax"`
+	RainTotal      *float64      `json:"rainTotal"`
+	LightningTotal *int64        `json:"lightningTotal"`
+}
+
+// summaryQueryTimeout bounds handleSummary's SummarizeObservations call so a
+// slow full-table aggregate scan can't hold the request open indefinitely.
+const summaryQueryTimeout = 5 * time.Second
+
+// allowedSummaryDays is the exact set of windows the UI's Records card
+// offers; unlike /history's from/to (which default rather than reject),
+// there's no sensible fallback for a window the UI never asks for, so
+// anything else 400s rather than silently coercing to a nearby value.
+var allowedSummaryDays = map[int]bool{7: true, 30: true, 180: true, 365: true}
+
+// f64 maps a nullable SQL float to its wire form: nil means the aggregate's
+// underlying column was NULL for every row in-window, not zero.
+func f64(n sql.NullFloat64) *float64 {
+	if n.Valid {
+		v := n.Float64
+		return &v
+	}
+	return nil
+}
+
+// i64 is f64's sql.NullInt64 counterpart.
+func i64(n sql.NullInt64) *int64 {
+	if n.Valid {
+		v := n.Int64
+		return &v
+	}
+	return nil
+}
+
 // registerObservations registers the Contract C JSON API handlers reading
 // SQLite. Additive per the Deps seam server.go documents: a new field
 // (Observations) plus this one register call, siblings (registerHealthz,
@@ -102,6 +169,9 @@ func registerObservations(mux *http.ServeMux, deps Deps) {
 	})
 	mux.HandleFunc("GET /api/observations/history", func(w http.ResponseWriter, r *http.Request) {
 		handleHistory(w, r, deps.Observations)
+	})
+	mux.HandleFunc("GET /api/observations/summary", func(w http.ResponseWriter, r *http.Request) {
+		handleSummary(w, r, deps.Observations)
 	})
 }
 
@@ -164,6 +234,51 @@ func handleHistory(w http.ResponseWriter, r *http.Request, reader ObservationRea
 	}
 
 	writeJSON(w, http.StatusOK, historyResponse{Points: points})
+}
+
+// handleSummary serves the windowed observation aggregates (Contract C's
+// RecordsSummary) for a days query param drawn from allowedSummaryDays --
+// deliberately stricter than handleHistory's from/to (which default on a bad
+// value), since there is no sensible fallback for a window the UI never
+// offers.
+func handleSummary(w http.ResponseWriter, r *http.Request, reader ObservationReader) {
+	if reader == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "observation store not configured")
+		return
+	}
+
+	days, err := strconv.Atoi(r.URL.Query().Get("days"))
+	if err != nil || !allowedSummaryDays[days] {
+		writeJSONError(w, http.StatusBadRequest, "days must be one of 7, 30, 180, 365")
+		return
+	}
+
+	to := time.Now().Unix()
+	from := to - int64(days)*86400
+
+	ctx, cancel := context.WithTimeout(r.Context(), summaryQueryTimeout)
+	defer cancel()
+
+	s, err := reader.SummarizeObservations(ctx, from, to)
+	if err != nil {
+		slog.ErrorContext(ctx, "httpserver: summarize observations", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to load records summary")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, summaryResponse{
+		Window:         summaryWindow{Days: days, From: from, To: to},
+		Count:          s.Count,
+		CoveredFrom:    i64(s.CoveredFrom),
+		CoveredTo:      i64(s.CoveredTo),
+		Temperature:    summaryMinMax{Max: f64(s.TempMax), Min: f64(s.TempMin)},
+		Humidity:       summaryMinMax{Max: f64(s.HumidityMax), Min: f64(s.HumidityMin)},
+		Pressure:       summaryMinMax{Max: f64(s.PressureMax), Min: f64(s.PressureMin)},
+		WindMax:        f64(s.WindMax),
+		GustMax:        f64(s.GustMax),
+		RainTotal:      f64(s.RainTotal),
+		LightningTotal: i64(s.LightningTotal),
+	})
 }
 
 // parseEpochOrDefault parses s as a base-10 unix-epoch-seconds integer,

--- a/internal/httpserver/observations_test.go
+++ b/internal/httpserver/observations_test.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"math"
@@ -28,6 +29,11 @@ type fakeObservationReader struct {
 	// -- simulating the real writer's allowlist rejecting an unknown field
 	// before running any query.
 	historyErr error
+
+	// summary and summaryErr back SummarizeObservations for
+	// TestHandleSummary_*.
+	summary    sqlite.Summary
+	summaryErr error
 }
 
 func (f *fakeObservationReader) LatestObservationAny(context.Context) (sqlite.Observation, error) {
@@ -39,6 +45,10 @@ func (f *fakeObservationReader) HistoryPoints(_ context.Context, field string, _
 		return nil, f.historyErr
 	}
 	return f.history[field], nil
+}
+
+func (f *fakeObservationReader) SummarizeObservations(context.Context, int64, int64) (sqlite.Summary, error) {
+	return f.summary, f.summaryErr
 }
 
 func testDepsWithObservations(reader ObservationReader) Deps {
@@ -297,3 +307,68 @@ func TestAPI_ObservationsNilStore(t *testing.T) {
 // the handler must map ANY HistoryPoints error to 400, not just a specific
 // sentinel, since HistoryPoints has no exported sentinel for this case.
 var errUnknownFieldForTest = errors.New("unknown history field")
+
+// TestHandleSummary_OK proves GET /api/observations/summary?days=N maps a
+// valid allowlisted window to 200 with the summaryResponse shape (Contract C
+// -- web/src/types/weather.ts RecordsSummary, Task 4), including the
+// window echo and a spot-check of the NULL-able fields when they are valid.
+func TestHandleSummary_OK(t *testing.T) {
+	reader := &fakeObservationReader{summary: sqlite.Summary{
+		Count:          5,
+		CoveredFrom:    sql.NullInt64{Int64: 10, Valid: true},
+		CoveredTo:      sql.NullInt64{Int64: 90, Valid: true},
+		TempMax:        sql.NullFloat64{Float64: 25, Valid: true},
+		TempMin:        sql.NullFloat64{Float64: 5, Valid: true},
+		WindMax:        sql.NullFloat64{Float64: 8, Valid: true},
+		GustMax:        sql.NullFloat64{Float64: 12, Valid: true},
+		RainTotal:      sql.NullFloat64{Float64: 3.5, Valid: true},
+		LightningTotal: sql.NullInt64{Int64: 4, Valid: true},
+	}}
+
+	srv := New(testDepsWithObservations(reader))
+	req := httptest.NewRequest(http.MethodGet, "/api/observations/summary?days=7", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/observations/summary?days=7 = %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+
+	var got summaryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v (body: %s)", err, rec.Body.String())
+	}
+	if got.Window.Days != 7 || got.Count != 5 || *got.Temperature.Max != 25 || *got.RainTotal != 3.5 || *got.LightningTotal != 4 {
+		t.Fatalf("bad body: %+v", got)
+	}
+}
+
+// TestHandleSummary_BadDays proves every non-allowlisted days value --
+// missing, non-numeric, or a number outside {7,30,180,365} -- 400s. This is
+// deliberately stricter than /history's from/to (which default rather than
+// reject), because a window that isn't one of the four the UI offers has no
+// sensible fallback.
+func TestHandleSummary_BadDays(t *testing.T) {
+	for _, q := range []string{"", "?days=1", "?days=abc", "?days=8"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/observations/summary"+q, nil)
+		rec := httptest.NewRecorder()
+		New(testDepsWithObservations(&fakeObservationReader{})).Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("GET /api/observations/summary%s = %d, want 400", q, rec.Code)
+		}
+	}
+}
+
+// TestHandleSummary_NilReader proves the summary handler 503s (not panics)
+// when Deps.Observations is nil, matching the other two observation
+// handlers' nil-guard pattern (see TestAPI_ObservationsNilStore).
+func TestHandleSummary_NilReader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/observations/summary?days=7", nil)
+	rec := httptest.NewRecorder()
+	New(testDepsWithObservations(nil)).Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /api/observations/summary?days=7 = %d, want 503", rec.Code)
+	}
+}

--- a/internal/httpserver/observations_test.go
+++ b/internal/httpserver/observations_test.go
@@ -360,6 +360,20 @@ func TestHandleSummary_BadDays(t *testing.T) {
 	}
 }
 
+// TestHandleSummary_ReaderError proves GET /api/observations/summary 500s
+// (with the ErrorContext log path exercised) when SummarizeObservations
+// returns an error, e.g. a query timeout or a sqlite failure -- the one
+// branch of handleSummary's error handling left uncovered.
+func TestHandleSummary_ReaderError(t *testing.T) {
+	reader := &fakeObservationReader{summaryErr: errors.New("boom")}
+	req := httptest.NewRequest(http.MethodGet, "/api/observations/summary?days=7", nil)
+	rec := httptest.NewRecorder()
+	New(testDepsWithObservations(reader)).Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("GET /api/observations/summary?days=7 = %d, want 500", rec.Code)
+	}
+}
+
 // TestHandleSummary_NilReader proves the summary handler 503s (not panics)
 // when Deps.Observations is nil, matching the other two observation
 // handlers' nil-guard pattern (see TestAPI_ObservationsNilStore).

--- a/internal/sqlite/db.go
+++ b/internal/sqlite/db.go
@@ -82,3 +82,27 @@ func Open(ctx context.Context, path string, cfg Config) (*sql.DB, error) {
 	}
 	return db, nil
 }
+
+// OpenReadOnly opens a read-only handle to an existing SQLite database for
+// query-side work (e.g. HTTP API reads). It must be opened AFTER Open, which
+// creates/migrates the database and its WAL files. WAL journaling lets these
+// read connections run concurrently with the single ingest writer without
+// SQLITE_BUSY. It deliberately does NOT set journal_mode — a read-only
+// connection cannot run that write PRAGMA, and the database is already WAL
+// from Open.
+func OpenReadOnly(ctx context.Context, path string, cfg Config) (*sql.DB, error) {
+	dsn := fmt.Sprintf(
+		"file:%s?mode=ro&_pragma=busy_timeout(%d)&_pragma=foreign_keys(1)",
+		path, cfg.BusyTimeout.Milliseconds(),
+	)
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite read-only: %w", err)
+	}
+	db.SetMaxOpenConns(4) // concurrent readers alongside the single writer (WAL)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping sqlite read-only: %w", err)
+	}
+	return db, nil
+}

--- a/internal/sqlite/db_test.go
+++ b/internal/sqlite/db_test.go
@@ -54,6 +54,48 @@ func assertPragmaInt(t *testing.T, db *sql.DB, pragma string, want int) {
 	}
 }
 
+func TestOpenReadOnly_ReadsWriterData(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	cfg := Config{BusyTimeout: 5000 * time.Millisecond, BatchSize: 1, FlushInterval: time.Second}
+
+	wdb, err := Open(ctx, path, cfg) // runs migrations, creates WAL
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := wdb.Close(); err != nil {
+			t.Errorf("close write handle: %v", err)
+		}
+	})
+
+	// seed one observation row directly
+	_, err = wdb.ExecContext(ctx, `INSERT INTO tempest_observations
+		(id, serial_number, timestamp, temp_air) VALUES ('a','ST-1',100,21.5)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rdb, err := OpenReadOnly(ctx, path, cfg)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rdb.Close(); err != nil {
+			t.Errorf("close read handle: %v", err)
+		}
+	})
+
+	var got float64
+	if err := rdb.QueryRowContext(ctx, `SELECT temp_air FROM tempest_observations WHERE id='a'`).Scan(&got); err != nil {
+		t.Fatalf("read via read-only handle: %v", err)
+	}
+	if got != 21.5 {
+		t.Fatalf("got %v want 21.5", got)
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	getenv := func(k string) string {
 		return map[string]string{

--- a/internal/sqlite/summary_test.go
+++ b/internal/sqlite/summary_test.go
@@ -1,0 +1,65 @@
+package sqlite
+
+import (
+	"database/sql"
+	"math"
+	"testing"
+)
+
+// TestSummarizeObservations proves SummarizeObservations aggregates a
+// [from, to] window correctly: MIN/MAX/SUM over the seeded rows, a SUM over
+// lightning_strike_count that skips a NULL row rather than treating it as
+// zero, and an empty window (no rows in range) surfacing Count==0 with every
+// sql.Null* field left invalid rather than zero-valued.
+func TestSummarizeObservations(t *testing.T) {
+	w := newTestWriter(t)
+	// newTestWriter defaults readDB to db (no WithReadDB option), so seeding
+	// through w.db (same package, unexported field) is equivalent to seeding
+	// through whatever handle SummarizeObservations reads from here.
+	db := w.db
+	ctx := t.Context()
+
+	seed := func(id string, ts int64, temp, hum, pres, wavg, wgust, rain float64, ls sql.NullInt64) {
+		_, err := db.ExecContext(ctx, `INSERT INTO tempest_observations
+			(id, serial_number, timestamp, temp_air, humidity, pressure, wind_avg, wind_gust, rain_rate, lightning_strike_count)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			id, "ST-1", ts, temp, hum, pres, wavg, wgust, rain, ls)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("a", 100, 10, 40, 1000, 3, 5, 0.5, sql.NullInt64{Int64: 2, Valid: true})
+	seed("b", 200, 25, 90, 1020, 8, 12, 1.0, sql.NullInt64{}) // NULL lightning
+	seed("c", 300, 18, 60, 1010, 5, 9, 0.25, sql.NullInt64{Int64: 3, Valid: true})
+
+	s, err := w.SummarizeObservations(ctx, 100, 300)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Count != 3 {
+		t.Fatalf("count=%d", s.Count)
+	}
+	if s.TempMax.Float64 != 25 || s.TempMin.Float64 != 10 {
+		t.Fatalf("temp %v/%v", s.TempMax, s.TempMin)
+	}
+	if s.WindMax.Float64 != 8 || s.GustMax.Float64 != 12 {
+		t.Fatalf("wind %v/%v", s.WindMax, s.GustMax)
+	}
+	if math.Abs(s.RainTotal.Float64-1.75) > 1e-9 {
+		t.Fatalf("rain %v", s.RainTotal)
+	}
+	if s.LightningTotal.Int64 != 5 {
+		t.Fatalf("lightning=%d (want 5, NULL row skipped)", s.LightningTotal.Int64)
+	}
+	if s.CoveredFrom.Int64 != 100 || s.CoveredTo.Int64 != 300 {
+		t.Fatalf("coverage %v/%v", s.CoveredFrom, s.CoveredTo)
+	}
+
+	empty, err := w.SummarizeObservations(ctx, 1000, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty.Count != 0 || empty.TempMax.Valid || empty.RainTotal.Valid || empty.CoveredFrom.Valid {
+		t.Fatalf("empty window not all-null: %+v", empty)
+	}
+}

--- a/internal/sqlite/writer.go
+++ b/internal/sqlite/writer.go
@@ -925,3 +925,58 @@ func (w *Writer) HistoryPoints(ctx context.Context, field string, from, to int64
 	}
 	return points, nil
 }
+
+// Summary is the windowed aggregate over tempest_observations in [from, to].
+// Every aggregate is nullable: MIN/MAX/SUM over zero rows (or an all-NULL
+// column) return SQL NULL, not 0, so each is scanned into a sql.Null* rather
+// than silently reporting a misleading zero value. Count == 0 is the
+// authoritative empty-window signal -- callers must check it before reading
+// any other field.
+type Summary struct {
+	Count          int64
+	CoveredFrom    sql.NullInt64
+	CoveredTo      sql.NullInt64
+	TempMax        sql.NullFloat64
+	TempMin        sql.NullFloat64
+	HumidityMax    sql.NullFloat64
+	HumidityMin    sql.NullFloat64
+	PressureMax    sql.NullFloat64
+	PressureMin    sql.NullFloat64
+	WindMax        sql.NullFloat64
+	GustMax        sql.NullFloat64
+	RainTotal      sql.NullFloat64
+	LightningTotal sql.NullInt64
+}
+
+const summarizeObservationsSQL = `
+	SELECT
+	  COUNT(*),
+	  MIN(timestamp), MAX(timestamp),
+	  MAX(temp_air),  MIN(temp_air),
+	  MAX(humidity),  MIN(humidity),
+	  MAX(pressure),  MIN(pressure),
+	  MAX(wind_avg),  MAX(wind_gust),
+	  SUM(rain_rate),                 -- rain_rate = obs_st[12], per-interval mm accumulation -> SUM = total mm
+	  SUM(lightning_strike_count)
+	FROM tempest_observations
+	WHERE timestamp BETWEEN ? AND ?
+`
+
+// SummarizeObservations aggregates the tempest_observations rows in [from,
+// to] into one Summary. Aggregates over 0 rows (or all-NULL columns) are SQL
+// NULL, surfaced via sql.Null*; Count == 0 signals an empty window. Runs on
+// the read-only handle (w.readDB) so a wide scan never queues behind the
+// single ingest writer connection.
+func (w *Writer) SummarizeObservations(ctx context.Context, from, to int64) (Summary, error) {
+	var s Summary
+	err := w.readDB.QueryRowContext(ctx, summarizeObservationsSQL, from, to).Scan(
+		&s.Count, &s.CoveredFrom, &s.CoveredTo,
+		&s.TempMax, &s.TempMin, &s.HumidityMax, &s.HumidityMin,
+		&s.PressureMax, &s.PressureMin, &s.WindMax, &s.GustMax,
+		&s.RainTotal, &s.LightningTotal,
+	)
+	if err != nil {
+		return Summary{}, fmt.Errorf("summarize observations: %w", err)
+	}
+	return s, nil
+}

--- a/internal/sqlite/writer.go
+++ b/internal/sqlite/writer.go
@@ -162,6 +162,13 @@ type flushRequest struct {
 type Writer struct {
 	db *sql.DB
 
+	// readDB serves the read methods (LatestObservation, LatestObservationAny,
+	// HistoryPoints). It defaults to db when WithReadDB is not supplied, so
+	// existing callers observe identical behavior. When set to a dedicated
+	// read-only handle (via WithReadDB), heavy query-side scans run
+	// concurrently with the single ingest writer instead of queuing behind it.
+	readDB *sql.DB
+
 	rows chan rowEnvelope
 
 	batchSize     int
@@ -187,20 +194,38 @@ type Writer struct {
 	shutdownCtx context.Context
 }
 
+// WriterOption configures a Writer at construction.
+type WriterOption func(*Writer)
+
+// WithReadDB routes read methods (LatestObservation, LatestObservationAny,
+// HistoryPoints) through a dedicated read-only handle instead of the single
+// write connection, so heavy reads never queue behind ingest. Pass a handle
+// opened via OpenReadOnly.
+func WithReadDB(db *sql.DB) WriterOption {
+	return func(w *Writer) { w.readDB = db }
+}
+
 // NewWriter starts the single writer goroutine and returns a Writer backed
 // by db (opened and migrated via Open). ctx bounds only the writer's normal
 // (non-shutdown) database operations; Close(ctx) supplies the live context
 // used for the final drain-and-flush. NewWriter does not take ownership of
 // db — db was created by the caller (via Open), and Close does not close it;
 // the caller remains responsible for db.Close() once every writer using it
-// has been closed.
-func NewWriter(ctx context.Context, db *sql.DB, cfg Config) *Writer {
+// has been closed. Without WithReadDB, read methods use db like before;
+// callers on a single connection keep identical behavior.
+func NewWriter(ctx context.Context, db *sql.DB, cfg Config, opts ...WriterOption) *Writer {
 	w := &Writer{
 		db:            db,
 		rows:          make(chan rowEnvelope, rowChanCap),
 		batchSize:     cfg.BatchSize,
 		flushInterval: cfg.FlushInterval,
 		done:          make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	if w.readDB == nil {
+		w.readDB = db
 	}
 	w.wg.Add(1)
 	go w.run(ctx)
@@ -778,7 +803,7 @@ func scanObservation(row *sql.Row) (Observation, error) {
 // (ORDER BY timestamp DESC LIMIT 1). Returns ErrObservationNotFound,
 // checkable via errors.Is, when serial has no rows.
 func (w *Writer) LatestObservation(ctx context.Context, serial string) (Observation, error) {
-	row := w.db.QueryRowContext(ctx, selectLatestObservationSQL, serial)
+	row := w.readDB.QueryRowContext(ctx, selectLatestObservationSQL, serial)
 	obs, err := scanObservation(row)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
@@ -809,7 +834,7 @@ const selectLatestObservationAnySQL = `
 // registerObservations for how the API handler uses this. Returns
 // ErrObservationNotFound, checkable via errors.Is, when the table is empty.
 func (w *Writer) LatestObservationAny(ctx context.Context) (Observation, error) {
-	row := w.db.QueryRowContext(ctx, selectLatestObservationAnySQL)
+	row := w.readDB.QueryRowContext(ctx, selectLatestObservationAnySQL)
 	obs, err := scanObservation(row)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
@@ -871,7 +896,7 @@ func (w *Writer) HistoryPoints(ctx context.Context, field string, from, to int64
 		column, maxHistoryPoints,
 	)
 
-	rows, err := w.db.QueryContext(ctx, query, from, to)
+	rows, err := w.readDB.QueryContext(ctx, query, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("query history points: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -202,6 +202,12 @@ func main() {
 	// same deferred cleanup, after metricsSink.Close returns, rather than via
 	// its own defer (which LIFO ordering would run BEFORE the sink drains).
 	var sqliteDB *sql.DB
+	// sqliteRDB is the dedicated read-only handle (UDP mode only, when the
+	// sqlite store is selected), opened after sqliteDB and passed to the
+	// writer via sqlite.WithReadDB so query-side reads run concurrently with
+	// the single ingest writer (WAL) instead of queuing behind it. Closed
+	// alongside sqliteDB in the deferred cleanup below, after the sink drains.
+	var sqliteRDB *sql.DB
 	// sw is the *sqlite.Writer handle (UDP mode only, when the sqlite store is
 	// selected), captured here so it can also be wired into httpserver.Deps.Observations
 	// below -- the same writer instance both drains the metrics sink and backs
@@ -227,6 +233,11 @@ func main() {
 		}
 		if err := metricsSink.Close(cleanupCtx); err != nil {
 			slog.Error("sink close", "err", err)
+		}
+		if sqliteRDB != nil {
+			if err := sqliteRDB.Close(); err != nil {
+				slog.Error("sqlite read db close", "err", err)
+			}
 		}
 		if sqliteDB != nil {
 			if err := sqliteDB.Close(); err != nil {
@@ -298,7 +309,12 @@ func main() {
 				log.Fatalf("failed to open sqlite: %v", err)
 			}
 			sqliteDB = db
-			sw = sqlite.NewWriter(ctx, db, sqliteCfg)
+			rdb, err := sqlite.OpenReadOnly(ctx, choice.sqlitePath, sqliteCfg)
+			if err != nil {
+				log.Fatalf("failed to open sqlite read handle: %v", err)
+			}
+			sqliteRDB = rdb
+			sw = sqlite.NewWriter(ctx, db, sqliteCfg, sqlite.WithReadDB(rdb))
 			metricsSink.AddWriter(sw)
 		}
 	}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1525,11 +1525,10 @@
 .rstat-body { flex: 1; display: flex; flex-direction: column; justify-content: center; }
 .rstat-value { font-size: 1.6rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; }
 .rstat-unit { font-size: .82rem; color: var(--text-muted); font-weight: 500; margin-left: 3px; }
-.rstat-pair { display: flex; flex-direction: column; gap: 8px; }
-.rpair-row { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; }
+.rstat-pair { display: flex; flex-direction: column; gap: 12px; }
+.rpair-row { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; }
 .rpair-tag { font-size: .7rem; letter-spacing: .04em; text-transform: uppercase; color: var(--text-secondary); font-weight: 600; }
-.rpair-val { font-size: 1.32rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; text-align: right; }
-.rpair-val .rstat-unit { font-size: .78rem; }
+.rpair-val { font-size: 1.28rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; white-space: nowrap; }
 
 /* --- Reduced motion ------------------------------------------------ */
 @media (prefers-reduced-motion: reduce) {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1514,6 +1514,23 @@
   }
 }
 
+/* --- Records summary card ------------------------------------------ */
+.records-card { grid-column: 1 / -1; }
+.records-header { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+.records-title { font-size: .82rem; letter-spacing: .08em; text-transform: uppercase; color: var(--text-secondary); font-weight: 600; }
+.records-window { margin-left: auto; font-size: .8rem; color: var(--text-muted); display: inline-flex; align-items: center; gap: 6px; padding: 4px 12px; border: 1px solid var(--border-color); border-radius: 999px; }
+.records-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); align-items: stretch; }
+.rstat { padding: 14px 16px; border-radius: 14px; border: 1px solid var(--border-color); background: rgba(255,255,255,.05); display: flex; flex-direction: column; }
+.rstat-label { font-size: .68rem; letter-spacing: .06em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 10px; }
+.rstat-body { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+.rstat-value { font-size: 1.6rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; }
+.rstat-unit { font-size: .82rem; color: var(--text-muted); font-weight: 500; margin-left: 3px; }
+.rstat-pair { display: flex; flex-direction: column; gap: 8px; }
+.rpair-row { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; }
+.rpair-tag { font-size: .7rem; letter-spacing: .04em; text-transform: uppercase; color: var(--text-secondary); font-weight: 600; }
+.rpair-val { font-size: 1.32rem; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; text-align: right; }
+.rpair-val .rstat-unit { font-size: .78rem; }
+
 /* --- Reduced motion ------------------------------------------------ */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+import type { WeatherData } from './hooks/useWeatherData';
+import type { CurrentObservation, ForecastDay, RecordsSummary } from './types/weather';
+import { PrecipitationType, PressureTrend } from './types/weather';
+
+const mockCurrent: CurrentObservation = {
+  timestamp: 1_700_000_000,
+  windLull: 0.5,
+  windAvg: 1.2,
+  windGust: 3.4,
+  windDirection: 180,
+  windSampleInterval: 3,
+  stationPressure: 1013.2,
+  airTemperature: 21.5,
+  relativeHumidity: 55,
+  illuminance: 10000,
+  uvIndex: 3,
+  solarRadiation: 400,
+  rainAccumulated: 0,
+  precipitationType: PrecipitationType.None,
+  lightningStrikeAvgDistance: 0,
+  lightningStrikeCount: 0,
+  battery: 2.8,
+  reportInterval: 1,
+  localDayRainAccumulation: 0,
+  feelsLike: 21.5,
+  dewPoint: 12.1,
+  wetBulbTemperature: 15.0,
+  heatIndex: 21.5,
+  windChill: 21.5,
+  pressureTrend: PressureTrend.Steady,
+};
+
+const mockForecast: ForecastDay[] = [
+  {
+    dayNum: 21,
+    monthNum: 7,
+    conditions: 'Clear',
+    icon: 'clear-day',
+    airTempHigh: 25,
+    airTempLow: 15,
+    precipProbability: 0,
+    precipType: 'none',
+    sunrise: Math.floor(Date.now() / 1000),
+    sunset: Math.floor(Date.now() / 1000) + 36000,
+  },
+];
+
+const mockSummary: RecordsSummary = {
+  window: { days: 7, from: 1_699_000_000, to: 1_700_000_000 },
+  count: 42,
+  coveredFrom: 1_699_000_000,
+  coveredTo: 1_700_000_000,
+  temperature: { max: 28.4, min: 10.1 },
+  humidity: { max: 88, min: 30 },
+  pressure: { max: 1020.5, min: 1005.2 },
+  windMax: 8.3,
+  gustMax: 14.7,
+  rainTotal: 12.5,
+  lightningTotal: 3,
+};
+
+const mockWeatherData: WeatherData = {
+  station: null,
+  current: mockCurrent,
+  forecast: mockForecast,
+  status: null,
+  almanac: null,
+  summary: mockSummary,
+  isLoading: false,
+  error: null,
+  lastUpdated: new Date(),
+  isStale: false,
+  refresh: vi.fn(),
+};
+
+vi.mock('./hooks/useWeatherData', () => ({
+  useWeatherData: vi.fn(() => mockWeatherData),
+}));
+
+describe('App dashboard layout', () => {
+  it('renders the Records card before the 7-Day Forecast', () => {
+    render(<App />);
+
+    const recordsAnchor = screen.getByText('Records');
+    const forecastAnchor = screen.getByText('7-Day Forecast');
+
+    expect(recordsAnchor).toBeInTheDocument();
+    expect(forecastAnchor).toBeInTheDocument();
+
+    // DOCUMENT_POSITION_FOLLOWING on recordsAnchor -> forecastAnchor means
+    // forecastAnchor comes AFTER recordsAnchor in document order.
+    const position = recordsAnchor.compareDocumentPosition(forecastAnchor);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { HumidityCard } from './components/HumidityCard';
 import { SolarUVCard } from './components/SolarUVCard';
 import { RainCard } from './components/RainCard';
 import { LightningCard } from './components/LightningCard';
+import { RecordsCard } from './components/RecordsCard';
 import { ForecastStrip } from './components/ForecastStrip';
 import { StationHealth } from './components/StationHealth';
 import { AlmanacCard } from './components/AlmanacCard';
@@ -21,7 +22,7 @@ import './App.css';
 
 function App() {
   const { prefs, setPrefs } = useUnits();
-  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, refresh } =
+  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, refresh, summary } =
     useWeatherData(undefined, prefs.recordsWindowDays);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -80,6 +81,7 @@ function App() {
             <RainCard current={current} unit={prefs.rainUnit} />
             <LightningCard current={current} />
             {status && <StationHealth status={status} />}
+            <RecordsCard summary={summary} prefs={prefs} />
             <ForecastStrip forecast={forecast} unit={prefs.temperatureUnit} />
             {almanac && <AlmanacCard almanac={almanac} unit={prefs.temperatureUnit} />}
             {station && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,9 +20,9 @@ import type { ThemeName } from './types/weather';
 import './App.css';
 
 function App() {
-  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, refresh } =
-    useWeatherData();
   const { prefs, setPrefs } = useUnits();
+  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, refresh } =
+    useWeatherData(undefined, prefs.recordsWindowDays);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {

--- a/web/src/api/tempestApi.test.ts
+++ b/web/src/api/tempestApi.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchCurrentObservation, fetchStationStatus } from './tempestApi';
+import { fetchCurrentObservation, fetchStationStatus, fetchRecordsSummary } from './tempestApi';
 import tempestApiSource from './tempestApi.ts?raw';
 import { PrecipitationType, PressureTrend } from '../types/weather';
-import type { CurrentObservation } from '../types/weather';
+import type { CurrentObservation, RecordsSummary } from '../types/weather';
 
 const mockObservation: CurrentObservation = {
   timestamp: 1700000000,
@@ -105,6 +105,59 @@ describe('fetchStationStatus', () => {
     expect(result.isOnline).toBe(true);
     expect(result.lastReport).toBe(freshObservation.timestamp);
     expect(result.batteryLevel).toBe(mockObservation.battery);
+  });
+});
+
+describe('fetchRecordsSummary', () => {
+  const mockSummary: RecordsSummary = {
+    window: { days: 7, from: 1699999000, to: 1700000000 },
+    count: 42,
+    coveredFrom: 1699999100,
+    coveredTo: 1700000000,
+    temperature: { max: 22.1, min: 8.4 },
+    humidity: { max: 95, min: 30 },
+    pressure: { max: 1020.5, min: 1005.2 },
+    windMax: 12.3,
+    gustMax: 18.9,
+    rainTotal: 4.2,
+    lightningTotal: 0,
+  };
+
+  it('GETs the days-windowed Contract C endpoint and returns a typed RecordsSummary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockSummary),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchRecordsSummary(7);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/observations/summary?days=7');
+    expect(init?.signal).toBeUndefined();
+    expect(result).toEqual(mockSummary);
+  });
+
+  it('forwards an AbortSignal to fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockSummary),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+
+    await fetchRecordsSummary(7, controller.signal);
+
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
+  });
+
+  it('throws on a non-OK response instead of returning stub/garbage data', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+    await expect(fetchRecordsSummary(7)).rejects.toThrow();
   });
 });
 

--- a/web/src/api/tempestApi.ts
+++ b/web/src/api/tempestApi.ts
@@ -21,6 +21,8 @@ import type {
   ForecastDay,
   StationStatus,
   StationAlmanac,
+  RecordsSummary,
+  RecordsWindowDays,
 } from '../types/weather';
 
 // Single-sourced so the endpoint path used by a fetch* function and the one
@@ -31,6 +33,7 @@ const ENDPOINTS = {
   station: '/api/station',
   forecast: '/api/forecast',
   almanac: '/api/almanac',
+  summary: '/api/observations/summary',
 } as const;
 
 // A report older than this is treated as "station offline" by
@@ -116,4 +119,15 @@ export async function fetchStationAlmanac(
   signal?: AbortSignal
 ): Promise<StationAlmanac> {
   return getJSON<StationAlmanac>(ENDPOINTS.almanac, signal);
+}
+
+// ---------------------------------------------------------------------------
+// Records summary -- the core, real endpoint
+// (GET /api/observations/summary?days=N).
+// ---------------------------------------------------------------------------
+export async function fetchRecordsSummary(
+  days: RecordsWindowDays,
+  signal?: AbortSignal
+): Promise<RecordsSummary> {
+  return getJSON<RecordsSummary>(`${ENDPOINTS.summary}?days=${days}`, signal);
 }

--- a/web/src/components/RecordsCard.test.tsx
+++ b/web/src/components/RecordsCard.test.tsx
@@ -37,8 +37,9 @@ describe('RecordsCard', () => {
     expect(screen.getByText('Gust')).toBeInTheDocument();
     // 30C -> 86F (formatTemp rounds and appends unit)
     expect(screen.getByText('86°F')).toBeInTheDocument();
-    // Lightning is a raw integer count, no formatter
+    // Lightning is a raw integer count with a "strikes" unit label
     expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('strikes')).toBeInTheDocument();
   });
 
   it('renders em-dashes when count is 0, even if aggregates are non-null', () => {
@@ -66,6 +67,8 @@ describe('RecordsCard', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(6);
     // humidity/pressure were left non-null, so they should still render
     expect(screen.getByText('90%')).toBeInTheDocument();
+    // a null lightning count shows an em-dash, not "— strikes"
+    expect(screen.queryByText('strikes')).not.toBeInTheDocument();
   });
 
   it('renders a safe placeholder when summary is null, without crashing', () => {

--- a/web/src/components/RecordsCard.test.tsx
+++ b/web/src/components/RecordsCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RecordsCard } from './RecordsCard';
+import type { RecordsSummary, UserPreferences } from '../types/weather';
+
+const prefs: UserPreferences = {
+  temperatureUnit: 'F',
+  windUnit: 'mph',
+  pressureUnit: 'inHg',
+  rainUnit: 'in',
+  theme: 'nord',
+  recordsWindowDays: 7,
+};
+
+const fullSummary: RecordsSummary = {
+  window: { days: 7, from: 1700000000, to: 1700600000 },
+  count: 42,
+  coveredFrom: 1700000000,
+  coveredTo: 1700600000,
+  temperature: { max: 30, min: 5 },
+  humidity: { max: 90, min: 20 },
+  pressure: { max: 1020, min: 995 },
+  windMax: 12,
+  gustMax: 20,
+  rainTotal: 15,
+  lightningTotal: 3,
+};
+
+describe('RecordsCard', () => {
+  it('renders tile labels and formatted values for a full summary', () => {
+    render(<RecordsCard summary={fullSummary} prefs={prefs} />);
+
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    expect(screen.getAllByText('High').length).toBe(3);
+    expect(screen.getAllByText('Low').length).toBe(3);
+    expect(screen.getByText('Sustained')).toBeInTheDocument();
+    expect(screen.getByText('Gust')).toBeInTheDocument();
+    // 30C -> 86F (formatTemp rounds and appends unit)
+    expect(screen.getByText('86°F')).toBeInTheDocument();
+    // Lightning is a raw integer count, no formatter
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders em-dashes when count is 0, even if aggregates are non-null', () => {
+    const emptySummary: RecordsSummary = { ...fullSummary, count: 0 };
+    render(<RecordsCard summary={emptySummary} prefs={prefs} />);
+
+    // 6 tiles, each with at least one value slot -> every value shows an em-dash
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(8);
+    expect(screen.queryByText('86°F')).not.toBeInTheDocument();
+  });
+
+  it('renders em-dashes for individually-null aggregates', () => {
+    const nullAggSummary: RecordsSummary = {
+      ...fullSummary,
+      count: 1,
+      temperature: { max: null, min: null },
+      windMax: null,
+      gustMax: null,
+      rainTotal: null,
+      lightningTotal: null,
+    };
+    render(<RecordsCard summary={nullAggSummary} prefs={prefs} />);
+
+    // temperature high/low, wind sustained/gust, rain, lightning = 6 em-dashes
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(6);
+    // humidity/pressure were left non-null, so they should still render
+    expect(screen.getByText('90%')).toBeInTheDocument();
+  });
+
+  it('renders a safe placeholder when summary is null, without crashing', () => {
+    render(<RecordsCard summary={null} prefs={prefs} />);
+
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/RecordsCard.tsx
+++ b/web/src/components/RecordsCard.tsx
@@ -1,0 +1,118 @@
+import { memo } from 'react';
+import type { RecordsSummary, UserPreferences } from '../types/weather';
+import { formatTemp, formatWind, formatPressure, formatRain } from '../hooks/useUnits';
+import { GlassCard } from './GlassCard';
+
+interface RecordsCardProps {
+  summary: RecordsSummary | null;
+  prefs: UserPreferences;
+}
+
+const EM_DASH = '—';
+
+function fmt(value: number | null, formatter: (v: number) => string): string {
+  return value === null ? EM_DASH : formatter(value);
+}
+
+function RecordsCardImpl({ summary, prefs }: RecordsCardProps) {
+  const windowDays = summary?.window.days ?? prefs.recordsWindowDays;
+
+  // A window with no observations (or not yet loaded) renders every aggregate
+  // as an em-dash, regardless of what the individual fields happen to hold.
+  const isEmpty = summary === null || summary.count === 0;
+  const s = isEmpty ? null : summary;
+
+  const tempMax = s?.temperature.max ?? null;
+  const tempMin = s?.temperature.min ?? null;
+  const humidityMax = s?.humidity.max ?? null;
+  const humidityMin = s?.humidity.min ?? null;
+  const pressureMax = s?.pressure.max ?? null;
+  const pressureMin = s?.pressure.min ?? null;
+  const windMax = s?.windMax ?? null;
+  const gustMax = s?.gustMax ?? null;
+  const rainTotal = s?.rainTotal ?? null;
+  const lightningTotal = s?.lightningTotal ?? null;
+
+  return (
+    <GlassCard className="records-card">
+      <div className="records-header">
+        <span className="records-title">Records</span>
+        <span className="records-window">Last {windowDays} days</span>
+      </div>
+
+      <div className="records-grid">
+        <div className="rstat">
+          <span className="rstat-label">Temperature</span>
+          <div className="rstat-body rstat-pair">
+            <div className="rpair-row">
+              <span className="rpair-tag">High</span>
+              <span className="rpair-val">{fmt(tempMax, (v) => formatTemp(v, prefs.temperatureUnit))}</span>
+            </div>
+            <div className="rpair-row">
+              <span className="rpair-tag">Low</span>
+              <span className="rpair-val">{fmt(tempMin, (v) => formatTemp(v, prefs.temperatureUnit))}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rstat">
+          <span className="rstat-label">Humidity</span>
+          <div className="rstat-body rstat-pair">
+            <div className="rpair-row">
+              <span className="rpair-tag">High</span>
+              <span className="rpair-val">{fmt(humidityMax, (v) => `${Math.round(v)}%`)}</span>
+            </div>
+            <div className="rpair-row">
+              <span className="rpair-tag">Low</span>
+              <span className="rpair-val">{fmt(humidityMin, (v) => `${Math.round(v)}%`)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rstat">
+          <span className="rstat-label">Pressure</span>
+          <div className="rstat-body rstat-pair">
+            <div className="rpair-row">
+              <span className="rpair-tag">High</span>
+              <span className="rpair-val">{fmt(pressureMax, (v) => formatPressure(v, prefs.pressureUnit))}</span>
+            </div>
+            <div className="rpair-row">
+              <span className="rpair-tag">Low</span>
+              <span className="rpair-val">{fmt(pressureMin, (v) => formatPressure(v, prefs.pressureUnit))}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rstat">
+          <span className="rstat-label">Wind</span>
+          <div className="rstat-body rstat-pair">
+            <div className="rpair-row">
+              <span className="rpair-tag">Sustained</span>
+              <span className="rpair-val">{fmt(windMax, (v) => formatWind(v, prefs.windUnit))}</span>
+            </div>
+            <div className="rpair-row">
+              <span className="rpair-tag">Gust</span>
+              <span className="rpair-val">{fmt(gustMax, (v) => formatWind(v, prefs.windUnit))}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rstat">
+          <span className="rstat-label">Rain</span>
+          <div className="rstat-body">
+            <span className="rstat-value">{fmt(rainTotal, (v) => formatRain(v, prefs.rainUnit))}</span>
+          </div>
+        </div>
+
+        <div className="rstat">
+          <span className="rstat-label">Lightning</span>
+          <div className="rstat-body">
+            <span className="rstat-value">{fmt(lightningTotal, (v) => `${v}`)}</span>
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+export const RecordsCard = memo(RecordsCardImpl);

--- a/web/src/components/RecordsCard.tsx
+++ b/web/src/components/RecordsCard.tsx
@@ -107,7 +107,10 @@ function RecordsCardImpl({ summary, prefs }: RecordsCardProps) {
         <div className="rstat">
           <span className="rstat-label">Lightning</span>
           <div className="rstat-body">
-            <span className="rstat-value">{fmt(lightningTotal, (v) => `${v}`)}</span>
+            <span className="rstat-value">
+              {fmt(lightningTotal, (v) => `${v}`)}
+              {lightningTotal !== null && <span className="rstat-unit">strikes</span>}
+            </span>
           </div>
         </div>
       </div>

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -56,6 +56,41 @@ describe('SettingsPanel', () => {
   });
 });
 
+describe('SettingsPanel Records window selector (Task 7)', () => {
+  it('renders a Records section with a Window row and the four window buttons', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    expect(screen.getByText('Records')).toBeInTheDocument();
+    expect(screen.getByText('Window')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '30 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '180 days' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '365 days' })).toBeInTheDocument();
+  });
+
+  it('marks the button matching prefs.recordsWindowDays as active', () => {
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={vi.fn()} onClose={vi.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: '7 days' })).toHaveClass('active');
+    expect(screen.getByRole('button', { name: '30 days' })).not.toHaveClass('active');
+  });
+
+  it('calls onPrefsChange with the selected window when a button is clicked', () => {
+    const onPrefsChange = vi.fn();
+    render(
+      <SettingsPanel isOpen={true} prefs={prefs} onPrefsChange={onPrefsChange} onClose={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '30 days' }));
+
+    expect(onPrefsChange).toHaveBeenCalledWith({ recordsWindowDays: 30 });
+  });
+});
+
 describe('SettingsPanel dialog semantics (P2.14)', () => {
   it('exposes role="dialog", aria-modal="true", and an accessible name from the h2', () => {
     render(

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -9,6 +9,7 @@ const prefs: UserPreferences = {
   pressureUnit: 'inHg',
   rainUnit: 'in',
   theme: 'liquid-glass',
+  recordsWindowDays: 7,
 };
 
 describe('SettingsPanel', () => {

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -139,6 +139,22 @@ export function SettingsPanel({ isOpen, prefs, onPrefsChange, onClose }: Setting
         </div>
 
         <div className="settings-section">
+          <h3>Records</h3>
+          <div className="setting-row">
+            <label>Window</label>
+            <div className="toggle-group">
+              {([7, 30, 180, 365] as const).map((d) => (
+                <button
+                  key={d}
+                  className={prefs.recordsWindowDays === d ? 'active' : ''}
+                  onClick={() => onPrefsChange({ recordsWindowDays: d })}
+                >{d} days</button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="settings-section">
           <h3>Theme</h3>
           <div className="theme-grid">
             {themeList.map((t) => (

--- a/web/src/hooks/useUnits.ts
+++ b/web/src/hooks/useUnits.ts
@@ -13,6 +13,7 @@ const DEFAULT_PREFS: UserPreferences = {
   pressureUnit: 'mb',
   rainUnit: 'in',
   theme: 'nord',
+  recordsWindowDays: 7,
 };
 
 function loadPrefs(): UserPreferences {

--- a/web/src/hooks/useWeatherData.test.ts
+++ b/web/src/hooks/useWeatherData.test.ts
@@ -8,6 +8,8 @@ import type {
   StationMeta,
   StationStatus,
   StationAlmanac,
+  RecordsSummary,
+  RecordsWindowDays,
 } from '../types/weather';
 
 vi.mock('../api/tempestApi', () => ({
@@ -16,6 +18,7 @@ vi.mock('../api/tempestApi', () => ({
   fetchForecast: vi.fn(),
   fetchStationStatus: vi.fn(),
   fetchStationAlmanac: vi.fn(),
+  fetchRecordsSummary: vi.fn(),
 }));
 
 const baseObs: CurrentObservation = {
@@ -78,6 +81,20 @@ const baseAlmanac: StationAlmanac = {
   moonIllumination: 1,
 };
 
+const baseSummary: RecordsSummary = {
+  window: { days: 7, from: 1699999000, to: 1700000000 },
+  count: 100,
+  coveredFrom: 1699999000,
+  coveredTo: 1700000000,
+  temperature: { max: 20, min: 5 },
+  humidity: { max: 90, min: 30 },
+  pressure: { max: 1020, min: 1000 },
+  windMax: 10,
+  gustMax: 15,
+  rainTotal: 5,
+  lightningTotal: 2,
+};
+
 const mockedApi = vi.mocked(api);
 
 beforeEach(() => {
@@ -93,6 +110,7 @@ describe('useWeatherData', () => {
     mockedApi.fetchForecast.mockResolvedValue([]);
     mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
     mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -112,6 +130,7 @@ describe('useWeatherData', () => {
     mockedApi.fetchForecast.mockRejectedValue(new Error('weatherflow down'));
     mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
     mockedApi.fetchStationAlmanac.mockRejectedValue(new Error('weatherflow down'));
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -129,6 +148,7 @@ describe('useWeatherData', () => {
       .mockResolvedValueOnce(baseStatus)
       .mockRejectedValueOnce(new Error('status endpoint down'));
     mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -180,6 +200,7 @@ describe('useWeatherData - isLoading with polling', () => {
     mockedApi.fetchForecast.mockResolvedValue([]);
     mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
     mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -226,6 +247,7 @@ describe('useWeatherData - isLoading with polling', () => {
     mockedApi.fetchForecast.mockResolvedValue([]);
     mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
     mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -272,6 +294,7 @@ describe('useWeatherData - isLoading with polling', () => {
     mockedApi.fetchForecast.mockResolvedValue([]);
     mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
     mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
 
     const { result } = renderHook(() => useWeatherData());
 
@@ -294,5 +317,56 @@ describe('useWeatherData - isLoading with polling', () => {
     expect(mockedApi.fetchCurrentObservation).toHaveBeenCalledTimes(2);
     expect(result.current.current).toBe(refAfterInitialLoad);
     expect(result.current.current).not.toBe(secondObs);
+  });
+});
+
+describe('useWeatherData - records summary', () => {
+  const setupCoreMocks = () => {
+    mockedApi.fetchCurrentObservation.mockResolvedValue(baseObs);
+    mockedApi.fetchStationMeta.mockResolvedValue(baseStation);
+    mockedApi.fetchForecast.mockResolvedValue([]);
+    mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
+    mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+  };
+
+  it('fetches the summary for the current window, exposes it, and re-fetches when the window pref changes', async () => {
+    setupCoreMocks();
+    const summary7: RecordsSummary = { ...baseSummary, window: { ...baseSummary.window, days: 7 } };
+    const summary30: RecordsSummary = { ...baseSummary, window: { ...baseSummary.window, days: 30 } };
+    mockedApi.fetchRecordsSummary
+      .mockResolvedValueOnce(summary7)
+      .mockResolvedValueOnce(summary30);
+
+    const { result, rerender } = renderHook(
+      ({ days }: { days: RecordsWindowDays }) => useWeatherData(undefined, days),
+      { initialProps: { days: 7 } }
+    );
+
+    await waitFor(() => expect(result.current.summary).toEqual(summary7));
+    expect(mockedApi.fetchRecordsSummary).toHaveBeenNthCalledWith(1, 7, expect.any(AbortSignal));
+
+    rerender({ days: 30 });
+
+    await waitFor(() => expect(result.current.summary).toEqual(summary30));
+    expect(mockedApi.fetchRecordsSummary).toHaveBeenNthCalledWith(2, 30, expect.any(AbortSignal));
+  });
+
+  it('retains the prior summary when a refetch after a window change fails (stale-retain)', async () => {
+    setupCoreMocks();
+    mockedApi.fetchRecordsSummary
+      .mockResolvedValueOnce(baseSummary)
+      .mockRejectedValueOnce(new Error('summary endpoint down'));
+
+    const { result, rerender } = renderHook(
+      ({ days }: { days: RecordsWindowDays }) => useWeatherData(undefined, days),
+      { initialProps: { days: 7 } }
+    );
+
+    await waitFor(() => expect(result.current.summary).toEqual(baseSummary));
+
+    rerender({ days: 30 });
+
+    await waitFor(() => expect(mockedApi.fetchRecordsSummary).toHaveBeenCalledTimes(2));
+    expect(result.current.summary).toEqual(baseSummary);
   });
 });

--- a/web/src/hooks/useWeatherData.ts
+++ b/web/src/hooks/useWeatherData.ts
@@ -5,6 +5,8 @@ import type {
   ForecastDay,
   StationStatus,
   StationAlmanac,
+  RecordsSummary,
+  RecordsWindowDays,
 } from '../types/weather';
 import {
   fetchCurrentObservation,
@@ -12,6 +14,7 @@ import {
   fetchForecast,
   fetchStationStatus,
   fetchStationAlmanac,
+  fetchRecordsSummary,
 } from '../api/tempestApi';
 
 // There is no WebSocket backend (Contract C is plain JSON, see design §11),
@@ -27,6 +30,7 @@ export interface WeatherData {
   forecast: ForecastDay[];
   status: StationStatus | null;
   almanac: StationAlmanac | null;
+  summary: RecordsSummary | null;
   isLoading: boolean;
   error: string | null;
   lastUpdated: Date | null;
@@ -56,12 +60,16 @@ function describeError(result: PromiseRejectedResult): string {
     : 'Failed to load weather data';
 }
 
-export function useWeatherData(stationId?: number): WeatherData {
+export function useWeatherData(
+  stationId?: number,
+  recordsWindowDays: RecordsWindowDays = 7
+): WeatherData {
   const [station, setStation] = useState<StationMeta | null>(null);
   const [current, setCurrent] = useState<CurrentObservation | null>(null);
   const [forecast, setForecast] = useState<ForecastDay[]>([]);
   const [status, setStatus] = useState<StationStatus | null>(null);
   const [almanac, setAlmanac] = useState<StationAlmanac | null>(null);
+  const [summary, setSummary] = useState<RecordsSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -172,12 +180,37 @@ export function useWeatherData(stationId?: number): WeatherData {
     return () => clearInterval(id);
   }, [pollCurrent]);
 
+  // Records summary is a separate, slow-moving slice (a 7-365 day
+  // aggregate read from the local store, keyed on window not stationId) --
+  // it has its own trigger (the window pref changing), not the 30s poll or
+  // loadData's stationId-keyed refresh, so it gets its own controller and
+  // effect rather than sharing abortRef/loadData.
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    (async () => {
+      try {
+        const result = await fetchRecordsSummary(recordsWindowDays, signal);
+        if (signal.aborted) return;
+        setSummary(result);
+      } catch {
+        // Stale-retain (matches applySettled's philosophy for the other
+        // best-effort slices): on abort or a transient failure, keep
+        // whatever summary is already in state rather than clobbering it.
+      }
+    })();
+
+    return () => controller.abort();
+  }, [recordsWindowDays]);
+
   return {
     station,
     current,
     forecast,
     status,
     almanac,
+    summary,
     isLoading,
     error,
     lastUpdated,

--- a/web/src/types/weather.ts
+++ b/web/src/types/weather.ts
@@ -120,7 +120,33 @@ export interface UserPreferences {
   pressureUnit: PressureUnit;
   rainUnit: RainUnit;
   theme: string;
+  recordsWindowDays: RecordsWindowDays;
 }
 
 export type ThemeName = 'liquid-glass' | 'midnight-aurora' | 'desert-sunset' | 'nord' | 'tokyo-night' | 'catppuccin-mocha' | 'the-grid';
+
+// Records summary window -- Contract C (GET /api/observations/summary?days=N).
+// RecordsSummary mirrors the Go summaryResponse wire tags exactly (field-for-field,
+// same casing); kept distinct from StationAlmanac/TempRecord, which describe a
+// different (WeatherFlow-proxied) almanac shape.
+export type RecordsWindowDays = 7 | 30 | 180 | 365;
+
+export interface RecordsMinMax {
+  max: number | null;
+  min: number | null;
+}
+
+export interface RecordsSummary {
+  window: { days: RecordsWindowDays; from: number; to: number };
+  count: number;
+  coveredFrom: number | null;
+  coveredTo: number | null;
+  temperature: RecordsMinMax; // °C (SI)
+  humidity: RecordsMinMax;    // %
+  pressure: RecordsMinMax;    // mb (SI)
+  windMax: number | null;     // m/s (SI)
+  gustMax: number | null;     // m/s (SI)
+  rainTotal: number | null;   // mm (SI)
+  lightningTotal: number | null;
+}
 


### PR DESCRIPTION
## Summary

Adds a full-width **Records** summary card directly above the 7-Day Forecast, showing windowed observation aggregates over a rolling window (7 / 30 / 180 / 365 days) selectable in Settings:

- **Temperature** high/low, **Humidity** high/low, **Pressure** high/low
- **Wind** — sustained max + gust max (one tile)
- **Rain** total, **Lightning** total ("N strikes")

## How it works

- **New endpoint** `GET /api/observations/summary?days=N` — one SQL `MIN/MAX/SUM` aggregation over the window, served through a **dedicated read-only `*sql.DB`** (`OpenReadOnly`, `mode=ro`). WAL lets the read handle run concurrently with the single ingest writer, so a wide historical scan never queues behind live UDP writes. Reuses the existing `idx_obs_time` index — no new migration.
- **Strict validation** — `days` allowlist `{7,30,180,365}`; anything else → `400`. Nil store → `503`, query error → `500`, 5s deadline.
- **NULL discipline end-to-end** — `MIN/MAX/SUM` over 0 rows → SQL `NULL` → `sql.Null*` → JSON `null` → em-dash in the card; `count===0` is the empty signal.
- **Contract-C** — Go `summaryResponse` json tags mirror the TS `RecordsSummary` type field-for-field; backend emits SI units, the client formats to the user's unit prefs via `useUnits`.
- **Frontend** — memoized `RecordsCard`, a `useWeatherData` summary slice keyed on the window pref (own `AbortController`, stale-retain), and a Settings window selector. Paired-tile labels use `var(--text-secondary)` (never semantic colors) for legibility across all themes.

## Verification

- **Backend:** `CGO_ENABLED=0 go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run`, `go test ./... -race` — all clean.
- **Web:** 83 Vitest tests, `npm run build`, `tsc --noEmit` — all clean.
- **In-browser (live binary):** fed varied `obs_st` UDP packets → aggregates exact; the Settings 7→30-day switch re-fetched live (temp low 50°F→23°F, lightning 10→17); `?days=8`/missing/`abc` → 400; labels legible on light + dark themes; single-line values verified at desktop and 390px mobile.

Built task-by-task via TDD with per-task review and an independent cold whole-branch review (verdict: ship-ready, 0 critical).

## Follow-up

- #89 — the summary refreshes only on window change, not on the 30s poll or manual Refresh (deliberate this iteration; tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
