### PR TITLE
fix(ci): go-release Go 1.26 + drop release-as (v3.0.0 binaries job failed)

### DIFF
--- a/.github/actions/go-release/action.yml
+++ b/.github/actions/go-release/action.yml
@@ -18,7 +18,12 @@ runs:
     - name: Install Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: "1.24"
+        # go.mod requires go >= 1.25.0; setup-go@v6 pins GOTOOLCHAIN=local, so
+        # the Go installed here must already satisfy that -- it cannot
+        # auto-upgrade. At "1.24" GoReleaser's build hook died with
+        # "go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)".
+        # Matches go.mod's toolchain (go1.26.1) and the actionlint job.
+        go-version: "1.26"
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": false,
   "include-component-in-tag": false,
-  "release-as": "3.0.0",
   "pull-request-title-pattern": "chore: release ${version}",
   "group-pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [


### PR DESCRIPTION
## Problem

The `release-binaries` job of the **v3.0.0** release failed:

```
⨯ release failed after 0s  error=exit status 1  message=hook failed: command failed
  cmd=go  output=go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

`actions/setup-go@v6` exports `GOTOOLCHAIN=local` whenever it's given a `go-version`. That pins the toolchain and forbids auto-upgrade — so with `go-version: "1.24"` against a `go.mod` requiring `>= 1.25.0`, GoReleaser's build hook can never succeed.

## Why it surfaced now

Latent since `go.mod` moved to 1.25/1.26. It only appeared because **no tag had been pushed since v2.0.0 (2025-12-18)**, so `go-release` hadn't run in seven months. Automating releases (#102) exercised it on the first try.

Note the repo already knows this trap — the `actionlint` job in `on-pull-request.yml` carries a comment explaining it and uses `1.26`. The `tests` action dodges it only by still being on `setup-go@v4`, which doesn't pin `GOTOOLCHAIN`.

## Fix

`go-version: "1.24"` → `"1.26"` in `.github/actions/go-release/action.yml`, matching `go.mod`'s `toolchain go1.26.1` and the actionlint job, with a comment so it isn't "cleaned up" back to 1.24.

## Verification

`actionlint` v1.7.12 (same as CI) clean. Real proof is the `Versioned Release` re-run on the `v3.0.0` tag once this merges.

**Unaffected:** `release-image` and `tests` — this only touches the binaries path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: drop `release-as`

Shipped here deliberately rather than as a follow-up. `release-as: 3.0.0` was a one-shot to force the bootstrap; the manifest now reads `3.0.0`. Merging the Go fix **alone** would leave `main` with `release-as` still pinned while the manifest is already at that version — so the next run would try to re-cut 3.0.0 instead of computing the next version. The two changes have to land together.

With both in, the next merge to `main` produces a **v3.0.1** release PR (patch, from these `fix:` commits) whose `release-binaries` job actually works — which is also the real end-to-end proof of the fix.
