### PR TITLE
feat: add the backfill subcommand to repair gaps in observation history from the REST API

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -1,21 +1,84 @@
 ---
 name: Tests
-description: Runs Go Tests
+description: Runs the full Go quality gate — format, build, vet, lint, and race-enabled tests
 
 runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: "1.24"
+        # Read the version from go.mod rather than pinning it here. The
+        # previous hardcoded "1.24" was BELOW the module's own floor
+        # (go.mod declares go 1.25.0), so Go silently downloaded a
+        # different toolchain on every run and the pin documented nothing.
+        go-version-file: go.mod
+        cache: true
 
     - name: Prepare Go modules
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
-        go clean -modcache
+        # `go mod download`, not `go mod tidy`: tidy MUTATES go.mod/go.sum,
+        # so an untidy module could never fail CI — it was silently fixed
+        # in-place and the fix thrown away with the runner. The tidiness
+        # check below catches that condition instead of hiding it.
+        go mod download
+
+    - name: Check go.mod is tidy
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        cp go.mod go.mod.orig
+        cp go.sum go.sum.orig
         go mod tidy
+        if ! diff -q go.mod go.mod.orig >/dev/null || ! diff -q go.sum go.sum.orig >/dev/null; then
+          echo "::error::go.mod/go.sum are not tidy — run 'go mod tidy' and commit the result"
+          diff -u go.mod.orig go.mod || true
+          diff -u go.sum.orig go.sum || true
+          exit 1
+        fi
+        rm -f go.mod.orig go.sum.orig
+
+    - name: Check formatting
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "::error::gofmt reported unformatted files:"
+          echo "$unformatted"
+          exit 1
+        fi
+
+    - name: Build
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        # CGO_ENABLED=0 is load-bearing, not incidental: the SQLite driver is
+        # modernc.org/sqlite (pure Go) specifically so the release image can
+        # stay static on chainguard/static. A cgo dependency creeping in must
+        # break the build here rather than at image build time.
+        CGO_ENABLED: "0"
+      run: go build ./...
+
+    - name: Vet
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        # go vet compiles _test.go files; go build does not. It is also what
+        # rejects APIs newer than the go.mod language version — `go build`
+        # accepts them when the installed toolchain is newer.
+        go vet ./...
+
+    - name: Lint
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        # Pinned via `go run <module>@<version>`, matching how this repo
+        # already pins actionlint in on-pull-request.yml. Keep this version in
+        # step with what contributors run locally.
+        go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
 
     - name: Run all Tests
       shell: bash
@@ -23,11 +86,16 @@ runs:
       run: |
         go version
         START_TIME=$(date +%s)
-        go test -json ./... 2>&1 | tee test-output.json || true
+        # -race is the point of this step. CGO_ENABLED is deliberately NOT
+        # forced to 0 here: the race detector needs the host toolchain, and
+        # the static-image constraint is already proven by the Build step.
+        go test -race -json ./... 2>&1 | tee test-output.json || true
         END_TIME=$(date +%s)
         echo "TEST_DURATION=$((END_TIME - START_TIME))" >> $GITHUB_ENV
 
-        # Check if any tests failed
+        # A build failure or a panic can abort a package before any test
+        # event is emitted, so grepping only for test failures is not
+        # sufficient on its own — check for package-level failures too.
         if grep -q '"Action":"fail"' test-output.json; then
           echo "TEST_FAILED=true" >> $GITHUB_ENV
         else
@@ -62,9 +130,11 @@ runs:
         # Generate summary header
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Gate: gofmt · tidy · build (CGO_ENABLED=0) · vet · golangci-lint · go test -race" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Job | Status | Duration | Tests |" >> $GITHUB_STEP_SUMMARY
         echo "|-----|--------|----------|-------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Go Tests | ${STATUS} | ${DURATION_FMT} | ${PASSED}/${TOTAL} passed |" >> $GITHUB_STEP_SUMMARY
+        echo "| Go Tests (-race) | ${STATUS} | ${DURATION_FMT} | ${PASSED}/${TOTAL} passed |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         # Show success or failure message

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ Temporary Items
 .classpath
 .settings/
 *.iml
+
+# Session handoff prompts (scaffolding, not project artifacts)
+docs/prompts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,5 +315,18 @@ Test files located alongside implementation:
 - `internal/tempestudp/report_test.go`: UDP message parsing
 - `internal/tempestudp/wetbulb_test.go`: Wet bulb calculations
 - `internal/tempestapi/client_test.go`: API client
+- `internal/tempestapi/observations_test.go`: Null-preserving REST decode
+- `internal/weather/observation_test.go`: Store-neutral types
+- `internal/backfill/`: Window chunking, retry classification, gap assembly, and the `Run` core
+- `internal/sqlite/backfill_test.go`, `internal/postgres/backfill_test.go`: Gap detection and idempotent insert
+- `backfill_cmd_test.go`: Subcommand dispatch and flag parsing
 
-Go 1.23.0+ required (see go.mod).
+Postgres tests that need a live database skip unless `POSTGRES_URL` is set:
+
+```bash
+docker run --rm -d --name pg-test -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+POSTGRES_URL='postgres://postgres:x@localhost:55432/weather?sslmode=disable' go test ./internal/postgres/ -count=1
+docker rm -f pg-test
+```
+
+Go 1.25.0+ required (see go.mod; the pinned toolchain is go1.26.1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ The application switches modes based on presence of `TOKEN` environment variable
 - **`internal/tempest/`**: Defines all Prometheus metric descriptors (`prometheus.Desc`)
 - **`internal/tempestudp/`**: Parses UDP broadcast messages into metrics, includes wet bulb temperature calculations
 - **`internal/tempestapi/`**: REST API client for fetching historical observations
+- **`internal/weather/`**: Store-neutral `Observation`, `Gap`, and `Bounds` types shared by the REST client and both stores
+- **`internal/backfill/`**: Gap detection and API backfill orchestration for the `backfill` subcommand
 
 ### Data Flow (UDP Mode)
 
@@ -186,6 +188,11 @@ All tables use UUIDv7 primary keys (generated in Go, no PostgreSQL extensions re
 
 > **SQLite default:** every UDP-mode row above (`TOKEN` unset) **also** persists to SQLite at `SQLITE_PATH` (default `/data/tempest.db`), unless `ENABLE_POSTGRES` is the only configured store and `SQLITE_PATH` is unset. SQLite is not written in API-export mode (`TOKEN` set).
 
+> **Subcommands bypass mode selection.** `backfill` and `healthcheck` are chosen
+> by the first CLI argument, not by environment variables, and neither starts the
+> UDP listener or the HTTP server. Any other non-flag first argument is a usage
+> error (exit 2) rather than a silent fallthrough to daemon mode.
+
 ### Docker Compose Example
 
 ```yaml
@@ -236,9 +243,11 @@ scrape_configs:
 
 The `/metrics` endpoint exposes all weather station metrics in standard Prometheus format. A `/health` endpoint is also available for health checks.
 
-### API Export with Backfill
+### API Export Mode (TOKEN)
 
-To backfill historical data into Postgres:
+Setting `TOKEN` switches the process into the full historical-export path: it
+fetches historical observation data via the REST API and writes it to
+PostgreSQL and/or compressed files, then exits.
 
 ```bash
 TOKEN=your_api_token ENABLE_POSTGRES=true POSTGRES_URL=postgresql://... go run .
@@ -249,6 +258,56 @@ Optionally keep .gz files:
 ```bash
 TOKEN=your_api_token ENABLE_POSTGRES=true POSTGRES_URL=postgresql://... KEEP_EXPORT_FILES=true go run .
 ```
+
+### Backfill Subcommand
+
+Fills holes in the local observation history from the Tempest REST API. Unlike
+API Export Mode (which is selected by setting `TOKEN` and runs the whole export
+path), this is an explicit subcommand and can be run against a live database:
+
+```bash
+TOKEN=your_api_token tempestwx-utilities backfill
+TOKEN=... tempestwx-utilities backfill --dry-run
+TOKEN=... tempestwx-utilities backfill --from 2026-07-01T00:00:00Z --to 2026-07-05T00:00:00Z
+```
+
+It writes to whichever store is configured (SQLite by default, Postgres when
+`ENABLE_POSTGRES=true`) and is idempotent — re-running inserts nothing new.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--from`, `--to` | unset (auto-detect) | Explicit window, RFC3339 **UTC**. Must be given together. |
+| `--min-gap` | `30m` | Smallest interval that counts as a gap. Raise it for stations with a long `report_interval`. |
+| `--dry-run` | `false` | Detect and plan only: zero observation fetches, zero writes. It still lists devices, so it *does* validate the token. |
+| `--store` | unset | `sqlite` or `postgres`. **Required** when both stores are configured. |
+
+**`--store` and the fan-out configuration.** With `ENABLE_POSTGRES=true` *and*
+`SQLITE_PATH` set, the daemon writes every observation to **both** stores.
+Backfill repairs one store per run, so in that configuration it refuses to start
+without `--store` rather than guessing — silently repairing Postgres while
+leaving the Litestream-replicated SQLite database holed, and then reporting
+success, would be worse than failing.
+
+**Multiple sensors.** `backfill` enumerates every `ST` device on the account, so a
+station with two Tempest units has both repaired. (This differs from `TOKEN`-mode
+API export, which sees one device per station.)
+
+**Exit codes:** `0` success — including `--help`, and including permanent holes
+(windows the station was genuinely offline for, which the API cannot fill
+either); `1` one or more gaps failed, or a runtime error; `2` usage error.
+
+**Scope:** `tempest_observations` only. There is no historical REST endpoint for
+rapid wind, hub status, or discrete events. Lightning is partially recovered in
+aggregate through the observation columns, but not as `tempest_events` rows.
+
+**Safety:** if the API's station serials and the store's serials have **no
+overlap at all** (on a non-empty store), backfill stops and writes nothing — that
+is the signature of a serial-format mismatch, which would create a parallel
+series that never dedupes.
+
+A *newly added* station, or one this host never hears over UDP, is **not** a
+mismatch: its serial simply has no rows yet, and backfill fetches its whole
+history normally.
 
 ## Testing Notes
 

--- a/backfill_cmd.go
+++ b/backfill_cmd.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"tempestwx-utilities/internal/backfill"
+	"tempestwx-utilities/internal/config"
+	"tempestwx-utilities/internal/postgres"
+	"tempestwx-utilities/internal/sqlite"
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+
+	"database/sql"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// parseBackfillFlags reads the backfill subcommand's own FlagSet.
+//
+// Each subcommand owning its FlagSet (parsed from os.Args[2:]) is the seam a
+// future subcommand slots into: a new subcommand is a new file plus one
+// dispatch line, with no sibling touched.
+//
+// --from/--to are RFC3339 interpreted as UTC. The store is UTC epoch and the
+// API takes epoch seconds; an ambiguous local-time parse would be a quiet
+// wrong-window bug, so a non-RFC3339 value is rejected rather than guessed at.
+func parseBackfillFlags(args []string) (backfill.Config, string, error) {
+	fs := flag.NewFlagSet("backfill", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	fromStr := fs.String("from", "", "start of the window to repair, RFC3339 UTC (default: auto-detect)")
+	toStr := fs.String("to", "", "end of the window to repair, RFC3339 UTC (default: auto-detect)")
+	minGap := fs.Duration("min-gap", 30*time.Minute, "smallest interval that counts as a gap")
+	dryRun := fs.Bool("dry-run", false, "detect and plan only: no observation fetches, no writes")
+
+	store := fs.String("store", "", "which store to repair: sqlite or postgres (required when both are configured)")
+
+	if err := fs.Parse(args); err != nil {
+		return backfill.Config{}, "", err
+	}
+
+	cfg := backfill.Config{MinGap: *minGap, DryRun: *dryRun}
+
+	// --store is returned separately, not folded into backfill.Config: it
+	// selects which handle the SHELL opens, and Run has no use for it. A core
+	// config struct carrying a field the core ignores is a trap.
+	switch *store {
+	case "", "sqlite", "postgres":
+	default:
+		return cfg, *store, usageErr(fs, "--store must be sqlite or postgres, got %q", *store)
+	}
+
+	if (*fromStr == "") != (*toStr == "") {
+		return cfg, *store, usageErr(fs, "--from and --to must be given together, or neither")
+	}
+	if *fromStr != "" {
+		from, err := time.Parse(time.RFC3339, *fromStr)
+		if err != nil {
+			return cfg, *store, usageErr(fs, "--from must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+		}
+		to, err := time.Parse(time.RFC3339, *toStr)
+		if err != nil {
+			return cfg, *store, usageErr(fs, "--to must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+		}
+		cfg.From, cfg.To = from.UTC(), to.UTC()
+		if !cfg.To.After(cfg.From) {
+			return cfg, *store, usageErr(fs, "--to must be after --from")
+		}
+	}
+	return cfg, *store, nil
+}
+
+// usageErr reports a validation failure the way flag reports a parse failure:
+// message plus usage, on stderr. Centralizing it means runBackfill prints
+// nothing itself, so flag's message is never duplicated.
+func usageErr(fs *flag.FlagSet, format string, a ...any) error {
+	err := fmt.Errorf(format, a...)
+	_, _ = fmt.Fprintln(fs.Output(), err)
+	fs.Usage()
+	return err
+}
+
+// resolveStore decides which single store this run repairs.
+//
+// Backfill repairs ONE store per run. selectStore returns BOTH when
+// ENABLE_POSTGRES=true and SQLITE_PATH is set — a documented fan-out the
+// daemon honors by writing every observation to both (main.go:302-336). In
+// that configuration backfill cannot infer the target, and guessing is the
+// worst option available: repairing Postgres while leaving the
+// Litestream-replicated SQLite database still holed, then exiting 0, tells
+// the operator the history is fixed when it is not.
+func resolveStore(choice storeChoice, flagValue string) (string, error) {
+	var configured []string
+	if choice.sqlite {
+		configured = append(configured, "sqlite")
+	}
+	if choice.postgres {
+		configured = append(configured, "postgres")
+	}
+
+	switch len(configured) {
+	case 0:
+		return "", errors.New("backfill: no store configured; set SQLITE_PATH, or ENABLE_POSTGRES=true with POSTGRES_URL")
+	case 1:
+		if flagValue != "" && flagValue != configured[0] {
+			return "", fmt.Errorf("backfill: --store=%s, but only %s is configured", flagValue, configured[0])
+		}
+		return configured[0], nil
+	default:
+		if flagValue == "" {
+			return "", fmt.Errorf(
+				"backfill: both %s are configured; pass --store=sqlite or --store=postgres. "+
+					"Backfill repairs one store per run and will not guess — silently repairing "+
+					"only one while reporting success would leave the other permanently holed",
+				strings.Join(configured, " and "))
+		}
+		return flagValue, nil
+	}
+}
+
+// sqliteStore adapts the package-level SQLite functions to backfill.Store.
+//
+// backfill.Store has FOUR methods. If either adapter fails to compile with
+// "does not implement backfill.Store (missing method DistinctSerials)", the
+// fix is to ADD the method here. Do NOT remove DistinctSerials from the
+// interface — that silently reverts the pre-flight fix, because SeriesBounds
+// is windowed and would false-positive on any station quiet during the
+// queried window.
+type sqliteStore struct{ db *sql.DB }
+
+func (s sqliteStore) DistinctSerials(ctx context.Context) ([]string, error) {
+	return sqlite.DistinctSerials(ctx, s.db)
+}
+
+func (s sqliteStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
+	return sqlite.SeriesBounds(ctx, s.db, from, to)
+}
+
+func (s sqliteStore) FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	return sqlite.FindObservationGaps(ctx, s.db, from, to, minGap)
+}
+
+func (s sqliteStore) InsertObservations(ctx context.Context, obs []weather.Observation) (int, error) {
+	return sqlite.InsertObservations(ctx, s.db, obs)
+}
+
+// postgresStore adapts the package-level Postgres functions to backfill.Store.
+// See sqliteStore's comment: four methods, and DistinctSerials is not optional.
+type postgresStore struct{ pool *pgxpool.Pool }
+
+func (s postgresStore) DistinctSerials(ctx context.Context) ([]string, error) {
+	return postgres.DistinctSerials(ctx, s.pool)
+}
+
+func (s postgresStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
+	return postgres.SeriesBounds(ctx, s.pool, from, to)
+}
+
+func (s postgresStore) FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	return postgres.FindObservationGaps(ctx, s.pool, from, to, minGap)
+}
+
+func (s postgresStore) InsertObservations(ctx context.Context, obs []weather.Observation) (int, error) {
+	return postgres.InsertObservations(ctx, s.pool, obs)
+}
+
+// runBackfill is the backfill subcommand's shell: parse, read env, open
+// handles, wire dependencies, return an exit code.
+//
+// It performs ALL cleanup via internal defers. Copying the healthcheck shape
+// (os.Exit at the dispatch site, main.go:189-191) would skip db.Close() and
+// the pgx pool drain.
+//
+// Exit codes: 0 success (including permanent holes), 1 a gap failed or a
+// runtime error, 2 a usage error.
+func runBackfill(ctx context.Context, args []string) int {
+	cfg, storeFlag, err := parseBackfillFlags(args)
+	if err != nil {
+		// --help is NOT a usage error. flag prints the usage itself and
+		// returns ErrHelp; exiting 2 here would break every CI smoke test
+		// that runs `cmd --help`.
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		// parseBackfillFlags owns the FlagSet's output and has already
+		// reported the error, so nothing is printed here — printing again
+		// would duplicate flag's own message.
+		return 2
+	}
+
+	// TOKEN is validated BEFORE any store handle is opened, so the failure
+	// costs no I/O and leaves nothing to close.
+	token := os.Getenv("TOKEN")
+	if token == "" {
+		slog.Error("backfill: TOKEN is required to reach the Tempest REST API")
+		return 1
+	}
+
+	// Signal wiring lives in the subcommand — the healthcheck path has none
+	// to inherit.
+	ctx, stop := signalContext(ctx, signal.NotifyContext)
+	defer stop()
+
+	enablePostgres, err := config.ParseBoolEnv("ENABLE_POSTGRES")
+	if err != nil {
+		slog.Error("backfill: bad ENABLE_POSTGRES", "error", err)
+		return 1
+	}
+	choice := selectStore(enablePostgres, os.Getenv("SQLITE_PATH"))
+
+	// Backfill repairs ONE store per run, and must never guess which. The
+	// daemon fans out to both when ENABLE_POSTGRES and SQLITE_PATH are both
+	// set (main.go:147-154, :302-336); silently repairing Postgres while
+	// leaving the SQLite database — the one Litestream replicates to S3 —
+	// still holed, then reporting success, is the worst available outcome.
+	target, err := resolveStore(choice, storeFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	var store backfill.Store
+	switch target {
+	case "postgres":
+		dbConfig, err := config.GetDatabaseConfig()
+		if err != nil {
+			slog.Error("backfill: database configuration", "error", err)
+			return 1
+		}
+		if dbConfig == "" {
+			slog.Error("backfill: POSTGRES_URL or POSTGRES_HOST is required when ENABLE_POSTGRES is true")
+			return 1
+		}
+		// Backfill opens the WRITE path: it must create the schema and
+		// insert. OpenPool starts no goroutines, unlike NewPostgresWriter.
+		pool, err := postgres.OpenPool(ctx, dbConfig)
+		if err != nil {
+			slog.Error("backfill: open postgres", "error", err)
+			return 1
+		}
+		defer pool.Close()
+		if err := postgres.CreateSchema(ctx, pool); err != nil {
+			slog.Error("backfill: create postgres schema", "error", err)
+			return 1
+		}
+		store = postgresStore{pool: pool}
+	case "sqlite":
+		// The write handle, not OpenReadOnly: read-only fails when the file
+		// does not exist and cannot migrate, and its ingest-contention
+		// rationale does not apply to a separate one-shot process.
+		db, err := sqlite.Open(ctx, choice.sqlitePath, sqlite.LoadConfig(os.Getenv))
+		if err != nil {
+			slog.Error("backfill: open sqlite", "path", choice.sqlitePath, "error", err)
+			return 1
+		}
+		defer func() {
+			if err := db.Close(); err != nil {
+				slog.Error("backfill: close sqlite", "error", err)
+			}
+		}()
+		store = sqliteStore{db: db}
+	default:
+		// Unreachable today — resolveStore returns only "sqlite" or
+		// "postgres" — but a nil Store interface would panic deep inside Run,
+		// far from the cause.
+		slog.Error("backfill: unknown store target", "target", target)
+		return 1
+	}
+	slog.Info("backfill: store selected", "store", target)
+
+	client := tempestapi.NewClient(token)
+	// ListDevices, NOT ListStations: ListStations collapses each station to a
+	// single ST device, so a two-sensor station would leave one sensor's gaps
+	// permanently unrepaired and unlogged.
+	devices, err := client.ListDevices(ctx)
+	if err != nil {
+		slog.Error("backfill: list devices", "error", err)
+		return 1
+	}
+	if len(devices) == 0 {
+		slog.Error("backfill: the API reported no ST devices for this token")
+		return 1
+	}
+	slog.Info("backfill: devices discovered", "count", len(devices))
+
+	stats, err := backfill.Run(ctx, cfg, client, store, devices, time.Now().UTC())
+	slog.Info("backfill: complete",
+		"gaps", stats.Gaps, "returned", stats.Returned,
+		"inserted", stats.Inserted, "failed", stats.Failed, "dry_run", cfg.DryRun)
+	if err != nil {
+		slog.Error("backfill: finished with failures", "error", err)
+		return 1
+	}
+	return 0
+}

--- a/backfill_cmd.go
+++ b/backfill_cmd.go
@@ -49,6 +49,14 @@ func parseBackfillFlags(args []string) (backfill.Config, string, error) {
 
 	cfg := backfill.Config{MinGap: *minGap, DryRun: *dryRun}
 
+	// A non-positive --min-gap is a silent misconfiguration, not a usable
+	// setting: zero makes every consecutive one-minute observation pair a
+	// "gap", and a negative value pushes detectTo (now - minGap) into the
+	// future.
+	if *minGap <= 0 {
+		return cfg, *store, usageErr(fs, "--min-gap must be positive, got %s", minGap.String())
+	}
+
 	// --store is returned separately, not folded into backfill.Config: it
 	// selects which handle the SHELL opens, and Run has no use for it. A core
 	// config struct carrying a field the core ignores is a trap.
@@ -240,7 +248,11 @@ func runBackfill(ctx context.Context, args []string) int {
 			return 1
 		}
 		// Backfill opens the WRITE path: it must create the schema and
-		// insert. OpenPool starts no goroutines, unlike NewPostgresWriter.
+		// insert. OpenPool starts no batch-worker goroutines, unlike
+		// NewPostgresWriter's four (pgxpool.NewWithConfig itself starts its
+		// own internal goroutine for idle-connection maintenance regardless
+		// of caller — that's pgx's concern, not the contrast being drawn
+		// here).
 		pool, err := postgres.OpenPool(ctx, dbConfig)
 		if err != nil {
 			slog.Error("backfill: open postgres", "error", err)

--- a/backfill_cmd_test.go
+++ b/backfill_cmd_test.go
@@ -26,26 +26,80 @@ func TestParseBackfillFlagsDefaults(t *testing.T) {
 	}
 }
 
+// The Z-suffixed case alone cannot pin the ".UTC()" conversion in
+// parseBackfillFlags: time.Parse(time.RFC3339, ...) already returns a
+// time.UTC location for a Z suffix, so cfg.From.Location() != time.UTC can
+// never fire regardless of whether the conversion is present. The
+// offset-bearing case forces time.Parse to return a non-UTC location, so the
+// location check only passes if the conversion actually runs — and the
+// instant check confirms it converts to the correct point in time, not just
+// relabels the location.
 func TestParseBackfillFlagsRFC3339IsUTC(t *testing.T) {
-	cfg, _, err := parseBackfillFlags([]string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"})
-	if err != nil {
-		t.Fatalf("parseBackfillFlags: %v", err)
+	tests := []struct {
+		name     string
+		args     []string
+		wantFrom time.Time
+		wantTo   time.Time
+	}{
+		{
+			name:     "Z suffix is already UTC",
+			args:     []string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"},
+			wantFrom: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			wantTo:   time.Date(2026, 1, 3, 3, 4, 5, 0, time.UTC),
+		},
+		{
+			name:     "offset is normalized to UTC",
+			args:     []string{"--from", "2026-01-02T03:04:05+05:00", "--to", "2026-01-03T03:04:05+05:00"},
+			wantFrom: time.Date(2026, 1, 1, 22, 4, 5, 0, time.UTC),
+			wantTo:   time.Date(2026, 1, 2, 22, 4, 5, 0, time.UTC),
+		},
 	}
-	if cfg.From.Location() != time.UTC {
-		t.Errorf("From location = %v, want UTC", cfg.From.Location())
-	}
-	if cfg.From.Format(time.RFC3339) != "2026-01-02T03:04:05Z" {
-		t.Errorf("From = %v, want 2026-01-02T03:04:05Z", cfg.From.Format(time.RFC3339))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _, err := parseBackfillFlags(tt.args)
+			if err != nil {
+				t.Fatalf("parseBackfillFlags: %v", err)
+			}
+			if cfg.From.Location() != time.UTC {
+				t.Errorf("From location = %v, want UTC", cfg.From.Location())
+			}
+			if cfg.To.Location() != time.UTC {
+				t.Errorf("To location = %v, want UTC", cfg.To.Location())
+			}
+			if !cfg.From.Equal(tt.wantFrom) {
+				t.Errorf("From = %v, want %v", cfg.From, tt.wantFrom)
+			}
+			if !cfg.To.Equal(tt.wantTo) {
+				t.Errorf("To = %v, want %v", cfg.To, tt.wantTo)
+			}
+		})
 	}
 }
 
+// Both flags are always passed here, deliberately. The both-or-neither guard
+// (TestParseBackfillFlagsRequiresBothOrNeither) fires before the RFC3339
+// parse and its error also contains "from" or "to" — so a single-flag call
+// would satisfy a substring-on-the-flag-name assertion without ever reaching
+// the RFC3339 branch under test. Asserting on "RFC3339" instead, which only
+// the parse-failure message contains, is what actually pins this branch.
 func TestParseBackfillFlagsRejectsNonRFC3339(t *testing.T) {
-	_, _, err := parseBackfillFlags([]string{"--from", "2026-01-02"})
-	if err == nil {
-		t.Fatal("a non-RFC3339 --from must be rejected; an ambiguous local-time parse is a quiet wrong-window bug")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"bad --from", []string{"--from", "2026-01-02", "--to", "2026-01-03T00:00:00Z"}},
+		{"bad --to", []string{"--from", "2026-01-02T00:00:00Z", "--to", "2026-01-03"}},
 	}
-	if !strings.Contains(err.Error(), "from") {
-		t.Errorf("error = %q, want it to name the offending flag", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseBackfillFlags(tt.args)
+			if err == nil {
+				t.Fatal("a non-RFC3339 date must be rejected; an ambiguous local-time parse is a quiet wrong-window bug")
+			}
+			if !strings.Contains(err.Error(), "RFC3339") {
+				t.Errorf("error = %q, want it to report the RFC3339 requirement (the both-or-neither guard's message would also contain the flag name)", err)
+			}
+		})
 	}
 }
 

--- a/backfill_cmd_test.go
+++ b/backfill_cmd_test.go
@@ -155,6 +155,30 @@ func TestRunBackfillWithoutTokenFailsBeforeOpeningTheStore(t *testing.T) {
 	}
 }
 
+// --min-gap must be strictly positive. Zero makes every consecutive
+// one-minute observation pair a "gap"; a negative value pushes detectTo
+// into the future. Both are silent misconfigurations, not usable settings.
+func TestParseBackfillFlagsRejectsNonPositiveMinGap(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"zero", []string{"--min-gap", "0s"}},
+		{"negative", []string{"--min-gap", "-5m"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseBackfillFlags(tt.args)
+			if err == nil {
+				t.Fatalf("--min-gap %v must be rejected", tt.args)
+			}
+			if !strings.Contains(err.Error(), "min-gap") {
+				t.Errorf("error = %q, want it to name --min-gap", err)
+			}
+		})
+	}
+}
+
 func TestParseBackfillFlagsStoreValidation(t *testing.T) {
 	for _, v := range []string{"sqlite", "postgres", ""} {
 		if _, got, err := parseBackfillFlags([]string{"--store", v}); err != nil || got != v {

--- a/backfill_cmd_test.go
+++ b/backfill_cmd_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseBackfillFlagsDefaults(t *testing.T) {
+	cfg, _, err := parseBackfillFlags(nil)
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if cfg.MinGap != 30*time.Minute {
+		t.Errorf("MinGap = %v, want 30m", cfg.MinGap)
+	}
+	if cfg.DryRun {
+		t.Error("DryRun should default to false")
+	}
+	if !cfg.From.IsZero() || !cfg.To.IsZero() {
+		t.Error("From/To should default to zero (auto-detect)")
+	}
+}
+
+func TestParseBackfillFlagsRFC3339IsUTC(t *testing.T) {
+	cfg, _, err := parseBackfillFlags([]string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"})
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if cfg.From.Location() != time.UTC {
+		t.Errorf("From location = %v, want UTC", cfg.From.Location())
+	}
+	if cfg.From.Format(time.RFC3339) != "2026-01-02T03:04:05Z" {
+		t.Errorf("From = %v, want 2026-01-02T03:04:05Z", cfg.From.Format(time.RFC3339))
+	}
+}
+
+func TestParseBackfillFlagsRejectsNonRFC3339(t *testing.T) {
+	_, _, err := parseBackfillFlags([]string{"--from", "2026-01-02"})
+	if err == nil {
+		t.Fatal("a non-RFC3339 --from must be rejected; an ambiguous local-time parse is a quiet wrong-window bug")
+	}
+	if !strings.Contains(err.Error(), "from") {
+		t.Errorf("error = %q, want it to name the offending flag", err)
+	}
+}
+
+func TestParseBackfillFlagsRequiresBothOrNeither(t *testing.T) {
+	if _, _, err := parseBackfillFlags([]string{"--from", "2026-01-02T00:00:00Z"}); err == nil {
+		t.Error("--from without --to must be rejected")
+	}
+	if _, _, err := parseBackfillFlags([]string{"--to", "2026-01-02T00:00:00Z"}); err == nil {
+		t.Error("--to without --from must be rejected")
+	}
+}
+
+func TestParseBackfillFlagsRejectsInvertedRange(t *testing.T) {
+	_, _, err := parseBackfillFlags([]string{"--from", "2026-01-03T00:00:00Z", "--to", "2026-01-02T00:00:00Z"})
+	if err == nil {
+		t.Fatal("--to before --from must be rejected")
+	}
+}
+
+func TestParseBackfillFlagsDryRun(t *testing.T) {
+	cfg, _, err := parseBackfillFlags([]string{"--dry-run", "--min-gap", "2h"})
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if !cfg.DryRun {
+		t.Error("--dry-run not applied")
+	}
+	if cfg.MinGap != 2*time.Hour {
+		t.Errorf("MinGap = %v, want 2h", cfg.MinGap)
+	}
+}
+
+// TOKEN must be validated BEFORE any store handle is opened, so the failure
+// costs no I/O and leaves nothing to close.
+//
+// The ordering is proven by pointing SQLITE_PATH at a path inside a writable
+// temp dir and asserting the file was never created. An earlier version of
+// this test used a bogus path and asserted only exit==1 — which passes
+// identically whether TOKEN is checked before or after the store opens, since
+// a failed open also returns 1. That test could not fail for its stated
+// reason.
+func TestRunBackfillWithoutTokenFailsBeforeOpeningTheStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "should-never-be-created.db")
+	t.Setenv("TOKEN", "")
+	t.Setenv("ENABLE_POSTGRES", "")
+	t.Setenv("SQLITE_PATH", dbPath)
+
+	if got := runBackfill(t.Context(), nil); got != 1 {
+		t.Errorf("exit code = %d, want 1 for a missing TOKEN", got)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("SQLite database at %s was created; TOKEN must be validated before the store is opened", dbPath)
+	}
+}
+
+func TestParseBackfillFlagsStoreValidation(t *testing.T) {
+	for _, v := range []string{"sqlite", "postgres", ""} {
+		if _, got, err := parseBackfillFlags([]string{"--store", v}); err != nil || got != v {
+			t.Errorf("--store=%q: got (%q, %v), want (%q, nil)", v, got, err, v)
+		}
+	}
+	if _, _, err := parseBackfillFlags([]string{"--store", "mysql"}); err == nil {
+		t.Error("--store=mysql must be rejected")
+	}
+}
+
+func TestResolveStore(t *testing.T) {
+	both := storeChoice{sqlite: true, postgres: true}
+	onlySQLite := storeChoice{sqlite: true}
+	onlyPG := storeChoice{postgres: true}
+	none := storeChoice{}
+
+	tests := []struct {
+		name    string
+		choice  storeChoice
+		flag    string
+		want    string
+		wantErr bool
+	}{
+		{"single store needs no flag", onlySQLite, "", "sqlite", false},
+		{"single store, matching flag", onlyPG, "postgres", "postgres", false},
+		{"single store, contradicting flag", onlySQLite, "postgres", "", true},
+		{"both configured, flag chooses", both, "postgres", "postgres", false},
+		{"both configured, flag chooses sqlite", both, "sqlite", "sqlite", false},
+		// The regression: never silently pick one.
+		{"both configured, no flag", both, "", "", true},
+		{"nothing configured", none, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStore(tt.choice, tt.flag)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The design's "Store selection" row demands exit 2 AND nothing written.
+// TestResolveStore covers the pure function; this covers the command, which
+// is what the row actually specifies. No Docker needed — resolveStore fires
+// before any handle is opened.
+func TestRunBackfillRefusesAmbiguousStoreAndWritesNothing(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "never.db")
+	t.Setenv("TOKEN", "x")
+	t.Setenv("ENABLE_POSTGRES", "true")
+	t.Setenv("SQLITE_PATH", dbPath)
+
+	if got := runBackfill(t.Context(), nil); got != 2 {
+		t.Errorf("exit code = %d, want 2 — both stores configured with no --store must refuse", got)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("SQLite database at %s was created; an ambiguous store selection must write nothing", dbPath)
+	}
+}
+
+// --help is not a usage error.
+func TestRunBackfillHelpExitsZero(t *testing.T) {
+	t.Setenv("TOKEN", "x")
+	if got := runBackfill(t.Context(), []string{"--help"}); got != 0 {
+		t.Errorf("exit code = %d, want 0 — `cmd --help` is a successful invocation", got)
+	}
+}
+
+func TestRunBackfillUsageErrorExitsTwo(t *testing.T) {
+	t.Setenv("TOKEN", "x")
+	if got := runBackfill(t.Context(), []string{"--from", "not-a-time", "--to", "also-not"}); got != 2 {
+		t.Errorf("exit code = %d, want 2 for a usage error", got)
+	}
+}
+
+func TestKnownSubcommands(t *testing.T) {
+	for _, name := range []string{"healthcheck", "backfill"} {
+		if !isKnownSubcommand(name) {
+			t.Errorf("%q should be a known subcommand", name)
+		}
+	}
+	for _, name := range []string{"backfil", "helthcheck", "migrate", ""} {
+		if isKnownSubcommand(name) {
+			t.Errorf("%q should NOT be a known subcommand", name)
+		}
+	}
+}
+
+// TestKnownSubcommands above tests a pure predicate — it would still pass if
+// main() never called it. This one tests the BEHAVIOR the design mandates:
+// an unknown subcommand must exit 2 and must NOT start the daemon.
+//
+// The regression it guards is real: before the dispatch fix, `backfil` fell
+// through and silently started a UDP listener, which never exits — so a
+// failure here shows up as a timeout, not just a bad exit code.
+func TestUnknownSubcommandExitsTwoWithoutStartingDaemon(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "twx")
+	//nolint:gosec // G204: test-only; builds this package's own binary into t.TempDir()
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", bin, ".")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	//nolint:gosec // G204: test-only; runs the binary this test just built
+	cmd := exec.CommandContext(t.Context(), bin, "backfil")
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected a non-zero exit, got err=%v\n%s", err, out)
+	}
+	if code := exitErr.ExitCode(); code != 2 {
+		t.Errorf("exit code = %d, want 2\n%s", code, out)
+	}
+	if !strings.Contains(string(out), "unknown subcommand") {
+		t.Errorf("output should name the bad subcommand, got:\n%s", out)
+	}
+}
+
+// `backfill` must actually REACH runBackfill through main()'s dispatch.
+//
+// TestRunBackfillHelpExitsZero calls runBackfill directly and so never crosses
+// the dispatch — deleting `case "backfill":` from main() leaves the entire
+// suite green while the binary falls through and starts the UDP daemon. That
+// is the same silent-daemon failure Task 10 exists to eliminate, reachable by
+// a one-line edit. Only a re-exec catches it.
+func TestBackfillSubcommandReachesRunBackfill(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "twx")
+	//nolint:gosec // G204: test-only; builds this package's own binary into t.TempDir()
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", bin, ".")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	// --help exits 0 and prints the backfill flag set. The daemon prints
+	// nothing resembling this, so it discriminates cleanly.
+	//nolint:gosec // G204: test-only; runs the binary this test just built
+	cmd := exec.CommandContext(t.Context(), bin, "backfill", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("`backfill --help` should exit 0, got %v\n%s", err, out)
+	}
+	for _, flagName := range []string{"-dry-run", "-from", "-min-gap", "-store", "-to"} {
+		if !strings.Contains(string(out), flagName) {
+			t.Errorf("`backfill --help` output missing %s — dispatch may not be reaching runBackfill.\ngot:\n%s", flagName, out)
+		}
+	}
+}

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -184,7 +184,11 @@ REST `obs_st` indices 0–17 match the UDP layout exactly, so the existing `len(
 
 **"Unmodified" means graduated, not all-or-nothing.** The UDP path accepts a tuple at `len(ob) >= 13` and fills the tail conditionally (`>= 6`, `>= 14`, `>= 16`, `>= 17`, `>= 18` — `sqlite/writer.go:406-457`). A single hard `len(ob) < 18 → drop` is **not** the same rule: it discards a short tuple's core measurements entirely. Because every `weather.Observation` measurement is a `*float64`, honoring the graduated guards is free — absent indices simply stay nil.
 
-**Dropped tuples must be counted and logged.** A tuple that *is* rejected (below the floor, or a null `ob[0]` that cannot be keyed) must increment a counter surfaced in the run summary. Otherwise a window whose tuples were all malformed reports `requested=0, inserted=0` — byte-identical to the permanent-hole signal, which is the one machine-readable diagnostic the whole reporting design rests on.
+**Dropped tuples must be counted and logged at WARN, per window, by the decode itself.** A tuple that *is* rejected (below the floor, or a null `ob[0]` that cannot be keyed) must appear in the log with a count and the serial. Otherwise a window whose tuples were all malformed reports `returned=0, inserted=0` — byte-identical to the permanent-hole signal, which is the one machine-readable diagnostic the whole reporting design rests on.
+
+The count is deliberately **not** threaded into the run summary: doing so would widen the `ObservationSource` seam between backfill and the REST client to carry a diagnostic, and the log stream is already the machine-readable surface this design chose when it cut the bespoke summary line.
+
+Note the summary field is named `returned`, not `requested`: it counts what the API handed back after drops. The closed gap interval and the shared chunk-window endpoints both mean a few observations are fetched more than once, so it is not a count of distinct missing observations.
 
 ## Gap detection
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -62,6 +62,20 @@ holding the pool contract (`MaxConns=10`, `MinConns=2`, `MaxConnLifetime=time.Ho
 
 `OpenPool` does **not** run `CreateSchema` — backfill calls `CreateSchema` explicitly, so schema creation stays an observable step of the caller rather than a side effect of opening a pool.
 
+### 3. Device-level lookup — `internal/tempestapi`
+
+`ListStations` collapses each station to a single `ST` device (see "Serial-number invariant"), so there is no way to enumerate every sensor on the account.
+
+**Decision:** add
+
+```go
+func (c *Client) ListDevices(ctx context.Context) ([]Station, error)
+```
+
+returning **one `Station` per `ST` device** across all stations — same struct, but `DeviceID`/`SerialNumber` are per device rather than per station, and a station with two Tempests yields two entries. `CreatedAt` carries the owning station's `created_epoch`, which is what `detectFrom` needs.
+
+`ListStations` is **not** modified: `ModeAPIExport` depends on its current one-per-station shape. The two share the response-decoding struct so the JSON contract lives in one place.
+
 ## Entry point and testability
 
 The subcommand is split into a **shell** and a **testable core**. A single `runBackfill(ctx) int` that reads flags, `TOKEN`, store config, and `time.Now()` internally cannot be driven from a test, which would make the mandated dry-run, head/tail/empty-domain, and serial pre-flight tests unwritable — a direct conflict with TDD.
@@ -86,17 +100,29 @@ func backfill(
 
   ```go
   type backfillStore interface {
+      DistinctSerials(ctx context.Context) ([]string, error)
       SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
       FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
       InsertObservations(ctx context.Context, obs []weather.Observation) (inserted int, err error)
   }
   ```
 
-  `SeriesBounds` returns the first and last stored timestamp per serial within a
-  window (`weather.Bounds`). It carries three jobs at once, which is why there is
-  no separate `DistinctSerials`: it supplies the head/tail boundaries `LAG`
-  cannot see, its key set *is* the set of serials present, and an empty result
-  is exactly the empty-store signal the pre-flight check needs.
+  `SeriesBounds` returns the first and last stored timestamp per serial **within a
+  window**, supplying the head/tail boundaries `LAG` cannot see.
+
+  `DistinctSerials` is **unwindowed** — `SELECT DISTINCT serial_number FROM
+  tempest_observations`, whole table — and exists solely for the pre-flight
+  check.
+
+  **These must not be merged.** An earlier revision of this design collapsed
+  `DistinctSerials` into `SeriesBounds` on the reasoning that "its key set *is*
+  the set of serials present." That reasoning silently assumed an unwindowed
+  query. `SeriesBounds` is windowed, so a station with no rows *inside the
+  queried window* looks absent from the store entirely — and the pre-flight
+  check then hard-stops on a station that is merely quiet, writing nothing,
+  including for the healthy stations. That is precisely what `--from/--to`
+  exists to do, so the merge broke the tool's main repair path. Keep them
+  separate.
 
   Defined in the **consumer** package (`internal/backfill`), Go-idiomatic. Thin adapters in that package bind a `*sql.DB` / `*pgxpool.Pool` to the package-level store functions.
 
@@ -130,6 +156,8 @@ Both stores must name these types, so they cannot live in `tempestapi` (storage 
 
 `Gap` carries `SerialNumber`, `From`, `To`, using `time.Time` as the canonical representation.
 
+**The interval is CLOSED `[From, To]`, not half-open.** Every producer emits endpoints that are rows which already exist — `prev`/`next` from `LAG`, `First`/`Last` from `SeriesBounds` — so both ends are re-fetched and re-offered to the store. `ON CONFLICT DO NOTHING` absorbs the duplicates, so this is harmless to correctness, but it must be documented as closed: labelling it `[From, To)` would be a lie, and it explains why `Requested` slightly exceeds the number of genuinely missing observations. Adjacent chunk windows likewise share an endpoint, for the same reason and with the same absorption.
+
 #### Accepted duplication (DRY, explicit)
 
 This adds a **fourth** in-tree representation of an observation row (`tempestudp.TempestObservationReport`, `sqlite`'s private `observationRow`, `postgres`'s private `observationRow`, now `weather.Observation`). That is accepted, and the reason is recorded so it is not "cleaned up" later:
@@ -153,6 +181,10 @@ The API method returns **raw API fields only**. Wet bulb is derived at the store
 ### Field alignment
 
 REST `obs_st` indices 0–17 match the UDP layout exactly, so the existing `len(ob) >= N` guards apply unmodified. The REST array has 22 elements; indices 18–21 (local-day rain accumulation, Nearcast accumulations, precip analysis type) map to no existing column and are ignored deliberately.
+
+**"Unmodified" means graduated, not all-or-nothing.** The UDP path accepts a tuple at `len(ob) >= 13` and fills the tail conditionally (`>= 6`, `>= 14`, `>= 16`, `>= 17`, `>= 18` — `sqlite/writer.go:406-457`). A single hard `len(ob) < 18 → drop` is **not** the same rule: it discards a short tuple's core measurements entirely. Because every `weather.Observation` measurement is a `*float64`, honoring the graduated guards is free — absent indices simply stay nil.
+
+**Dropped tuples must be counted and logged.** A tuple that *is* rejected (below the floor, or a null `ob[0]` that cannot be keyed) must increment a counter surfaced in the run summary. Otherwise a window whose tuples were all malformed reports `requested=0, inserted=0` — byte-identical to the permanent-hole signal, which is the one machine-readable diagnostic the whole reporting design rests on.
 
 ## Gap detection
 
@@ -259,8 +291,27 @@ func (e *StatusError) Error() string
 ```
 
 - Classification uses **`errors.As`** — **not `errors.AsType`**, which is Go 1.26 and `go.mod` declares `go 1.25.0`.
-- Retryable: `HTTPStatus == 429`, `HTTPStatus >= 500`, or a network error (`net.Error`, `context.DeadlineExceeded` on a single attempt). A non-zero `StatusCode` is **not** retryable — it is a real API-level failure.
+- Retryable: `HTTPStatus == 429`, `HTTPStatus >= 500`, or a network error (`net.Error`). A non-zero `StatusCode` is **not** retryable — it is a real API-level failure.
 - Per-gap failures accumulate with **`errors.Join`**; the joined error drives the non-zero exit.
+
+#### The per-attempt-timeout trap — mandatory
+
+`http.Client.Timeout` is **implemented as a context deadline**. The client sets a 30s timeout (`client.go:42`), and the `*url.Error` it produces satisfies **both** `errors.Is(err, context.DeadlineExceeded)` **and** `errors.As(err, &netErr)`:
+
+```
+Get "...": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+errors.Is(err, context.DeadlineExceeded) = true
+errors.As(err, &net.Error)              = true
+```
+
+So a classifier that opens with a blanket `if errors.Is(err, context.DeadlineExceeded) { return false }` guard marks **every per-attempt HTTP timeout as non-retryable**, and the `net.Error` branch is never reached. One slow WeatherFlow response then fails an entire gap on the first try with zero retries — the single most likely transient failure in a tool issuing thousands of sequential requests.
+
+**Therefore:**
+
+- Only **`context.Canceled`** is a blanket non-retryable signal.
+- A deadline error is fatal only when the **parent** context is actually done — check `ctx.Err() != nil` at the call site, not the error's identity.
+- A per-attempt timeout falls through to the `net.Error` branch and **is** retried.
+- The regression test must be built from a **real** `*url.Error` (an `httptest.Server` that stalls, plus a short-timeout client), not a synthetic `net.Error` fake. A fake cannot reproduce the dual-predicate error that causes the bug, so a test using one will pass against the broken classifier.
 
 ### Retry
 
@@ -305,9 +356,24 @@ Dedupe, gap closure, and convergence all require that the serial written by back
 
 **Pre-flight check — hard stop, not a warning.** Compare `ListStations` serials against `SELECT DISTINCT serial_number FROM tempest_observations`. On mismatch, log the offending serials and **exit non-zero having written nothing.** Warning-then-writing-anyway was the earlier spec and is incoherent: it names an outcome as corrupting and then produces it. The check only earns its place if it prevents the damage.
 
-Mismatch means "some API serial is absent from a **non-empty** store." An **empty** store is not a mismatch — it is the first-run case, and every gap is legitimately new.
+**Mismatch means the two serial sets are DISJOINT on a non-empty store** — no API serial appears in the store at all. That is the actual signature of format divergence, and it is the only condition that stops the run. The comparison uses `DistinctSerials` (whole table, unwindowed), never `SeriesBounds`.
 
-**Multiple `ST` devices:** `client.go:110-115` has no `break`, so the last device silently wins. Backfill must not inherit that. It iterates **all** `ST` devices returned by `ListStations` and backfills each independently, keyed by its own serial. (Fixing the loop in `ListStations` itself is out of scope — `ModeAPIExport` depends on current behavior.)
+The tempting-but-wrong rule is "*some* API serial is absent from a non-empty store." Two ordinary, non-corrupt situations satisfy it, and both would brick the tool:
+
+- **A second station the UDP listener never hears** (different VLAN or subnet). Its serial will *never* enter the store, so backfill would refuse to run — including for the healthy station.
+- **A newly added station.** Its first backfill would exit non-zero having written nothing, permanently, until the daemon happened to ingest a row from it.
+
+Neither is serial-format divergence. Under the disjoint rule both proceed normally, and a serial the API knows but the store has not yet seen simply yields a whole-range gap — which is exactly what the head/tail/empty detection domain is for.
+
+An **empty** store is likewise not a mismatch: it is the first-run case, and every gap is legitimately new.
+
+**Multiple `ST` devices — resolved by a new device-level lookup.** `client.go:110-115` has no `break`, so within one station the last `ST` device silently wins, and `ListStations` returns one already-collapsed `Station` per station. Backfill therefore **cannot** "iterate all `ST` devices returned by `ListStations`" — an earlier revision of this design said exactly that, and it is unimplementable: there is nothing to iterate.
+
+The consequence of inheriting the behavior is silent data loss. With two Tempest units on one station the UDP listener records both serials, but backfill only ever learns the last one; the other unit's gaps never close, and nothing is logged. It also evades the pre-flight check, which tests API⊄store, whereas this is the store⊄API direction.
+
+**Decision:** add `tempestapi.ListDevices`, returning **one entry per `ST` device** across all stations, and have backfill enumerate that. `ListStations` is left untouched — `ModeAPIExport` depends on its current behavior, and fixing its missing `break` remains a non-goal.
+
+> **Scope note (No-Wall, explicitly authorized).** The maintainer runs a single Tempest, so by the seam test this serves no present consumer and would normally be deferred. The seam test was **explicitly overridden for this feature only**, on the grounds that the tool is published and a multi-sensor user is a plausible request. Recorded so the exception stays visible and does not become precedent.
 
 ## The permanent-hole problem
 
@@ -331,7 +397,10 @@ Parsed from a `backfill`-owned `flag.FlagSet` over `os.Args[2:]`.
 |---|---|---|
 | `--from`, `--to` | unset (auto-detect) | **RFC3339, interpreted UTC.** The store is UTC epoch and the API takes epoch seconds; an ambiguous local-time parse is a quiet wrong-window bug. |
 | `--min-gap` | `30m` | |
-| `--dry-run` | false | Gap detection + plan only: **zero** API calls, **zero** writes. Consequently it cannot validate the token or reachability. |
+| `--dry-run` | false | Gap detection + plan only: **zero observation fetches**, **zero** writes. It still calls the device lookup (one API call), so it *does* validate the token and reachability. |
+| `--store` | unset | `sqlite` or `postgres`. **Required** when the environment selects more than one store; optional (and validated against the selection) otherwise. |
+
+**Why `--store` exists.** `selectStore` (`main.go:147-154`) returns *both* stores when `ENABLE_POSTGRES=true` **and** `SQLITE_PATH` is set — a documented fan-out the daemon honors by writing every observation to both. Backfill repairs one store per run, so with both configured it cannot infer the target. It must **never** guess: silently repairing Postgres while leaving the SQLite database (the one Litestream replicates to S3) still holed, and then reporting success, is the worst available outcome. Absent `--store` in that configuration, backfill exits `2` naming both candidates.
 
 **Why `--from/--to` exists** (restated — the earlier "avoids a full scan" rationale does not hold; `idx_obs_serial_time` already covers the detection query): it **bounds the API work**. Because permanent holes are accepted and never recorded, auto-detect re-requests every known-empty window on every run. An operator repairing a known outage can name it directly and skip that cost.
 
@@ -339,7 +408,9 @@ Parsed from a `backfill`-owned `flag.FlagSet` over `os.Args[2:]`.
 
 A failed gap logs and continues; per-gap errors accumulate via `errors.Join` and the process exits **non-zero** if any gap failed. Context cancellation is honored between windows and retries, leaving inserted rows intact — idempotency makes re-running safe. Backfill must **never** `log.Fatalf` mid-run: partial progress must be preserved and reported.
 
-Exit codes: `0` success (including permanent holes), `1` one or more gaps failed, `2` usage error.
+**A failed *window* must not abandon its gap.** "Continue on failure" applies at the window level too, not only between gaps. Returning from a gap on its first bad window discards every remaining window in that gap, and for a *deterministic* per-window failure the loss is **permanent across runs**, not transient: once the earlier windows land, the head gap collapses and the hole reappears as an interior gap starting at the same bad window, which fails again — so the windows behind it are never requested on any run. A tool whose entire premise is convergence would silently stop converging, and the `inserted=0` signal never fires because those windows are never even requested. Accumulate window errors with `errors.Join`, keep going, and fail the gap at the end.
+
+Exit codes: `0` success (including permanent holes, and `--help`), `1` one or more gaps failed or a runtime error, `2` usage error. **`flag.ErrHelp` is not a usage error** — `backfill --help` must exit `0`, or every CI smoke test that runs `cmd --help` fails.
 
 ## Testing
 
@@ -353,12 +424,22 @@ Every row below is written **test-first**; the entry-point split above is what m
 | Chunking | Multi-day range → N single-day requests. |
 | Empty window | One table-driven test, three cases, all → zero rows + no error: `obs` empty, `obs` null/absent, status-only envelope with no `type`. |
 | Error taxonomy | 429/503/network → retried; non-zero `status_code` → not retried, surfaces as `*StatusError` via `errors.As`. |
+| **Per-attempt timeout** | A **real** `*url.Error` from a stalled `httptest.Server` + short-timeout client → **retried**. A synthetic `net.Error` fake does not reproduce the dual-predicate error and would pass against the broken classifier. |
+| **Window failure isolation** | Three windows in one gap, the middle one permanently failing → windows 1 and 3 both inserted, gap still reported failed. |
 | Idempotency | Insert twice; second inserts 0, changes nothing. |
-| Dry-run | Zero writes, zero API calls. |
-| Serial pre-flight | Mismatched serials → non-zero exit, **zero rows written**. Empty store → not a mismatch. |
-| Dispatch | Unknown subcommand → usage, exit 2, **daemon not started**. |
+| Dry-run | Zero writes, zero **observation fetches**. |
+| Serial pre-flight | **Disjoint** sets on a non-empty store → non-zero exit, **zero rows written**. Empty store → not a mismatch. A *new* serial alongside a known one → **not** a mismatch; it yields a whole-range gap. A known serial with no rows *in the requested window* → **not** a mismatch. |
+| **Short tuples** | `len(ob) == 13` → row inserted with the tail columns NULL, not dropped. Rejected tuples increment the reported drop counter. |
+| **Store selection** | Both stores configured without `--store` → exit 2, nothing written. `--store` naming an unconfigured store → exit 2. |
+| Dispatch | Unknown subcommand → usage, exit 2, **daemon not started**. Asserted by re-exec, not by testing the predicate in isolation. |
+| **`--help`** | Exits **0**, not 2. |
+| Multi-device | A station reporting two `ST` devices → `ListDevices` returns two entries; both are backfilled. |
 
 Repo idiom applies: `t.Context()`, `t.TempDir()`, stdlib table-driven, no testify.
+
+**Tests that can only fail at compile time or by string match** (a struct-literal field-name assertion, a `strings.Contains` on a SQL constant) do **not** count toward the rows above. They assert the language spec or restate the file they live in; the behavior needs a test that can fail at runtime for the reason the row names.
+
+**The Postgres path ships unverified unless an integration test runs.** Its SQL differs materially from SQLite's — `EXTRACT(EPOCH FROM (ts - prev)) > $3` compares a `numeric` against a `float64` parameter, and `precip_type` is `INTEGER` while the bind is a `*float64` (pgx truncates silently). A skip-guarded integration test following `writer_integration_test.go`'s existing idiom must seed the same two-serial interleaved fixture the SQLite test uses, and it must be run at least once against a real database before the branch merges.
 
 ## Documentation owned by this design
 
@@ -367,7 +448,8 @@ Repo idiom applies: `t.Context()`, `t.TempDir()`, stdlib table-driven, no testif
 - **Name collision:** `CLAUDE.md:239` already has a section "**API Export with Backfill**" describing the *existing* `TOKEN`-triggered `ModeAPIExport`. Rename it (e.g. "API Export Mode") and add a distinct section for the `backfill` subcommand, so the two are not conflated.
 - `CLAUDE.md:78` describes `internal/tempestudp` as UDP parsing — accurate, and now protected by moving `Observation`/`Gap` to `internal/weather`. Add `internal/weather` to the package list.
 - The **operational-modes table** assumes mode is chosen by env vars; a subcommand bypasses that. Add a line stating that `backfill` and `healthcheck` short-circuit mode selection entirely.
-- Document the new flags and exit codes.
+- Document the new flags and exit codes — including `--store` (when it is required and why backfill refuses to guess), and the accurate `--dry-run` semantics (zero *observation fetches*, but one device-lookup call, so it *does* validate the token).
+- State the multi-sensor behavior: `backfill` enumerates every `ST` device via `ListDevices`, unlike `TOKEN`-mode export, which sees one device per station.
 
 Out of scope but noted: `CLAUDE.md` is broadly stale elsewhere (no SQLite-default/OTel/httpserver/radar coverage; still says "Go 1.23.0+" against a 1.25 floor). Not this design's job to fix — flagged for a separate docs pass.
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -443,7 +443,18 @@ Repo idiom applies: `t.Context()`, `t.TempDir()`, stdlib table-driven, no testif
 
 **Tests that can only fail at compile time or by string match** (a struct-literal field-name assertion, a `strings.Contains` on a SQL constant) do **not** count toward the rows above. They assert the language spec or restate the file they live in; the behavior needs a test that can fail at runtime for the reason the row names.
 
-**The Postgres path ships unverified unless an integration test runs.** Its SQL differs materially from SQLite's — `EXTRACT(EPOCH FROM (ts - prev)) > $3` compares a `numeric` against a `float64` parameter, and `precip_type` is `INTEGER` while the bind is a `*float64` (pgx truncates silently). A skip-guarded integration test following `writer_integration_test.go`'s existing idiom must seed the same two-serial interleaved fixture the SQLite test uses, and it must be run at least once against a real database before the branch merges.
+### Postgres path — verified by execution 2026-07-29
+
+The Postgres SQL was executed against a real **PostgreSQL 16** container (pgx v5, `CGO_ENABLED=0`) before implementation, using the plan's own integration test. Results, so they are not re-derived:
+
+- `EXTRACT(EPOCH FROM (ts - prev)) > $3` with a Go `float64` bind **works**; the partitioned `LAG` finds the masked hole.
+- `ON CONFLICT (serial_number, timestamp) DO NOTHING` returns `RowsAffected` 1 on insert and **0** on conflict, so the inserted count is real on this store too.
+- `MIN/MAX(timestamptz)` scan into `time.Time` cleanly.
+- **`*float64` → `INTEGER` column: pgx truncates toward zero, silently, with no error.** Measured: `2.0→2`, `2.4→2`, `2.6→2`, `-1.5→-1`. This is benign for the four affected columns (`precip_type`, `wind_sample_interval`, `lightning_strike_count`, `report_interval`) because the Tempest API supplies integral values there — but it is a silent lossy conversion, so do **not** widen this pattern to a column where a fractional value is meaningful.
+
+The test was also **mutation-checked**: removing `PARTITION BY serial_number` makes it fail (`did not find the ST-ITEST-A hole ... got []`), as does corrupting the INTEGER round-trip assertion. It is not a test that passes by construction.
+
+It remains **skip-guarded on `POSTGRES_URL`**, so a CI run without a database proves nothing about this path. Re-run it against a real database after any change to the Postgres SQL.
 
 ## Documentation owned by this design
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -1,7 +1,7 @@
 # API Backfill Tool — Design
 
-**Date:** 2026-07-28 (revised 2026-07-29 after senior-Go-engineer review)
-**Status:** Approved, revised
+**Date:** 2026-07-28 (revised 2026-07-29 after two senior-Go-engineer reviews)
+**Status:** Approved, revised — plan-ready
 **Related:** #80 is a sibling *tool*, not a shared abstraction — no coupling between them.
 
 ## Problem
@@ -16,8 +16,8 @@ A `backfill` subcommand that finds holes in the local observation history and fi
 
 | Decision | Choice | Why |
 |---|---|---|
-| What to backfill | Auto-detect gaps, with `--from`/`--to` override | Should need no input in the common case; the override covers a known window without a full scan. |
-| How data reaches the store | Dedicated typed API→row path | See "Why not reuse an existing write path" below — the reasoning is **not** simply that `WriteMetrics` is a no-op. |
+| What to backfill | Auto-detect gaps, with `--from`/`--to` override | Should need no input in the common case. |
+| How data reaches the store | Dedicated typed API→row path | See "Why not reuse an existing write path" — the reasoning is **not** simply that `WriteMetrics` is a no-op. |
 | Invocation | Subcommand on the existing binary | `main.go:189` already dispatches `os.Args[1] == "healthcheck"`. Additive, no packaging change; #80's `migrate` slots in the same way. |
 
 ### Why not reuse an existing write path
@@ -38,19 +38,103 @@ Three candidates exist. All are rejected, for distinct reasons that must be reco
 
 **Also out:** changing `ModeAPIExport` or `sqlite.WriteMetrics`.
 
+## Prerequisite API additions
+
+Two APIs the design depends on **do not exist in the tree**. They are in scope for this work and must be built before the code that consumes them.
+
+### 1. Station serial accessor — `internal/tempestapi`
+
+`Station.serialNumber` and `Station.deviceID` are **unexported** (`internal/tempestapi/client.go:55-56`), so the serial pre-flight check cannot read a serial from outside the package.
+
+**Decision: export the fields** (`SerialNumber`, `DeviceID`) rather than add accessor methods. `Station` is already a plain data struct with three exported fields and no invariants to protect; adding two getters for a value type would be ceremony (KISS). Update the four construction/read sites inside the package.
+
+### 2. Pool constructor — `internal/postgres`
+
+There is **no way to obtain a `*pgxpool.Pool`**. `NewPostgresWriter` is the only constructor (`writer.go:144`), and it also pings, runs `CreateSchema`, and starts **four** background goroutines (`writer.go:190-199`) — all of which this design forbids for a one-shot tool.
+
+**Decision:** add
+
+```go
+func OpenPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error)
+```
+
+holding the pool contract (`MaxConns=10`, `MinConns=2`, `MaxConnLifetime=time.Hour`, `MaxConnIdleTime=10m`, `HealthCheckPeriod=30s`) and the ping. `NewPostgresWriter` is refactored to **call it**, so the tuning lives in exactly one place rather than being copied out of `writer.go:151-155`. This is DRY on a genuine shared contract: change a pool setting and both callers must change together.
+
+`OpenPool` does **not** run `CreateSchema` — backfill calls `CreateSchema` explicitly, so schema creation stays an observable step of the caller rather than a side effect of opening a pool.
+
+## Entry point and testability
+
+The subcommand is split into a **shell** and a **testable core**. A single `runBackfill(ctx) int` that reads flags, `TOKEN`, store config, and `time.Now()` internally cannot be driven from a test, which would make the mandated dry-run, head/tail/empty-domain, and serial pre-flight tests unwritable — a direct conflict with TDD.
+
+```go
+// Shell: parses os.Args[2:], reads env, opens handles, wires deps, returns an
+// exit code. Thin enough to need no unit test of its own.
+func runBackfill(ctx context.Context, args []string) int
+
+// Core: no env, no clock, no I/O construction. Fully testable.
+func backfill(
+    ctx   context.Context,
+    cfg   backfillConfig,
+    client observationSource,
+    store  backfillStore,
+    now   time.Time,
+) (backfillStats, error)
+```
+
+- **`now` is injected.** Nothing below the shell calls `time.Now()`. `detectTo = now - minGap` is then deterministic in tests.
+- **`backfillStore` is the one earned interface** — two concrete implementors exist on day one (SQLite and Postgres), so it is not speculative:
+
+  ```go
+  type backfillStore interface {
+      FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+      InsertObservations(ctx context.Context, obs []weather.Observation) (inserted int, err error)
+      DistinctSerials(ctx context.Context) ([]string, error)
+  }
+  ```
+
+  Defined in the **consumer** package (`internal/backfill`), Go-idiomatic. Thin adapters in that package bind a `*sql.DB` / `*pgxpool.Pool` to the package-level store functions.
+
+- **`observationSource`** is a one-method consumer-side interface over the API client, so the core tests need no HTTP at all. (`tempestapi.WithBaseURL`, `client.go:35-39`, remains available for tests that *do* want to exercise the real decode path against an `httptest.Server`.)
+
+### Subcommand dispatch
+
+Today `main()` matches only `healthcheck` and **falls through to daemon mode** for anything else — so `tempestwx-utilities backfil` (typo) silently starts a UDP listener.
+
+**Decision:**
+
+- `main` matches `os.Args[1]` against a known set: `healthcheck`, `backfill`.
+- Any **other non-flag** first argument prints usage to stderr and exits **2**. No silent fallthrough.
+- **Each subcommand owns its own `flag.FlagSet`, parsed from `os.Args[2:]`.** This — not an abstraction — is the No-Wall seam #80's `migrate` slots into: a new subcommand is a new file plus one dispatch line, and no sibling is edited.
+
+**Standards divergence (recorded, not resolved):** `go-standards` §6 says "all CLIs use Cobra" with `cmd/<binary>/main.go`. This project uses a hand-rolled `os.Args[1]` dispatch with a `main.go` at the root. We keep the established pattern: adding Cobra for two subcommands would be a dependency and a framework where a `switch` suffices (KISS), and the standard defers to established project patterns. Noted so the divergence is deliberate rather than overlooked.
+
 ## Data model
 
 ### `Observation` and `Gap` ownership
 
-Both stores must name these types, so they cannot live in `tempestapi` (storage would depend on the REST client). They also must not collide with the existing `sqlite.Observation` read-model (`internal/sqlite/writer.go:712`).
+Both stores must name these types, so they cannot live in `tempestapi` (storage would depend on the REST client). They must not collide with the existing `sqlite.Observation` read-model (`internal/sqlite/writer.go:712`).
 
-**Decision:** they live in **`internal/tempestudp`** — the neutral package both stores already import. Each store converts to its own private `observationRow` at its boundary (SQLite's timestamp is `int64`, Postgres's is `time.Time`; their pointer types differ).
+**Decision:** a new leaf package **`internal/weather`** owns `Observation` and `Gap`.
+
+`internal/tempestudp` — the earlier choice — is **wrong**: that package is the UDP wire protocol (`CLAUDE.md:78`), and `tempestudp.Gap` reads as "a gap in UDP," which is false. The original justification was import convenience, not cohesion.
+
+`Gap` must live in `internal/weather` **with** `Observation`, not in `internal/backfill` as first proposed: `FindObservationGaps` is a package-level function in `internal/sqlite` and `internal/postgres`, so putting `Gap` in the consumer would force the store packages to import `internal/backfill` — an inverted dependency — or duplicate the type.
+
+`internal/weather` imports nothing from this repo. `tempestapi`, `sqlite`, `postgres`, and `backfill` all import it; no cycles.
 
 `Gap` carries `SerialNumber`, `From`, `To`, using `time.Time` as the canonical representation.
 
+#### Accepted duplication (DRY, explicit)
+
+This adds a **fourth** in-tree representation of an observation row (`tempestudp.TempestObservationReport`, `sqlite`'s private `observationRow`, `postgres`'s private `observationRow`, now `weather.Observation`). That is accepted, and the reason is recorded so it is not "cleaned up" later:
+
+The store row types are **not** interchangeable — SQLite's timestamp is `int64` epoch and Postgres's is `time.Time`, and their nullable numeric pointer types differ. Unifying them would mean an abstraction over two genuinely different storage encodings, i.e. the wrong abstraction.
+
+**The cost is real and stated:** adding an observation column touches ~4 sites plus the migration. That is the accepted price; the alternative (a generic row abstraction) is worse. **Do not extract one.**
+
 ### Nullability — mandatory
 
-`GetObservationRows` **must** decode the `obs` array as `[][]*float64` (or `[]json.RawMessage`), mapping JSON `null` → nil pointer → SQL NULL.
+The API decode **must** unmarshal the `obs` array as **`[][]*float64`**, mapping JSON `null` → nil pointer → SQL NULL. (The `[]json.RawMessage` alternative floated earlier is dropped — one rule, no fork.)
 
 It **must not** reuse `tempestudp.TempestObservationReport`, whose `Obs` is `[][]float64` (`internal/tempestudp/report.go:135`): unmarshalling `null` into a non-pointer numeric is a silent no-op that yields `0.0`. That would write `battery = 0.0 V`, `pressure = 0.0 mb` where the API said "unknown" — physically meaningful values that `SummarizeObservations`' `MIN(pressure)` and every chart read as real. Backfill operates precisely on marginal windows, where nulls are most likely.
 
@@ -58,7 +142,7 @@ It **must not** reuse `tempestudp.TempestObservationReport`, whose `Obs` is `[][
 
 `temp_wetbulb` is **not** returned by the API — it is computed in Go at ingest from `ob[7]/ob[8]/ob[6]` with a NaN→NULL guard (`internal/sqlite/writer.go:410,432-434`).
 
-`GetObservationRows` returns **raw API fields only**. Wet bulb is derived at the store boundary using the same `tempestudp.WetBulbTemperatureC` + `math.IsNaN` guard the ingest path uses, single-sourced — so backfilled and live rows are indistinguishable. (Change the formula and all call sites change together: shared knowledge, not shared shape.)
+The API method returns **raw API fields only**. Wet bulb is derived at the store boundary using the same `tempestudp.WetBulbTemperatureC` + `math.IsNaN` guard the ingest path uses, single-sourced — so backfilled and live rows are indistinguishable. (Change the formula and all call sites change together: shared knowledge, not shared shape.)
 
 ### Field alignment
 
@@ -94,18 +178,45 @@ SELECT serial_number, prev, ts FROM (
 
 **Required test:** two serials whose interleaved timestamps mask each other.
 
+### Signatures — pinned
+
+Both stores expose the **same** signature in `time.Time`, so the interface above is satisfiable without a shim:
+
+```go
+// internal/sqlite   — converts time.Time ↔ int64 epoch internally
+func FindObservationGaps(ctx context.Context, db *sql.DB, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+// internal/postgres — passes time.Time through
+func FindObservationGaps(ctx context.Context, pool *pgxpool.Pool, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+```
+
+The epoch conversion stays at the SQLite boundary, matching how that package already handles timestamps.
+
+### SQLite connection limit — must not stream
+
+`sqlite.Open` sets `db.SetMaxOpenConns(1)` (`internal/sqlite/db.go:73`) — a single writer connection, by design.
+
+**Therefore `FindObservationGaps` must fully materialize its `[]weather.Gap` and close its `*sql.Rows` before any insert runs.** The specification above already does this. A "nicer" streaming iterator that yielded gaps while the caller inserted would **deadlock on the single connection with no error and no timeout** — it would simply hang. This constraint is load-bearing; do not refactor it away.
+
 ### Detection domain — head, tail, and empty
 
 `LAG` yields NULL for the first row of each partition, so it finds **interior gaps only**. Left there, a fresh/empty store reports "no gaps" and writes nothing, and the natural "the box was down, repair it" case — whose outage is entirely in the tail — is invisible.
 
 The detection domain is explicit:
 
-- `detectTo` defaults to `now - minGap`.
+- `detectTo` defaults to `now - minGap` (`now` injected, see entry point).
 - `detectFrom` defaults to the station's `created_epoch` from `ListStations` (`internal/tempestapi/client.go:123`).
 - Gaps are the union of: `[detectFrom, first_row]`, the interior `LAG` gaps, and `[last_row, detectTo]`.
 - **Empty table:** the whole `[detectFrom, detectTo]` range is one gap. This is a first-class case, not an edge case.
 
 ## Fetch and insert
+
+### API method
+
+```go
+func (c *Client) Observations(ctx context.Context, station Station, start, end time.Time) ([]weather.Observation, error)
+```
+
+Named `Observations`, not `GetObservationRows`: Go getters take no `Get` prefix, and "Rows" is storage vocabulary that does not belong in a REST client. It sits alongside the existing `GetObservations` (which returns `[]prometheus.Metric` for `ModeAPIExport` and is untouched).
 
 ### Chunking
 
@@ -115,25 +226,49 @@ All fetches — auto-detected **and** `--from/--to` — go through the chunker. 
 
 ### Empty-window handling
 
-`GetObservationRows` must check `status.status_code` (as `ListStations` does, `client.go:102-104`; `GetObservations` currently does not), distinguish "no data" from a real error, treat an absent/null `obs` array as **zero rows, not an error**, and must **not** route through `tempestudp.ParseReport`, whose type dispatch errors with `unhandled message type: ""` on a `status`-only envelope.
+`Observations` must check `status.status_code` (as `ListStations` does, `client.go:102-104`; `GetObservations` currently does not), distinguish "no data" from a real error, treat an absent/null `obs` array as **zero rows, not an error**, and must **not** route through `tempestudp.ParseReport`, whose type dispatch errors with `unhandled message type: ""` on a `status`-only envelope.
 
 **Resolved from the published OpenAPI spec** ([swagger.json](https://weatherflow.github.io/Tempest/api/swagger/swagger.json)), which settles this without a token:
 
 - The `ObservationSet` response includes a `status` object → `status_code` (`integer/int32`, example `0`) and `status_message` (`string`, example `"SUCCESS"`). So `status_code == 0` is the success signal, and checking it is correct.
-- **`ObservationSet` declares no `required` array.** Neither `type` nor `obs` is required, so a response omitting either is schema-legal. This confirms the hazard directly: routing through `tempestudp.ParseReport` — which dispatches on a top-level `type` and errors `unhandled message type: ""` when absent — would turn a legitimate empty window into a hard error.
+- **`ObservationSet` declares no `required` array.** Neither `type` nor `obs` is required, so a response omitting either is schema-legal. This confirms the hazard directly.
 - Reported in the field: `status_code` 0 with `status_message` `"SUCCESS - Either no capabilities or no recent observations"` and an empty/absent `obs` ([Tempest community](https://community.tempest.earth/t/getting-station-data/17879)).
 
 **Therefore, treat as normative:** `status_code == 0` is success; an absent, `null`, or empty `obs` is **zero rows, not an error**; an absent `type` is **not** an error. A non-zero `status_code` is a real failure carrying `status_message`.
 
-*Remaining (non-blocking) verification:* pin a real empty-window body as a fixture when a token is available, to confirm the exact serialization. The design no longer depends on that answer — the schema establishes that both fields are optional, which is the property the handling must be robust to either way.
+*Remaining (non-blocking) verification:* pin a real empty-window body as a fixture when a token is available. The design no longer depends on that answer.
+
+### Error taxonomy
+
+Three behaviors branch on the *kind* of error — retry on 429/5xx/network, treat non-zero `status_code` as a real failure, exit non-zero if any gap failed. Without a typed error, the retry layer could only string-match.
+
+```go
+// internal/tempestapi
+type StatusError struct {
+    HTTPStatus int    // 0 when the failure is an API-level status_code
+    StatusCode int    // WeatherFlow status.status_code; 0 when purely HTTP
+    Message    string // status.status_message
+}
+func (e *StatusError) Error() string
+```
+
+- Classification uses **`errors.As`** — **not `errors.AsType`**, which is Go 1.26 and `go.mod` declares `go 1.25.0`.
+- Retryable: `HTTPStatus == 429`, `HTTPStatus >= 500`, or a network error (`net.Error`, `context.DeadlineExceeded` on a single attempt). A non-zero `StatusCode` is **not** retryable — it is a real API-level failure.
+- Per-gap failures accumulate with **`errors.Join`**; the joined error drives the non-zero exit.
 
 ### Retry
 
-Bounded exponential backoff on 429/5xx/network errors, honoring `Retry-After` when present, plus a small inter-request delay. A gap is marked failed only after retries are exhausted. Context cancellation is checked between windows **and** between retry attempts. WeatherFlow publishes no rate limits, which argues for conservatism rather than for ignoring the question.
+Bounded exponential backoff on retryable errors. A gap is marked failed only after retries are exhausted. Context cancellation is checked between windows **and** between retry attempts.
+
+**Cut:** `Retry-After` parsing and the fixed inter-request delay. WeatherFlow publishes no rate limits, so both were guesses at a constraint we cannot see; bounded backoff already handles 429 correctly. Add either if a real 429 is ever observed (YAGNI — no present consumer).
 
 ### Insert
 
-`InsertObservations(ctx, db, rows) (inserted int, err error)` — `ON CONFLICT (serial_number, timestamp) DO NOTHING`, matching both existing insert paths (`internal/sqlite/writer.go:631`, `internal/postgres/writer.go:255`).
+```go
+func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observation) (inserted int, err error)
+```
+
+`ON CONFLICT (serial_number, timestamp) DO NOTHING`, matching both existing insert paths (`internal/sqlite/writer.go:631`, `internal/postgres/writer.go:255`).
 
 The inserted count is obtainable on both stores and is the mechanism that makes the permanent-hole tradeoff visible: SQLite's per-row `stmt.ExecContext` returns `RowsAffected` 0 for a skipped conflict and 1 for an insert; Postgres's `br.Exec()` returns a `pgconn.CommandTag` with the same semantics (currently discarded at `internal/postgres/writer.go:268`). Both need a signature change, neither a semantics change.
 
@@ -151,28 +286,40 @@ The realistic invocation is `docker exec <running container> tempestwx-utilities
 
 ## Lifecycle
 
-- `runBackfill(ctx) int` performs **all** cleanup via internal defers and returns an exit code; the dispatch site does `os.Exit(runBackfill(ctx))`. Copying the healthcheck shape (`os.Exit` at the dispatch site with no cleanup, `main.go:189-191`) would skip `db.Close()` and the pgx pool drain.
+- `runBackfill(ctx, args) int` performs **all** cleanup via internal defers and returns an exit code; the dispatch site does `os.Exit(runBackfill(ctx, os.Args[2:]))`. Copying the healthcheck shape (`os.Exit` at the dispatch site with no cleanup, `main.go:189-191`) would skip `db.Close()` and the pgx pool drain.
 - Signal context (SIGINT/SIGTERM) is wired in the subcommand; the healthcheck path has none to inherit.
+- **Missing `TOKEN` fails fast** — validated in the shell *before* any store handle is opened, so the failure costs no I/O and leaves nothing to close.
 - Store selection reuses `selectStore` (`main.go:147-154`), which is genuinely pure — no I/O, no goroutines, no globals. Everything *downstream* of it is currently inline in `main()` (`main.go:256-336`) and entangled with HTTP-server and sink teardown; backfill constructs its own handles rather than reusing that block.
 - Backfill opens the **write** handle (it must migrate and insert). `OpenReadOnly` is not used: it fails when the file does not exist and cannot migrate, and its ingest-contention rationale does not apply to a separate one-shot process.
+- **Logging: `log/slog` for all new code.** Structured attrs are also what makes progress machine-readable (see below). The existing `log.Printf` call sites are untouched.
 
 ## Serial-number invariant
 
 Dedupe, gap closure, and convergence all require that the serial written by backfill exactly matches the serial written by UDP ingest. Backfill's comes from `ListStations` (`client.go:110-115`), ingest's from the broadcast field. If they ever diverge, backfill writes a **parallel series under a second serial**, `UNIQUE` never fires, rows double, and the gap never closes — silently and cumulatively.
 
-**Pre-flight check:** compare `ListStations` serials against `SELECT DISTINCT serial_number FROM tempest_observations` and warn on mismatch. Also note `client.go:110-115` has no `break`, so with multiple `ST` devices the last silently wins — backfill must handle multiple devices explicitly rather than inherit that.
+**Pre-flight check — hard stop, not a warning.** Compare `ListStations` serials against `SELECT DISTINCT serial_number FROM tempest_observations`. On mismatch, log the offending serials and **exit non-zero having written nothing.** Warning-then-writing-anyway was the earlier spec and is incoherent: it names an outcome as corrupting and then produces it. The check only earns its place if it prevents the damage.
+
+Mismatch means "some API serial is absent from a **non-empty** store." An **empty** store is not a mismatch — it is the first-run case, and every gap is legitimately new.
+
+**Multiple `ST` devices:** `client.go:110-115` has no `break`, so the last device silently wins. Backfill must not inherit that. It iterates **all** `ST` devices returned by `ListStations` and backfills each independently, keyed by its own serial. (Fixing the loop in `ListStations` itself is out of scope — `ModeAPIExport` depends on current behavior.)
 
 ## The permanent-hole problem
 
 If the station was genuinely offline, the API has no data for that window either. Auto-detect rediscovers the same hole on every run and never converges.
 
-**Decision: accept it, and make it visible.** Report `requested N, inserted M` per gap, plus a machine-greppable summary line (`gaps=3 requested=4320 inserted=0`) so automation can detect non-convergence. Exit code stays 0 — a permanent hole is not an error.
+**Decision: accept it, and make it visible.** Log per gap with structured `slog` attrs — `serial`, `from`, `to`, `requested`, `inserted` — so automation can detect non-convergence (`inserted=0` across runs) directly from the log stream. Exit code stays 0: a permanent hole is not an error.
+
+**Cut:** the bespoke `gaps=3 requested=4320 inserted=0` summary line. It was a third output format with no present consumer, and `go-standards` §6.1 would want `--json` rather than an ad-hoc grammar. `slog` attrs already provide the machine-readable surface; if a caller later needs a single-line total, add `--json` then.
 
 Rejected: persisting a table of attempted windows. It adds schema and durable state to save only redundant API calls, and goes stale if the API later fills its own history.
 
-`--min-gap` (default 30m) keeps ordinary reporting jitter from registering. Stations configured with a long `report_interval` need a larger value.
+`--min-gap` (default 30m) keeps ordinary reporting jitter from registering.
+
+**Considered and rejected: deriving `--min-gap` from the stored `report_interval` column.** It is nullable (`migrations/0001_init.sql:12`, `*int64` in Go), so a fallback would be needed anyway; it varies per row; and the flag has a genuine present consumer — a station configured with a long report interval needs a larger value than the default. Keep the flag.
 
 ## Flags
+
+Parsed from a `backfill`-owned `flag.FlagSet` over `os.Args[2:]`.
 
 | Flag | Default | Notes |
 |---|---|---|
@@ -180,31 +327,54 @@ Rejected: persisting a table of attempted windows. It adds schema and durable st
 | `--min-gap` | `30m` | |
 | `--dry-run` | false | Gap detection + plan only: **zero** API calls, **zero** writes. Consequently it cannot validate the token or reachability. |
 
+**Why `--from/--to` exists** (restated — the earlier "avoids a full scan" rationale does not hold; `idx_obs_serial_time` already covers the detection query): it **bounds the API work**. Because permanent holes are accepted and never recorded, auto-detect re-requests every known-empty window on every run. An operator repairing a known outage can name it directly and skip that cost.
+
 ## Error handling
 
-A failed gap logs and continues; the process exits **non-zero** if any gap failed. Context cancellation is honored between windows and retries, leaving inserted rows intact — idempotency makes re-running safe. Backfill must **never** `log.Fatalf` mid-run: partial progress must be preserved and reported.
+A failed gap logs and continues; per-gap errors accumulate via `errors.Join` and the process exits **non-zero** if any gap failed. Context cancellation is honored between windows and retries, leaving inserted rows intact — idempotency makes re-running safe. Backfill must **never** `log.Fatalf` mid-run: partial progress must be preserved and reported.
+
+Exit codes: `0` success (including permanent holes), `1` one or more gaps failed, `2` usage error.
 
 ## Testing
+
+Every row below is written **test-first**; the entry-point split above is what makes that possible.
 
 | Area | Test |
 |---|---|
 | Nullability | Fixture with `null` obs elements → assert row pointer fields are **nil**, not zero. |
-| Gap detection — partitioning | **Two serials with interleaved timestamps that mask each other.** Regression test for C1. |
+| Gap detection — partitioning | **Two serials with interleaved timestamps that mask each other.** |
 | Gap detection — domain | Head gap, tail gap, empty table, no-gaps. |
 | Chunking | Multi-day range → N single-day requests. |
-| Empty window | Three fixtures, all → zero rows + no error: `obs` empty, `obs` null/absent, and a status-only envelope with no `type`. |
+| Empty window | One table-driven test, three cases, all → zero rows + no error: `obs` empty, `obs` null/absent, status-only envelope with no `type`. |
+| Error taxonomy | 429/503/network → retried; non-zero `status_code` → not retried, surfaces as `*StatusError` via `errors.As`. |
 | Idempotency | Insert twice; second inserts 0, changes nothing. |
 | Dry-run | Zero writes, zero API calls. |
-| Serial pre-flight | Mismatched serials → warning. |
+| Serial pre-flight | Mismatched serials → non-zero exit, **zero rows written**. Empty store → not a mismatch. |
+| Dispatch | Unknown subcommand → usage, exit 2, **daemon not started**. |
+
+Repo idiom applies: `t.Context()`, `t.TempDir()`, stdlib table-driven, no testify.
+
+## Documentation owned by this design
+
+`CLAUDE.md` must be updated as part of this work:
+
+- **Name collision:** `CLAUDE.md:239` already has a section "**API Export with Backfill**" describing the *existing* `TOKEN`-triggered `ModeAPIExport`. Rename it (e.g. "API Export Mode") and add a distinct section for the `backfill` subcommand, so the two are not conflated.
+- `CLAUDE.md:78` describes `internal/tempestudp` as UDP parsing — accurate, and now protected by moving `Observation`/`Gap` to `internal/weather`. Add `internal/weather` to the package list.
+- The **operational-modes table** assumes mode is chosen by env vars; a subcommand bypasses that. Add a line stating that `backfill` and `healthcheck` short-circuit mode selection entirely.
+- Document the new flags and exit codes.
+
+Out of scope but noted: `CLAUDE.md` is broadly stale elsewhere (no SQLite-default/OTel/httpserver/radar coverage; still says "Go 1.23.0+" against a 1.25 floor). Not this design's job to fix — flagged for a separate docs pass.
 
 ## Constraints
 
-- `CGO_ENABLED=0` stays buildable. `modernc.org/sqlite` bundles SQLite 3.46.0; `LAG(...) OVER (PARTITION BY ...)` verified working under it.
+- `CGO_ENABLED=0` stays buildable. `modernc.org/sqlite` bundles SQLite 3.46.0; `LAG(...) OVER (PARTITION BY ...)` verified working under it by execution.
+- Zero new dependencies.
 - Timestamps UTC epoch; PKs UUIDv7 generated in Go. Note UUIDv7 embeds *insert* time, so backfilled rows sort by `id` in insert order, not observation order — consistent with the ingest path, but `id` ordering must not be assumed chronological.
-- Go 1.25 floor, toolchain go1.26.1.
+- Go 1.25 floor, toolchain go1.26.1. **No Go 1.26-only APIs** (notably `errors.AsType`).
 
 ## Non-goals
 
 - Backfilling rapid wind, hub status, or events.
 - Modifying `ModeAPIExport` or `sqlite.WriteMetrics`.
+- Fixing the missing `break` in `ListStations`' device loop.
 - Implementing #80's `migrate` — this only establishes the dispatch pattern it slots into.

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -383,7 +383,7 @@ The consequence of inheriting the behavior is silent data loss. With two Tempest
 
 If the station was genuinely offline, the API has no data for that window either. Auto-detect rediscovers the same hole on every run and never converges.
 
-**Decision: accept it, and make it visible.** Log per gap with structured `slog` attrs — `serial`, `from`, `to`, `requested`, `inserted` — so automation can detect non-convergence (`inserted=0` across runs) directly from the log stream. Exit code stays 0: a permanent hole is not an error.
+**Decision: accept it, and make it visible.** Log per gap with structured `slog` attrs — `serial`, `from`, `to`, `returned`, `inserted` — so automation can detect non-convergence (`inserted=0` across runs) directly from the log stream. Exit code stays 0: a permanent hole is not an error.
 
 **Cut:** the bespoke `gaps=3 requested=4320 inserted=0` summary line. It was a third output format with no present consumer, and `go-standards` §6.1 would want `--json` rather than an ad-hoc grammar. `slog` attrs already provide the machine-readable surface; if a caller later needs a single-line total, add `--json` then.
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -86,14 +86,19 @@ The subcommand is split into a **shell** and a **testable core**. A single `runB
 func runBackfill(ctx context.Context, args []string) int
 
 // Core: no env, no clock, no I/O construction. Fully testable.
-func backfill(
-    ctx   context.Context,
-    cfg   backfillConfig,
-    client observationSource,
-    store  backfillStore,
-    now   time.Time,
-) (backfillStats, error)
+// Lives in internal/backfill and is EXPORTED — the shell is in package main
+// and cannot call an unexported function across the package boundary.
+func Run(
+    ctx      context.Context,
+    cfg      Config,
+    src      ObservationSource,
+    store    Store,
+    stations []tempestapi.Station,
+    now      time.Time,
+) (Stats, error)
 ```
+
+The `stations` parameter is required, not incidental: `Run` cannot resolve `detectFrom` (from each station's `CreatedAt`), run the serial pre-flight, or key any fetch without it. An earlier draft of this section omitted it and used unexported names throughout; both were wrong, and the implementation plan's Task 9 is authoritative on this signature.
 
 - **`now` is injected.** Nothing below the shell calls `time.Now()`. `detectTo = now - minGap` is then deterministic in tests.
 - **`backfillStore` is the one earned interface** — two concrete implementors exist on day one (SQLite and Postgres), so it is not speculative:
@@ -235,7 +240,7 @@ The epoch conversion stays at the SQLite boundary, matching how that package alr
 
 ### SQLite connection limit — must not stream
 
-`sqlite.Open` sets `db.SetMaxOpenConns(1)` (`internal/sqlite/db.go:73`) — a single writer connection, by design.
+`sqlite.Open` sets `db.SetMaxOpenConns(1)` (`internal/sqlite/db.go:74`) — a single writer connection, by design.
 
 **Therefore `FindObservationGaps` must fully materialize its `[]weather.Gap` and close its `*sql.Rows` before any insert runs.** The specification above already does this. A "nicer" streaming iterator that yielded gaps while the caller inserted would **deadlock on the single connection with no error and no timeout** — it would simply hang. This constraint is load-bearing; do not refactor it away.
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -117,7 +117,15 @@ All fetches — auto-detected **and** `--from/--to` — go through the chunker. 
 
 `GetObservationRows` must check `status.status_code` (as `ListStations` does, `client.go:102-104`; `GetObservations` currently does not), distinguish "no data" from a real error, treat an absent/null `obs` array as **zero rows, not an error**, and must **not** route through `tempestudp.ParseReport`, whose type dispatch errors with `unhandled message type: ""` on a `status`-only envelope.
 
-> **OPEN QUESTION (blocks planning of this component only):** the exact response shape for a window with no data is not determinable from public docs. Resolve with one live call using a real token against a window predating the station's `created_epoch`, and pin the response as a test fixture. The permanent-hole tradeoff below depends on this returning cleanly.
+**Resolved from the published OpenAPI spec** ([swagger.json](https://weatherflow.github.io/Tempest/api/swagger/swagger.json)), which settles this without a token:
+
+- The `ObservationSet` response includes a `status` object → `status_code` (`integer/int32`, example `0`) and `status_message` (`string`, example `"SUCCESS"`). So `status_code == 0` is the success signal, and checking it is correct.
+- **`ObservationSet` declares no `required` array.** Neither `type` nor `obs` is required, so a response omitting either is schema-legal. This confirms the hazard directly: routing through `tempestudp.ParseReport` — which dispatches on a top-level `type` and errors `unhandled message type: ""` when absent — would turn a legitimate empty window into a hard error.
+- Reported in the field: `status_code` 0 with `status_message` `"SUCCESS - Either no capabilities or no recent observations"` and an empty/absent `obs` ([Tempest community](https://community.tempest.earth/t/getting-station-data/17879)).
+
+**Therefore, treat as normative:** `status_code == 0` is success; an absent, `null`, or empty `obs` is **zero rows, not an error**; an absent `type` is **not** an error. A non-zero `status_code` is a real failure carrying `status_message`.
+
+*Remaining (non-blocking) verification:* pin a real empty-window body as a fixture when a token is available, to confirm the exact serialization. The design no longer depends on that answer — the schema establishes that both fields are optional, which is the property the handling must be robust to either way.
 
 ### Retry
 
@@ -184,7 +192,7 @@ A failed gap logs and continues; the process exits **non-zero** if any gap faile
 | Gap detection — partitioning | **Two serials with interleaved timestamps that mask each other.** Regression test for C1. |
 | Gap detection — domain | Head gap, tail gap, empty table, no-gaps. |
 | Chunking | Multi-day range → N single-day requests. |
-| Empty window | Fixture (pinned from the live call above) → zero rows, no error. |
+| Empty window | Three fixtures, all → zero rows + no error: `obs` empty, `obs` null/absent, and a status-only envelope with no `type`. |
 | Idempotency | Insert twice; second inserts 0, changes nothing. |
 | Dry-run | Zero writes, zero API calls. |
 | Serial pre-flight | Mismatched serials → warning. |

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -1,14 +1,12 @@
 # API Backfill Tool — Design
 
-**Date:** 2026-07-28
-**Status:** Approved
-**Issue:** (none yet — sibling in spirit to #80, which is a separate tool, not a shared abstraction)
+**Date:** 2026-07-28 (revised 2026-07-29 after senior-Go-engineer review)
+**Status:** Approved, revised
+**Related:** #80 is a sibling *tool*, not a shared abstraction — no coupling between them.
 
 ## Problem
 
 The service persists observations it receives over UDP. Anything it misses — the process was down, the host rebooted, the container was rescheduled — is simply absent from the store, and nothing today can recover it. The Tempest REST API retains historical observations, so the data is available; there is just no way to get it in.
-
-A related gap: `internal/sqlite/writer.go`'s `WriteMetrics` is a **documented no-op**, so the existing API-export mode (`ModeAPIExport`, triggered by `TOKEN`) writes to Postgres, OTel, and Prometheus but **never to SQLite** — which is the default store. Backfill built on that path would silently do nothing for most deployments.
 
 ## Goal
 
@@ -18,84 +16,187 @@ A `backfill` subcommand that finds holes in the local observation history and fi
 
 | Decision | Choice | Why |
 |---|---|---|
-| What to backfill | **Auto-detect gaps, with `--from`/`--to` override** | "Backfill missing data" should need no input in the common case; the override covers a known-bad window without a full scan. |
-| How data reaches the store | **Typed API→row path** | `sqlite.WriteMetrics` is a no-op, so the `[]prometheus.Metric` export path cannot reach the default store. A typed path is lossless and works for SQLite and Postgres alike. |
-| Invocation | **Subcommand on the existing binary** | `main.go:189` already dispatches `os.Args[1] == "healthcheck"`. Extending it needs no packaging change: the tool ships in the same image and release artifacts. #80 can later add `migrate` the same way, additively. |
+| What to backfill | Auto-detect gaps, with `--from`/`--to` override | Should need no input in the common case; the override covers a known window without a full scan. |
+| How data reaches the store | Dedicated typed API→row path | See "Why not reuse an existing write path" below — the reasoning is **not** simply that `WriteMetrics` is a no-op. |
+| Invocation | Subcommand on the existing binary | `main.go:189` already dispatches `os.Args[1] == "healthcheck"`. Additive, no packaging change; #80's `migrate` slots in the same way. |
+
+### Why not reuse an existing write path
+
+Three candidates exist. All are rejected, for distinct reasons that must be recorded so an implementer does not "helpfully" reuse one:
+
+- **`WriteMetrics` (`[]prometheus.Metric`)** — `sqlite.WriteMetrics` is a documented no-op (`internal/sqlite/writer.go:528-537`), so this path never reaches the default store.
+- **`WriteReport` (typed, correct row construction)** — the real blocker is its **enqueue semantics**: the continuous-report path is non-blocking and **drops on saturation** (`internal/sqlite/writer.go:346-357`, channel cap 1000 at `:23`). A single 1-day window is ~1440 rows, so naive reuse silently loses rows. It also cannot return an inserted count, which the reporting below depends on.
+- **`sqlite.Writer` methods generally** — `run` is documented as "the only goroutine that ever touches db" (`internal/sqlite/writer.go:161,236`). Adding an insert method to that type would breach the single-writer invariant and be callable from the daemon.
+
+**Therefore:** `FindObservationGaps` and `InsertObservations` are **package-level functions taking `*sql.DB` / `*pgxpool.Pool`**, not methods on the writer types. They start no goroutines.
 
 ## Scope
 
 **In:** `tempest_observations` only.
 
-**Out:** `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events`. These are not retrievable historically — rapid wind is a 3-second live broadcast, hub status is device telemetry, and events are instantaneous pushes. The REST device-observations endpoint returns only the ~1/minute `obs_st` equivalent.
+**Out:** `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events` — no historical REST endpoint exists for any of them (rapid wind is UDP/WebSocket-only; hub/device status and discrete strike/rain-start events are push-only). Note lightning is *partially* recovered in aggregate via `obs[14]`/`obs[15]` (avg distance, strike count per interval), which populate observation columns — but not as `tempest_events` rows.
 
-**Also out:** changing `ModeAPIExport`. Whether the legacy export path should be folded into this tool is a separate decision; this design leaves it untouched.
+**Also out:** changing `ModeAPIExport` or `sqlite.WriteMetrics`.
 
-## Components
+## Data model
 
-Each unit has one responsibility and is independently testable.
+### `Observation` and `Gap` ownership
 
-### `tempestapi.GetObservationRows(ctx, station, from, to) ([]Observation, error)` — new
+Both stores must name these types, so they cannot live in `tempestapi` (storage would depend on the REST client). They also must not collide with the existing `sqlite.Observation` read-model (`internal/sqlite/writer.go:712`).
 
-Returns typed observations mirroring the `tempest_observations` columns, instead of `[]prometheus.Metric`.
+**Decision:** they live in **`internal/tempestudp`** — the neutral package both stores already import. Each store converts to its own private `observationRow` at its boundary (SQLite's timestamp is `int64`, Postgres's is `time.Time`; their pointer types differ).
 
-The existing `GetObservations` is **not modified** — `ModeAPIExport` keeps using it. Two representations of an API observation will coexist (metrics for the legacy export, rows for backfill). This is accepted: they serve different consumers, and unifying them would require changing the legacy export path, which is out of scope.
+`Gap` carries `SerialNumber`, `From`, `To`, using `time.Time` as the canonical representation.
 
-### `FindObservationGaps(ctx, from, to, minGap) ([]Gap, error)` — new, on both stores
+### Nullability — mandatory
 
-A single SQL pass using `LAG(timestamp) OVER (ORDER BY timestamp)` to return adjacent-row intervals wider than `minGap`. On SQLite it runs on the read-only handle, so a wide scan never queues behind the ingest writer.
+`GetObservationRows` **must** decode the `obs` array as `[][]*float64` (or `[]json.RawMessage`), mapping JSON `null` → nil pointer → SQL NULL.
 
-### `InsertObservations(ctx, rows) (inserted int, err error)` — on both stores
+It **must not** reuse `tempestudp.TempestObservationReport`, whose `Obs` is `[][]float64` (`internal/tempestudp/report.go:135`): unmarshalling `null` into a non-pointer numeric is a silent no-op that yields `0.0`. That would write `battery = 0.0 V`, `pressure = 0.0 mb` where the API said "unknown" — physically meaningful values that `SummarizeObservations`' `MIN(pressure)` and every chart read as real. Backfill operates precisely on marginal windows, where nulls are most likely.
 
-Bulk idempotent insert, `ON CONFLICT DO NOTHING` against `UNIQUE(serial_number, timestamp)`. Returns the number of rows actually inserted so the tool can report `requested` vs `inserted`.
+### Derived columns
 
-### `backfill` subcommand
+`temp_wetbulb` is **not** returned by the API — it is computed in Go at ingest from `ob[7]/ob[8]/ob[6]` with a NaN→NULL guard (`internal/sqlite/writer.go:410,432-434`).
 
-Flag parsing, orchestration, progress output, dry-run. Writes to whichever store the daemon would use, reusing the existing `selectStore` logic — SQLite by default, Postgres when configured. No new configuration surface.
+`GetObservationRows` returns **raw API fields only**. Wet bulb is derived at the store boundary using the same `tempestudp.WetBulbTemperatureC` + `math.IsNaN` guard the ingest path uses, single-sourced — so backfilled and live rows are indistinguishable. (Change the formula and all call sites change together: shared knowledge, not shared shape.)
 
-## Data flow
+### Field alignment
 
+REST `obs_st` indices 0–17 match the UDP layout exactly, so the existing `len(ob) >= N` guards apply unmodified. The REST array has 22 elements; indices 18–21 (local-day rain accumulation, Nearcast accumulations, precip analysis type) map to no existing column and are ignored deliberately.
+
+## Gap detection
+
+### Partitioned by serial — mandatory
+
+```sql
+-- SQLite (timestamp INTEGER, epoch seconds)
+SELECT serial_number, prev, timestamp FROM (
+  SELECT serial_number,
+         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+         timestamp
+  FROM tempest_observations
+  WHERE timestamp BETWEEN ? AND ?
+) WHERE prev IS NOT NULL AND timestamp - prev > ?
 ```
-detect gaps (or use --from/--to)
-   → chunk each gap into 1-day windows        [matches existing export pagination]
-      → GetObservationRows(window)
-         → InsertObservations(rows)           [ON CONFLICT DO NOTHING]
-            → report: gap, requested, inserted, skipped
+
+```sql
+-- Postgres (timestamp TIMESTAMPTZ)
+SELECT serial_number, prev, ts FROM (
+  SELECT serial_number,
+         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+         timestamp AS ts
+  FROM tempest_observations
+  WHERE timestamp BETWEEN $1 AND $2
+) q WHERE prev IS NOT NULL AND EXTRACT(EPOCH FROM (ts - prev)) > $3
 ```
+
+**`PARTITION BY serial_number` is not optional.** The series is identified by `(serial_number, timestamp)` — the same uniqueness contract idempotency relies on. Without partitioning, two stations phase-offset by ~30s produce a merged sequence with no interval ever exceeding `--min-gap`, so a multi-hour outage on one station is **undetectable** and the tool reports "no gaps" and exits 0. The same failure hides a hardware swap (new serial) behind an apparently continuous sequence.
+
+**Required test:** two serials whose interleaved timestamps mask each other.
+
+### Detection domain — head, tail, and empty
+
+`LAG` yields NULL for the first row of each partition, so it finds **interior gaps only**. Left there, a fresh/empty store reports "no gaps" and writes nothing, and the natural "the box was down, repair it" case — whose outage is entirely in the tail — is invisible.
+
+The detection domain is explicit:
+
+- `detectTo` defaults to `now - minGap`.
+- `detectFrom` defaults to the station's `created_epoch` from `ListStations` (`internal/tempestapi/client.go:123`).
+- Gaps are the union of: `[detectFrom, first_row]`, the interior `LAG` gaps, and `[last_row, detectTo]`.
+- **Empty table:** the whole `[detectFrom, detectTo]` range is one gap. This is a first-class case, not an edge case.
+
+## Fetch and insert
+
+### Chunking
+
+All fetches — auto-detected **and** `--from/--to` — go through the chunker. The constraint is the API's documented cap: *observation data at one-minute resolution is available only for ranges of five days or less* ([apidocs.tempestwx.com](https://apidocs.tempestwx.com/reference/getobservationsbydeviceid)). Chunk size is **1 day**, comfortably inside it. Exceeding the cap silently returns coarser data that would be written as if it were 1-minute observations.
+
+**Required test:** a multi-day `--from/--to` produces N single-day requests.
+
+### Empty-window handling
+
+`GetObservationRows` must check `status.status_code` (as `ListStations` does, `client.go:102-104`; `GetObservations` currently does not), distinguish "no data" from a real error, treat an absent/null `obs` array as **zero rows, not an error**, and must **not** route through `tempestudp.ParseReport`, whose type dispatch errors with `unhandled message type: ""` on a `status`-only envelope.
+
+> **OPEN QUESTION (blocks planning of this component only):** the exact response shape for a window with no data is not determinable from public docs. Resolve with one live call using a real token against a window predating the station's `created_epoch`, and pin the response as a test fixture. The permanent-hole tradeoff below depends on this returning cleanly.
+
+### Retry
+
+Bounded exponential backoff on 429/5xx/network errors, honoring `Retry-After` when present, plus a small inter-request delay. A gap is marked failed only after retries are exhausted. Context cancellation is checked between windows **and** between retry attempts. WeatherFlow publishes no rate limits, which argues for conservatism rather than for ignoring the question.
+
+### Insert
+
+`InsertObservations(ctx, db, rows) (inserted int, err error)` — `ON CONFLICT (serial_number, timestamp) DO NOTHING`, matching both existing insert paths (`internal/sqlite/writer.go:631`, `internal/postgres/writer.go:255`).
+
+The inserted count is obtainable on both stores and is the mechanism that makes the permanent-hole tradeoff visible: SQLite's per-row `stmt.ExecContext` returns `RowsAffected` 0 for a skipped conflict and 1 for an insert; Postgres's `br.Exec()` returns a `pgconn.CommandTag` with the same semantics (currently discarded at `internal/postgres/writer.go:268`). Both need a signature change, neither a semantics change.
+
+The count is reported **only after a successful `Commit`** — `execBatch` rolls the whole transaction back on any row error (`internal/sqlite/writer.go:589-620`), and pgx `SendBatch` is all-or-nothing per batch.
+
+Insert transactions are bounded to **≤200 rows** (see concurrency below). If `InsertObservations` reuses the Postgres batch helper, it needs its own timeout: the existing hardcoded 5s (`internal/postgres/writer.go:240`) was sized for the 1-row live path.
+
+## Concurrency with a running daemon
+
+The realistic invocation is `docker exec <running container> tempestwx-utilities backfill` against a live `/data/tempest.db`. **This is supported**, with these consequences stated deliberately:
+
+- A long backfill transaction contends with ingest writes; `busy_timeout` defaults to 5s, and ingest's error path only **logs** (`internal/sqlite/writer.go:646`). Unbounded transactions could therefore cause **live observations to be silently lost while repairing historical ones**. Bounding inserts to ≤200 rows per transaction is the mitigation.
+- Litestream owns checkpointing; a second writer process is compatible with it.
+- Both processes run `Migrate` on open; per-migration transactions make this safe in practice, though `schema_version` has no uniqueness constraint.
+
+## Lifecycle
+
+- `runBackfill(ctx) int` performs **all** cleanup via internal defers and returns an exit code; the dispatch site does `os.Exit(runBackfill(ctx))`. Copying the healthcheck shape (`os.Exit` at the dispatch site with no cleanup, `main.go:189-191`) would skip `db.Close()` and the pgx pool drain.
+- Signal context (SIGINT/SIGTERM) is wired in the subcommand; the healthcheck path has none to inherit.
+- Store selection reuses `selectStore` (`main.go:147-154`), which is genuinely pure — no I/O, no goroutines, no globals. Everything *downstream* of it is currently inline in `main()` (`main.go:256-336`) and entangled with HTTP-server and sink teardown; backfill constructs its own handles rather than reusing that block.
+- Backfill opens the **write** handle (it must migrate and insert). `OpenReadOnly` is not used: it fails when the file does not exist and cannot migrate, and its ingest-contention rationale does not apply to a separate one-shot process.
+
+## Serial-number invariant
+
+Dedupe, gap closure, and convergence all require that the serial written by backfill exactly matches the serial written by UDP ingest. Backfill's comes from `ListStations` (`client.go:110-115`), ingest's from the broadcast field. If they ever diverge, backfill writes a **parallel series under a second serial**, `UNIQUE` never fires, rows double, and the gap never closes — silently and cumulatively.
+
+**Pre-flight check:** compare `ListStations` serials against `SELECT DISTINCT serial_number FROM tempest_observations` and warn on mismatch. Also note `client.go:110-115` has no `break`, so with multiple `ST` devices the last silently wins — backfill must handle multiple devices explicitly rather than inherit that.
 
 ## The permanent-hole problem
 
-If the station was genuinely offline, the API has no data for that window either. Auto-detect will therefore rediscover the same hole on every run and re-fetch it indefinitely — never converging.
+If the station was genuinely offline, the API has no data for that window either. Auto-detect rediscovers the same hole on every run and never converges.
 
-**Decision: accept it, and make it visible.** Report `requested N, inserted M` per gap so a permanently empty window is obvious to the operator.
+**Decision: accept it, and make it visible.** Report `requested N, inserted M` per gap, plus a machine-greppable summary line (`gaps=3 requested=4320 inserted=0`) so automation can detect non-convergence. Exit code stays 0 — a permanent hole is not an error.
 
-Rejected alternative: persisting a table of already-attempted windows. It adds schema and durable state to save only redundant API calls, and would itself become wrong if the API later fills in its own history.
+Rejected: persisting a table of attempted windows. It adds schema and durable state to save only redundant API calls, and goes stale if the API later fills its own history.
 
-`--min-gap` (default 30 minutes) keeps ordinary 1–2 minute reporting jitter from registering as a gap at all.
+`--min-gap` (default 30m) keeps ordinary reporting jitter from registering. Stations configured with a long `report_interval` need a larger value.
+
+## Flags
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--from`, `--to` | unset (auto-detect) | **RFC3339, interpreted UTC.** The store is UTC epoch and the API takes epoch seconds; an ambiguous local-time parse is a quiet wrong-window bug. |
+| `--min-gap` | `30m` | |
+| `--dry-run` | false | Gap detection + plan only: **zero** API calls, **zero** writes. Consequently it cannot validate the token or reachability. |
 
 ## Error handling
 
-- A failed gap **logs and continues** to the next; one bad window must not abandon the run. The process **exits non-zero** if any gap failed, so automation notices.
-- Honors context cancellation (SIGINT/SIGTERM) between windows. Already-inserted rows stay; idempotency makes re-running safe.
-- `--dry-run` performs gap detection and prints the plan, making **zero** API calls and **zero** writes.
-- API errors surface with station and window context. Unlike the current export path, backfill must **never** `log.Fatalf` mid-run — partial progress must be preserved and reported.
+A failed gap logs and continues; the process exits **non-zero** if any gap failed. Context cancellation is honored between windows and retries, leaving inserted rows intact — idempotency makes re-running safe. Backfill must **never** `log.Fatalf` mid-run: partial progress must be preserved and reported.
 
 ## Testing
 
 | Area | Test |
 |---|---|
-| API parsing | Fixture JSON → `GetObservationRows` → assert typed fields, including null/missing array elements. No network. |
-| Gap detection | Seed a temp SQLite DB with a known hole; assert exact gap boundaries. Plus no-gaps and empty-table cases. |
-| Idempotency | Insert the same rows twice; the second run inserts 0 and changes nothing. |
-| Dry-run | Asserts zero writes and zero API calls. |
+| Nullability | Fixture with `null` obs elements → assert row pointer fields are **nil**, not zero. |
+| Gap detection — partitioning | **Two serials with interleaved timestamps that mask each other.** Regression test for C1. |
+| Gap detection — domain | Head gap, tail gap, empty table, no-gaps. |
+| Chunking | Multi-day range → N single-day requests. |
+| Empty window | Fixture (pinned from the live call above) → zero rows, no error. |
+| Idempotency | Insert twice; second inserts 0, changes nothing. |
+| Dry-run | Zero writes, zero API calls. |
+| Serial pre-flight | Mismatched serials → warning. |
 
 ## Constraints
 
-- `CGO_ENABLED=0` stays buildable (pure-Go `modernc.org/sqlite`).
-- Timestamps are UTC unix-epoch integers; primary keys are UUIDv7 generated in Go.
+- `CGO_ENABLED=0` stays buildable. `modernc.org/sqlite` bundles SQLite 3.46.0; `LAG(...) OVER (PARTITION BY ...)` verified working under it.
+- Timestamps UTC epoch; PKs UUIDv7 generated in Go. Note UUIDv7 embeds *insert* time, so backfilled rows sort by `id` in insert order, not observation order — consistent with the ingest path, but `id` ordering must not be assumed chronological.
 - Go 1.25 floor, toolchain go1.26.1.
 
 ## Non-goals
 
-- Backfilling rapid wind, hub status, or events (not retrievable).
+- Backfilling rapid wind, hub status, or events.
 - Modifying `ModeAPIExport` or `sqlite.WriteMetrics`.
-- Implementing #80's `migrate` subcommand — this only establishes the dispatch pattern it can slot into.
+- Implementing #80's `migrate` — this only establishes the dispatch pattern it slots into.

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -86,11 +86,17 @@ func backfill(
 
   ```go
   type backfillStore interface {
+      SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
       FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
       InsertObservations(ctx context.Context, obs []weather.Observation) (inserted int, err error)
-      DistinctSerials(ctx context.Context) ([]string, error)
   }
   ```
+
+  `SeriesBounds` returns the first and last stored timestamp per serial within a
+  window (`weather.Bounds`). It carries three jobs at once, which is why there is
+  no separate `DistinctSerials`: it supplies the head/tail boundaries `LAG`
+  cannot see, its key set *is* the set of serials present, and an empty result
+  is exactly the empty-store signal the pre-flight check needs.
 
   Defined in the **consumer** package (`internal/backfill`), Go-idiomatic. Thin adapters in that package bind a `*sql.DB` / `*pgxpool.Pool` to the package-level store functions.
 

--- a/docs/designs/2026-07-28-api-backfill-tool-design.md
+++ b/docs/designs/2026-07-28-api-backfill-tool-design.md
@@ -1,0 +1,101 @@
+# API Backfill Tool — Design
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Issue:** (none yet — sibling in spirit to #80, which is a separate tool, not a shared abstraction)
+
+## Problem
+
+The service persists observations it receives over UDP. Anything it misses — the process was down, the host rebooted, the container was rescheduled — is simply absent from the store, and nothing today can recover it. The Tempest REST API retains historical observations, so the data is available; there is just no way to get it in.
+
+A related gap: `internal/sqlite/writer.go`'s `WriteMetrics` is a **documented no-op**, so the existing API-export mode (`ModeAPIExport`, triggered by `TOKEN`) writes to Postgres, OTel, and Prometheus but **never to SQLite** — which is the default store. Backfill built on that path would silently do nothing for most deployments.
+
+## Goal
+
+A `backfill` subcommand that finds holes in the local observation history and fills them from the Tempest REST API, idempotently and safely re-runnably.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| What to backfill | **Auto-detect gaps, with `--from`/`--to` override** | "Backfill missing data" should need no input in the common case; the override covers a known-bad window without a full scan. |
+| How data reaches the store | **Typed API→row path** | `sqlite.WriteMetrics` is a no-op, so the `[]prometheus.Metric` export path cannot reach the default store. A typed path is lossless and works for SQLite and Postgres alike. |
+| Invocation | **Subcommand on the existing binary** | `main.go:189` already dispatches `os.Args[1] == "healthcheck"`. Extending it needs no packaging change: the tool ships in the same image and release artifacts. #80 can later add `migrate` the same way, additively. |
+
+## Scope
+
+**In:** `tempest_observations` only.
+
+**Out:** `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events`. These are not retrievable historically — rapid wind is a 3-second live broadcast, hub status is device telemetry, and events are instantaneous pushes. The REST device-observations endpoint returns only the ~1/minute `obs_st` equivalent.
+
+**Also out:** changing `ModeAPIExport`. Whether the legacy export path should be folded into this tool is a separate decision; this design leaves it untouched.
+
+## Components
+
+Each unit has one responsibility and is independently testable.
+
+### `tempestapi.GetObservationRows(ctx, station, from, to) ([]Observation, error)` — new
+
+Returns typed observations mirroring the `tempest_observations` columns, instead of `[]prometheus.Metric`.
+
+The existing `GetObservations` is **not modified** — `ModeAPIExport` keeps using it. Two representations of an API observation will coexist (metrics for the legacy export, rows for backfill). This is accepted: they serve different consumers, and unifying them would require changing the legacy export path, which is out of scope.
+
+### `FindObservationGaps(ctx, from, to, minGap) ([]Gap, error)` — new, on both stores
+
+A single SQL pass using `LAG(timestamp) OVER (ORDER BY timestamp)` to return adjacent-row intervals wider than `minGap`. On SQLite it runs on the read-only handle, so a wide scan never queues behind the ingest writer.
+
+### `InsertObservations(ctx, rows) (inserted int, err error)` — on both stores
+
+Bulk idempotent insert, `ON CONFLICT DO NOTHING` against `UNIQUE(serial_number, timestamp)`. Returns the number of rows actually inserted so the tool can report `requested` vs `inserted`.
+
+### `backfill` subcommand
+
+Flag parsing, orchestration, progress output, dry-run. Writes to whichever store the daemon would use, reusing the existing `selectStore` logic — SQLite by default, Postgres when configured. No new configuration surface.
+
+## Data flow
+
+```
+detect gaps (or use --from/--to)
+   → chunk each gap into 1-day windows        [matches existing export pagination]
+      → GetObservationRows(window)
+         → InsertObservations(rows)           [ON CONFLICT DO NOTHING]
+            → report: gap, requested, inserted, skipped
+```
+
+## The permanent-hole problem
+
+If the station was genuinely offline, the API has no data for that window either. Auto-detect will therefore rediscover the same hole on every run and re-fetch it indefinitely — never converging.
+
+**Decision: accept it, and make it visible.** Report `requested N, inserted M` per gap so a permanently empty window is obvious to the operator.
+
+Rejected alternative: persisting a table of already-attempted windows. It adds schema and durable state to save only redundant API calls, and would itself become wrong if the API later fills in its own history.
+
+`--min-gap` (default 30 minutes) keeps ordinary 1–2 minute reporting jitter from registering as a gap at all.
+
+## Error handling
+
+- A failed gap **logs and continues** to the next; one bad window must not abandon the run. The process **exits non-zero** if any gap failed, so automation notices.
+- Honors context cancellation (SIGINT/SIGTERM) between windows. Already-inserted rows stay; idempotency makes re-running safe.
+- `--dry-run` performs gap detection and prints the plan, making **zero** API calls and **zero** writes.
+- API errors surface with station and window context. Unlike the current export path, backfill must **never** `log.Fatalf` mid-run — partial progress must be preserved and reported.
+
+## Testing
+
+| Area | Test |
+|---|---|
+| API parsing | Fixture JSON → `GetObservationRows` → assert typed fields, including null/missing array elements. No network. |
+| Gap detection | Seed a temp SQLite DB with a known hole; assert exact gap boundaries. Plus no-gaps and empty-table cases. |
+| Idempotency | Insert the same rows twice; the second run inserts 0 and changes nothing. |
+| Dry-run | Asserts zero writes and zero API calls. |
+
+## Constraints
+
+- `CGO_ENABLED=0` stays buildable (pure-Go `modernc.org/sqlite`).
+- Timestamps are UTC unix-epoch integers; primary keys are UUIDv7 generated in Go.
+- Go 1.25 floor, toolchain go1.26.1.
+
+## Non-goals
+
+- Backfilling rapid wind, hub status, or events (not retrievable).
+- Modifying `ModeAPIExport` or `sqlite.WriteMetrics`.
+- Implementing #80's `migrate` subcommand — this only establishes the dispatch pattern it can slot into.

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -33,9 +33,11 @@
 - **Tests use repo idiom:** `t.Context()`, `t.TempDir()`, stdlib table-driven subtests, no testify.
 - **The full gate must pass before any task is reported complete:**
   ```bash
-  CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+  CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
   ```
   `gofmt -l .` must print **nothing**. Paste real output; do not assert success without it.
+  **`go build ./...` does not compile `_test.go` files** — only `go vet` and `go test` do. Never cite `go build` as proof that a rename reached the tests.
+- **Prefer stdlib over hand-rolled helpers.** `slices.Chunk`, `slices.SortFunc`, `cmp.Or`, `min`/`max`, range-over-int and range-over-func are all available and are the house style. Do not write a loop the stdlib already provides.
 - **Work in the existing worktree.** Every task begins by confirming `pwd` ends in `.claude/worktrees/api-backfill` and that `docs/designs/2026-07-28-api-backfill-tool-design.md` exists. If not, STOP and report `NEEDS_CONTEXT`.
 
 ---
@@ -99,13 +101,16 @@ func TestGapDuration(t *testing.T) {
 	}
 }
 
-func TestObservationNullableFieldsDefaultNil(t *testing.T) {
+// The invariant this pins is that the measurement fields are POINTER-typed,
+// so a JSON null can round-trip to SQL NULL. It asserts through the type
+// system rather than through behavior — the behavioral proof is in Task 3's
+// decode test and Task 5's insert test.
+func TestObservationMeasurementFieldsArePointers(t *testing.T) {
 	var o Observation
-	if o.Pressure != nil {
-		t.Error("Pressure should default to nil (SQL NULL), not a zero value")
-	}
-	if o.TempWetbulb != nil {
-		t.Error("TempWetbulb should default to nil")
+	// Assigning nil compiles only if these are pointers.
+	o.Pressure, o.TempAir, o.Battery = nil, nil, nil
+	if o.Pressure != nil || o.TempAir != nil || o.Battery != nil {
+		t.Error("measurement fields must be *float64 so JSON null maps to SQL NULL")
 	}
 }
 ```
@@ -114,6 +119,8 @@ func TestObservationNullableFieldsDefaultNil(t *testing.T) {
 
 Run: `go test ./internal/weather/ -run 'TestGap|TestObservation' -v`
 Expected: FAIL — the package does not exist (`no Go files in .../internal/weather`).
+
+Note the `Bounds` type below has no dedicated test: it is a plain data carrier with no behavior, and Task 5/8 exercise it end-to-end. Do not add a zero-value test for it.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -168,15 +175,23 @@ type Observation struct {
 	LightningStrikeCount *float64 // obs_st[15]
 	Battery              *float64 // obs_st[16]
 	ReportInterval       *float64 // obs_st[17]
-
-	// TempWetbulb is derived in Go, not returned by the API. It is computed
-	// at the store boundary with the same tempestudp.WetBulbTemperatureC +
-	// math.IsNaN guard the UDP ingest path uses, so backfilled and live rows
-	// are indistinguishable.
-	TempWetbulb *float64
 }
 
-// Gap is a half-open hole [From, To) in one station's observation series.
+// NOTE: there is deliberately no TempWetbulb field. The API does not return
+// wet bulb; each store derives it at its own insert boundary from
+// TempAir/Humidity/Pressure using tempestudp.WetBulbTemperatureC. A field
+// here would never be read by any code path, and setting it would silently
+// do nothing — dead code that looks load-bearing.
+
+// Gap is a CLOSED hole [From, To] in one station's observation series.
+//
+// Closed, not half-open: every producer emits endpoints that are rows which
+// already exist (prev/next from LAG, First/Last from SeriesBounds), so both
+// ends get re-fetched and re-offered to the store. ON CONFLICT DO NOTHING
+// absorbs the duplicates, so this costs nothing but a slightly inflated
+// Requested count — but the doc must not claim a half-open interval it does
+// not have.
+//
 // The series is keyed by (SerialNumber, Timestamp) — the same uniqueness
 // contract idempotent inserts rely on — so a Gap is meaningless without its
 // serial.
@@ -221,10 +236,11 @@ git commit -m "feat(weather): add store-neutral Observation, Gap, and Bounds typ
 
 ---
 
-### Task 2: `tempestapi` — export Station fields, add `StatusError`
+### Task 2: `tempestapi` — export Station fields, add `StatusError` and `ListDevices`
 
 **Files:**
-- Modify: `internal/tempestapi/client.go:53-58` (struct), `:110-121` (construction), `:131` (`GetObservations` URL), `:160` (serial assignment)
+- Modify: `internal/tempestapi/client.go` — `Station` struct (`:53-59`), the `ListStations` construction (`:117-125`), `:131` (`GetObservations` URL), `:160` (serial assignment), plus the shared-decode extraction
+- Modify: `internal/tempestapi/client_test.go` — **20 references** must be renamed (see Step 4b); also gains the `ListDevices` tests
 - Create: `internal/tempestapi/errors.go`
 - Test: `internal/tempestapi/errors_test.go`
 
@@ -233,6 +249,7 @@ git commit -m "feat(weather): add store-neutral Observation, Gap, and Bounds typ
 - Produces:
   - `tempestapi.Station{Name string; StationID int; DeviceID int; SerialNumber string; CreatedAt time.Time}`
   - `tempestapi.StatusError{HTTPStatus, StatusCode int; Message string}` with `func (e *StatusError) Error() string`
+  - `func (c *Client) ListDevices(ctx context.Context) ([]Station, error)` — one entry per `ST` device across all stations
 
 **Why:** `Station.serialNumber` and `.deviceID` are currently **unexported** (`client.go:55-56`), so the serial pre-flight check cannot read a serial from outside the package. Export the fields rather than adding getters: `Station` is a plain data struct with three already-exported fields and no invariants to protect, so two getters would be pure ceremony.
 
@@ -373,25 +390,215 @@ Update the two read sites in `GetObservations`:
 - `:131` — `station.deviceID` becomes `station.DeviceID`
 - `:160` — `r.SerialNumber = station.serialNumber` becomes `r.SerialNumber = station.SerialNumber`
 
-Do **not** change any other behavior in this file. In particular, leave the missing `break` in the device loop alone — `ModeAPIExport` depends on current behavior and fixing it is an explicit non-goal.
+Do **not** change any other behavior in `client.go`. In particular, leave the missing `break` in the device loop alone — `ModeAPIExport` depends on current behavior and fixing it is an explicit non-goal.
+
+- [ ] **Step 4b: Rename the 20 references in `client_test.go` — REQUIRED, and expected**
+
+Exporting these fields **breaks `internal/tempestapi/client_test.go` in 20 places**. This is not optional collateral to be worked around; it is a mechanical rename with no behavior change, and it is in scope for this task.
+
+- **12 composite-literal keys** — `:421, :422, :464, :465, :485, :500, :515, :542, :660, :661, :764, :787`
+  `deviceID:` → `DeviceID:`, `serialNumber:` → `SerialNumber:`
+- **8 selector accesses** — `:94, :95, :97, :98, :222, :223, :225, :226`
+  `station.deviceID` → `station.DeviceID`, `station.serialNumber` → `station.SerialNumber`
+
+Verify none remain:
+
+```bash
+grep -n "deviceID\|serialNumber" internal/tempestapi/*.go
+```
+Expected: **no output.**
+
+Do **not** work around this by adding accessor methods or keeping shadow unexported fields — the whole point of Task 2 is that `Station` is a plain data struct.
+
+- [ ] **Step 4c: Write the failing test for `ListDevices`**
+
+`ListStations` returns **one already-collapsed `Station` per station**: its device loop (`client.go:110-115`) has no `break`, so within a station the *last* `ST` device overwrites the others. Backfill must reach every sensor, so it needs a device-level enumeration. Append to `internal/tempestapi/client_test.go`:
+
+```go
+func TestListDevicesReturnsEverySTDevice(t *testing.T) {
+	// One station, TWO Tempest sensors, plus a hub that must be ignored.
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+		"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+		"devices": [
+			{"device_id": 11, "device_type": "HB", "serial_number": "HB-00000001"},
+			{"device_id": 22, "device_type": "ST", "serial_number": "ST-00000022"},
+			{"device_id": 33, "device_type": "ST", "serial_number": "ST-00000033"}
+		]
+	}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	devices, err := c.ListDevices(t.Context())
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("got %d devices, want 2 (both ST sensors, hub excluded)", len(devices))
+	}
+	got := map[string]int{}
+	for _, d := range devices {
+		got[d.SerialNumber] = d.DeviceID
+		if !d.CreatedAt.Equal(time.Unix(1600000000, 0)) {
+			t.Errorf("%s CreatedAt = %v, want the owning station's created_epoch", d.SerialNumber, d.CreatedAt)
+		}
+	}
+	if got["ST-00000022"] != 22 || got["ST-00000033"] != 33 {
+		t.Errorf("device map = %v, want ST-00000022→22 and ST-00000033→33", got)
+	}
+}
+
+// ListStations must keep its existing one-per-station collapse — ModeAPIExport
+// depends on it. This pins the divergence so the shared decode refactor cannot
+// silently change it.
+func TestListStationsStillCollapsesToOneDevicePerStation(t *testing.T) {
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+		"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+		"devices": [
+			{"device_id": 22, "device_type": "ST", "serial_number": "ST-00000022"},
+			{"device_id": 33, "device_type": "ST", "serial_number": "ST-00000033"}
+		]
+	}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	stations, err := c.ListStations(t.Context())
+	if err != nil {
+		t.Fatalf("ListStations: %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("got %d stations, want 1", len(stations))
+	}
+	if stations[0].SerialNumber != "ST-00000033" {
+		t.Errorf("SerialNumber = %q, want ST-00000033 (last ST wins — unchanged behavior)", stations[0].SerialNumber)
+	}
+}
+```
+
+Run: `go test ./internal/tempestapi/ -run TestListDevices -v`
+Expected: FAIL to compile — `c.ListDevices undefined`.
+
+- [ ] **Step 4d: Extract the shared decode, then add `ListDevices`**
+
+In `client.go`, lift the anonymous response struct inside `ListStations` to a named type and give both methods one fetch path. The JSON contract is shared knowledge — both would have to change together if WeatherFlow changed the payload — so it lives in one place.
+
+```go
+// stationsResponse is the /stations payload. ListStations and ListDevices
+// both decode into it, so the JSON contract lives in exactly one place.
+type stationsResponse struct {
+	Stations []struct {
+		CreatedEpoch int64 `json:"created_epoch"`
+		Devices      []struct {
+			DeviceID     int    `json:"device_id"`
+			DeviceType   string `json:"device_type"`
+			SerialNumber string `json:"serial_number"`
+		} `json:"devices"`
+		Name      string `json:"name"`
+		StationID int    `json:"station_id"`
+	} `json:"stations"`
+	Status struct {
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
+	} `json:"status"`
+}
+
+// fetchStations performs the GET /stations call and validates the status
+// envelope. Behavior is byte-identical to what ListStations did inline.
+func (c *Client) fetchStations(ctx context.Context) (*stationsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stations", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{HTTPStatus: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	var data stationsResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+	if data.Status.StatusCode != 0 {
+		return nil, &StatusError{
+			StatusCode: data.Status.StatusCode,
+			Message:    data.Status.StatusMessage,
+		}
+	}
+	return &data, nil
+}
+
+// ListDevices returns one Station per ST device across all stations.
+//
+// It exists because ListStations collapses each station to a SINGLE ST device
+// (its loop has no break, so the last one wins). With two Tempest units on one
+// station that silently loses a sensor — the UDP listener records both serials,
+// but a caller driven by ListStations would only ever learn one, and the other
+// unit's gaps would never close, unlogged.
+//
+// ListStations is deliberately left with its collapsing behavior: ModeAPIExport
+// depends on it, and changing it is an explicit non-goal.
+func (c *Client) ListDevices(ctx context.Context) ([]Station, error) {
+	data, err := c.fetchStations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []Station
+	for _, station := range data.Stations {
+		for _, dev := range station.Devices {
+			if dev.DeviceType != "ST" {
+				continue
+			}
+			out = append(out, Station{
+				Name:         station.Name,
+				StationID:    station.StationID,
+				DeviceID:     dev.DeviceID,
+				SerialNumber: dev.SerialNumber,
+				CreatedAt:    time.Unix(station.CreatedEpoch, 0),
+			})
+		}
+	}
+	return out, nil
+}
+```
+
+Then rewrite `ListStations`' body to call `fetchStations` and keep its existing collapse loop verbatim over `data.Stations`. Its observable behavior — including last-ST-wins and the `deviceId != 0 && instance != ""` filter — must not change; `TestListStationsStillCollapsesToOneDevicePerStation` is the guard.
+
+Note this changes `ListStations`' error *type* for HTTP and status failures from `fmt.Errorf` to `*StatusError`. That is an improvement (it makes them classifiable) and `errors.As` still matches; check `client_test.go` for any assertion on the exact error string and update it if present.
 
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `go test ./internal/tempestapi/ -v`
-Expected: PASS — the new tests plus the existing `client_test.go` suite unchanged.
+Expected: PASS — the new tests, plus `client_test.go` passing **with its 20 references renamed**. The suite's *behavior* is unchanged; its *field names* are not.
 
 - [ ] **Step 6: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
-Expected: all clean. `go build ./...` catches any missed `station.deviceID` reference elsewhere in the repo.
+Expected: all clean. Note that **`go build ./...` will pass even with `client_test.go` broken** — it does not compile test files. `go vet ./...` is what catches a missed rename.
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add internal/tempestapi/
-git commit -m "feat(tempestapi): export Station identity fields and add typed StatusError"
+git commit -m "feat(tempestapi): export Station identity, add StatusError and ListDevices"
 ```
 
 ---
@@ -1669,7 +1876,7 @@ git commit -m "feat(postgres): add partitioned gap detection and idempotent back
 
 **Chunking constraint:** the API documents that *observation data at one-minute resolution is available only for ranges of five days or less*. Chunk size is **1 day**, comfortably inside it. Exceeding the cap silently returns coarser data that would be written as if it were 1-minute observations — a data-corruption failure with no error.
 
-**Retry classification:** context cancellation is the operator's decision and is never retried. Per-attempt timeouts surface as `net.Error` from the client's own 30s `http.Client.Timeout` (`client.go:42`) and are retried through that branch, so `context.DeadlineExceeded` on the *parent* context correctly aborts rather than spinning.
+**Retry classification — read the design's "per-attempt-timeout trap" before writing this.** `context.Canceled` is the only blanket non-retryable signal. A per-attempt HTTP timeout satisfies **both** `errors.Is(err, context.DeadlineExceeded)` and `errors.As(err, &netErr)`, because `http.Client.Timeout` is implemented as a context deadline — so a `DeadlineExceeded` guard would silently make every slow response permanent. Whether the *parent* context is done is answered at the call site with `ctx.Err()`, not by inspecting the error.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1684,6 +1891,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -1755,6 +1963,53 @@ func (fakeNetErr) Temporary() bool { return true }
 
 var _ net.Error = fakeNetErr{}
 
+// realTimeoutError produces the error an actual per-attempt HTTP timeout
+// yields — NOT a synthetic fake.
+//
+// This distinction is the whole point. http.Client.Timeout is implemented as a
+// context deadline, so the resulting *url.Error satisfies BOTH
+// errors.Is(err, context.DeadlineExceeded) AND errors.As(err, &netErr). A
+// hand-rolled net.Error fake satisfies only the second, so it cannot
+// reproduce the bug and would pass against a classifier that returns false for
+// every timeout. Build the real thing.
+func realTimeoutError(t *testing.T) error {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // stall until the client gives up
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected a timeout error, got none")
+	}
+	return err
+}
+
+// Regression test for the classifier bug: a per-attempt HTTP timeout MUST be
+// retried. If this fails, isRetryable is short-circuiting on
+// context.DeadlineExceeded before reaching the net.Error branch, and every
+// slow API response will fail its entire gap with zero retries.
+func TestIsRetryableRealHTTPTimeoutIsRetried(t *testing.T) {
+	err := realTimeoutError(t)
+
+	// Document the dual-predicate property that makes this subtle.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("precondition changed: a Client.Timeout error should satisfy errors.Is(DeadlineExceeded); got %v", err)
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) {
+		t.Fatalf("precondition changed: a Client.Timeout error should satisfy errors.As(net.Error); got %v", err)
+	}
+
+	if !isRetryable(err) {
+		t.Error("a per-attempt HTTP timeout must be retryable; " +
+			"isRetryable is short-circuiting on context.DeadlineExceeded")
+	}
+}
+
 func TestIsRetryable(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1771,7 +2026,6 @@ func TestIsRetryable(t *testing.T) {
 		{"wrapped 503 still classifies", fmt.Errorf("gap 1: %w", &tempestapi.StatusError{HTTPStatus: 503}), true},
 		{"network error", fakeNetErr{}, true},
 		{"context canceled is the operator's decision", context.Canceled, false},
-		{"parent deadline exceeded aborts", context.DeadlineExceeded, false},
 		{"unknown error", errors.New("boom"), false},
 	}
 	for _, tt := range tests {
@@ -1846,16 +2100,29 @@ func chunkWindow(from, to time.Time, size time.Duration) []window {
 // Classification uses errors.As, NOT errors.AsType — that is Go 1.26 and
 // go.mod declares go 1.25.0.
 //
-// Context cancellation is never retried: it is the operator's decision, and a
-// blown parent deadline would only fail again immediately. Per-attempt
-// timeouts do not arrive here as context errors — the client sets its own 30s
-// http.Client.Timeout (tempestapi/client.go:42), which surfaces as a
-// net.Error and is retried through that branch.
+// DO NOT add a `errors.Is(err, context.DeadlineExceeded) -> false` guard here.
+// It looks obviously correct and it is a serious bug. http.Client.Timeout is
+// IMPLEMENTED as a context deadline, so a per-attempt timeout produces a
+// *url.Error that satisfies BOTH errors.Is(err, context.DeadlineExceeded) AND
+// errors.As(err, &netErr):
+//
+//	Get "...": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+//	errors.Is(err, context.DeadlineExceeded) = true
+//	errors.As(err, &net.Error)               = true
+//
+// Such a guard therefore classifies EVERY slow API response as permanent,
+// failing the whole gap on the first try with zero retries — the single most
+// likely transient failure in a tool issuing thousands of sequential requests.
+// Timeouts must fall through to the net.Error branch below.
+//
+// Whether the PARENT context is done is a separate question, answered at the
+// call site with ctx.Err(), not by inspecting this error's identity.
+// context.Canceled is the one blanket signal: it is the operator's decision.
 func isRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) {
 		return false
 	}
 
@@ -2128,7 +2395,7 @@ git commit -m "feat(backfill): assemble head, tail, and empty-store gaps around 
       MinGap   time.Duration
       DryRun   bool
   }
-  type Stats struct{ Gaps, Requested, Inserted, Failed int }
+  type Stats struct{ Gaps, Returned, Inserted, Failed int }
   type ObservationSource interface {
       Observations(ctx context.Context, station tempestapi.Station, start, end time.Time) ([]weather.Observation, error)
   }
@@ -2186,10 +2453,19 @@ func (f *fakeSource) Observations(_ context.Context, _ tempestapi.Station, start
 }
 
 type fakeStore struct {
+	// serials is what DistinctSerials returns — the UNWINDOWED whole-table
+	// serial set the pre-flight check uses. It is deliberately independent of
+	// bounds, because the two queries genuinely differ: a serial can be in the
+	// store (serials) yet have no rows inside the queried window (bounds).
+	serials   []string
 	bounds    []weather.Bounds
 	gaps      []weather.Gap
 	inserted  [][]weather.Observation
 	insertErr error
+}
+
+func (f *fakeStore) DistinctSerials(context.Context) ([]string, error) {
+	return f.serials, nil
 }
 
 func (f *fakeStore) SeriesBounds(context.Context, time.Time, time.Time) ([]weather.Bounds, error) {
@@ -2220,7 +2496,9 @@ func obsAt(serial string, epoch int64) weather.Observation {
 	return weather.Observation{SerialNumber: serial, Timestamp: time.Unix(epoch, 0).UTC()}
 }
 
-func at(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+// at is ts (defined in gaps_test.go — same package) under the name these
+// tests read better with. A one-line alias, not a second implementation.
+func at(epoch int64) time.Time { return ts(epoch) }
 
 // --- tests ---
 
@@ -2250,9 +2528,13 @@ func TestRunDryRunMakesNoAPICallsAndNoWrites(t *testing.T) {
 
 func TestRunSerialMismatchIsHardStopWithNoWrites(t *testing.T) {
 	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
-	// The store holds a DIFFERENT serial than the API reports. Writing would
-	// create a parallel series that never dedupes.
-	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-OTHER", First: at(1000), Last: at(2000)}}}
+	// The store holds ONLY a different serial than the API reports — the two
+	// sets are disjoint, which is the signature of format divergence. Writing
+	// would create a parallel series that never dedupes.
+	store := &fakeStore{
+		serials: []string{"ST-OTHER"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-OTHER", First: at(1000), Last: at(2000)}},
+	}
 
 	_, err := Run(t.Context(),
 		Config{MinGap: 30 * time.Minute},
@@ -2283,6 +2565,85 @@ func TestRunEmptyStoreIsNotASerialMismatch(t *testing.T) {
 	}
 	if stats.Gaps == 0 {
 		t.Error("empty store should yield the whole range as one gap")
+	}
+}
+
+// Regression: adding a second station to the account must not brick backfill.
+// The sets overlap (ST-A is in both), so this is not format divergence — and
+// ST-B, which the store has never seen, should simply get a whole-range gap.
+func TestRunNewSerialAlongsideKnownSerialIsNotAMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-B", 5000)}}
+	store := &fakeStore{
+		serials: []string{"ST-A"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(199000)}},
+	}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A"), station("ST-B")}, at(200000))
+	if err != nil {
+		t.Fatalf("a new serial alongside a known one must not be a mismatch: %v", err)
+	}
+	if stats.Gaps == 0 {
+		t.Error("the new serial ST-B should yield a whole-range gap")
+	}
+	if stats.Inserted == 0 {
+		t.Error("the new serial's gap should have been fetched and inserted")
+	}
+}
+
+// Regression for the windowed-bounds bug: the pre-flight check must read
+// DistinctSerials (whole table), not SeriesBounds (windowed). A station that
+// simply had no rows inside the requested window is not missing from the
+// store, and `backfill --from X --to Y` is the tool's main repair path.
+func TestRunQuietSerialInRequestedWindowIsNotAMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-B", 5000)}}
+	store := &fakeStore{
+		// Both serials exist in the store...
+		serials: []string{"ST-A", "ST-B"},
+		// ...but only ST-A has rows inside the queried window.
+		bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(2000)}},
+	}
+
+	from := at(0)
+	_, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A"), station("ST-B")}, from.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("a serial with no rows in the requested window must not be a mismatch: %v", err)
+	}
+}
+
+// A permanently failing window must not abandon the windows behind it. If it
+// does, those windows are never requested on ANY future run and the tool
+// silently stops converging.
+func TestFillGapContinuesAfterAFailedWindow(t *testing.T) {
+	src := &fakeSource{
+		obs: []weather.Observation{obsAt("ST-A", 5000)},
+		// Window 1 succeeds, window 2 fails permanently (a status_code is not
+		// retryable, so exactly one call), window 3 succeeds.
+		errs: []error{nil, &tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}, nil},
+	}
+	store := &fakeStore{}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour) // three 24h windows
+
+	stats, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+
+	if err == nil {
+		t.Fatal("the gap must still be reported failed")
+	}
+	if len(src.calls) != 3 {
+		t.Errorf("made %d API calls, want 3 — window 3 must still be attempted after window 2 fails", len(src.calls))
+	}
+	if stats.Inserted != 2 {
+		t.Errorf("Inserted = %d, want 2 (windows 1 and 3 both landed)", stats.Inserted)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
 	}
 }
 
@@ -2438,6 +2799,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"tempestwx-utilities/internal/tempestapi"
@@ -2489,11 +2851,22 @@ type Config struct {
 
 // Stats is what the run did, in aggregate.
 type Stats struct {
-	Gaps      int // holes detected
-	Requested int // observations returned by the API
-	Inserted  int // rows actually new (0 across runs => a permanent hole)
-	Failed    int // gaps that failed after retries
+	Gaps int // holes detected
+	// Returned counts observations the API actually handed back, AFTER
+	// malformed tuples were dropped. It is not "rows requested" — the closed
+	// gap interval and the shared chunk-window endpoints both mean a few
+	// observations are fetched more than once.
+	Returned int
+	Inserted int // rows actually new (0 across runs => a permanent hole)
+	Failed   int // gaps that failed after retries
 }
+
+// NOTE: dropped-tuple counts are deliberately NOT here. They are logged at
+// WARN by the decode itself (Task 3), which is where the information exists.
+// Threading a diagnostic counter up through ObservationSource would widen the
+// seam between backfill and the REST client to carry a reporting nicety, and
+// the log stream is already the machine-readable surface this design chose
+// when it cut the bespoke summary line.
 
 // ObservationSource is the REST client, narrowed to what backfill needs.
 // *tempestapi.Client satisfies it.
@@ -2507,6 +2880,11 @@ type ObservationSource interface {
 // consumer, per Go convention; the adapters that bind a *sql.DB or
 // *pgxpool.Pool to it live in the command shell.
 type Store interface {
+	// DistinctSerials is UNWINDOWED — the whole table. It exists only for the
+	// pre-flight check and must NOT be replaced by SeriesBounds' key set:
+	// SeriesBounds is windowed, so a station that was simply quiet during the
+	// requested window would look absent from the store and trip the check.
+	DistinctSerials(ctx context.Context) ([]string, error)
 	SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
 	FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
 	InsertObservations(ctx context.Context, obs []weather.Observation) (int, error)
@@ -2532,13 +2910,17 @@ func Run(
 
 	detectFrom, detectTo := detectionRange(cfg, stations, now)
 
+	storedSerials, err := store.DistinctSerials(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("distinct serials: %w", err)
+	}
+	if err := preflight(stations, storedSerials); err != nil {
+		return stats, err
+	}
+
 	bounds, err := store.SeriesBounds(ctx, detectFrom, detectTo)
 	if err != nil {
 		return stats, fmt.Errorf("series bounds: %w", err)
-	}
-
-	if err := preflight(stations, bounds); err != nil {
-		return stats, err
 	}
 
 	gaps, err := plannedGaps(ctx, cfg, store, stations, bounds, detectFrom, detectTo)
@@ -2562,8 +2944,8 @@ func Run(
 
 	var failures []error
 	for _, g := range gaps {
-		requested, inserted, err := fillGap(ctx, src, store, byserial[g.SerialNumber], g)
-		stats.Requested += requested
+		returned, inserted, err := fillGap(ctx, src, store, byserial[g.SerialNumber], g)
+		stats.Returned += returned
 		stats.Inserted += inserted
 
 		if err != nil {
@@ -2580,13 +2962,13 @@ func Run(
 			continue
 		}
 
-		// requested vs inserted is what makes the permanent-hole tradeoff
+		// returned vs inserted is what makes the permanent-hole tradeoff
 		// visible: if the station was genuinely offline, the API has no data
 		// either and inserted stays 0 across runs. Structured attrs are the
 		// machine-readable surface — no bespoke summary format.
 		slog.Info("backfill: gap filled",
 			"serial", g.SerialNumber, "from", g.From, "to", g.To,
-			"requested", requested, "inserted", inserted)
+			"returned", returned, "inserted", inserted)
 	}
 
 	if len(failures) > 0 {
@@ -2645,64 +3027,109 @@ func plannedGaps(
 	return assembleGaps(interior, bounds, serials, detectFrom, detectTo, cfg.MinGap), nil
 }
 
-// preflight refuses to run when the API reports a serial the store has never
-// seen.
+// preflight refuses to run when the API's serials and the store's serials are
+// DISJOINT — no API serial appears in the store at all.
 //
 // Dedupe, gap closure, and convergence all require that the serial backfill
-// writes exactly matches the serial UDP ingest writes. If they diverge,
-// backfill writes a PARALLEL SERIES under a second serial: UNIQUE never
-// fires, rows double, and the gap never closes — silently and cumulatively.
-// So this is a hard stop, not a warning: warning-then-writing-anyway names an
-// outcome as corrupting and then produces it.
+// writes exactly matches the serial UDP ingest writes. If the two formats
+// diverge, backfill writes a PARALLEL SERIES under a second serial: UNIQUE
+// never fires, rows double, and the gap never closes — silently and
+// cumulatively. So this is a hard stop, not a warning: warning-then-writing-
+// anyway names an outcome as corrupting and then produces it.
 //
-// An EMPTY store is not a mismatch. It is the first-run case, where every gap
-// is legitimately new.
-func preflight(stations []tempestapi.Station, bounds []weather.Bounds) error {
-	if len(bounds) == 0 {
+// DISJOINT is the rule, and the distinction is load-bearing. The tempting
+// version — "some API serial is absent from a non-empty store" — fires on two
+// completely ordinary situations and would brick the tool for both:
+//
+//   - A second station on the account whose broadcasts this host never hears
+//     (different VLAN/subnet). Its serial will NEVER enter the store, so
+//     backfill would refuse to run, including for the healthy station.
+//   - A newly added station, whose first backfill would exit non-zero having
+//     written nothing — permanently, until the daemon happened to ingest a row.
+//
+// Neither is format divergence. Under the disjoint rule both proceed, and a
+// serial the API knows but the store has not seen simply becomes a whole-range
+// gap, which is exactly assembleGaps' job.
+//
+// storedSerials MUST come from DistinctSerials (unwindowed), never from
+// SeriesBounds' key set — see the Store interface comment.
+//
+// An EMPTY store is not a mismatch: it is the first-run case.
+func preflight(stations []tempestapi.Station, storedSerials []string) error {
+	if len(storedSerials) == 0 {
 		return nil
 	}
-	stored := make(map[string]struct{}, len(bounds))
-	for _, b := range bounds {
-		stored[b.SerialNumber] = struct{}{}
+	stored := make(map[string]struct{}, len(storedSerials))
+	for _, s := range storedSerials {
+		stored[s] = struct{}{}
 	}
-	var missing []error
-	for _, s := range stations {
-		if _, ok := stored[s.SerialNumber]; !ok {
-			missing = append(missing, fmt.Errorf("%w: API reports %q, store has none of it",
-				ErrSerialMismatch, s.SerialNumber))
+	for _, st := range stations {
+		if _, ok := stored[st.SerialNumber]; ok {
+			return nil // at least one serial matches: not divergence
 		}
 	}
-	return errors.Join(missing...)
+
+	apiSerials := make([]string, 0, len(stations))
+	for _, st := range stations {
+		apiSerials = append(apiSerials, st.SerialNumber)
+	}
+	return fmt.Errorf("%w: API reports %v, store holds %v — no overlap at all, "+
+		"which means the two are using different serial formats; backfilling would "+
+		"create a parallel series that never dedupes",
+		ErrSerialMismatch, apiSerials, storedSerials)
 }
 
 // fillGap fetches and inserts one gap, chunked and retried.
+//
+// A failed WINDOW does not abandon the gap. Returning here on the first bad
+// window would discard every remaining window, and for a DETERMINISTIC
+// per-window failure that loss is permanent across runs, not transient:
+// once the earlier windows land, the head gap collapses and the hole
+// reappears as an interior gap starting at the same bad window, which fails
+// again — so the windows behind it are never requested on ANY run. A tool
+// whose entire premise is convergence would silently stop converging, and the
+// inserted=0 signal never even fires because those windows are never
+// requested. So: log, accumulate, keep going, and fail the gap at the end.
+//
+// An INSERT error is different and does abort the gap: it means the store is
+// unhealthy, and hammering it with the remaining windows helps nobody.
 func fillGap(
 	ctx context.Context,
 	src ObservationSource,
 	store Store,
 	station tempestapi.Station,
 	g weather.Gap,
-) (requested, inserted int, err error) {
+) (returned, inserted int, err error) {
+	var windowErrs []error
+
 	for _, w := range chunkWindow(g.From, g.To, chunkSize) {
 		if err := ctx.Err(); err != nil {
-			return requested, inserted, err
+			return returned, inserted, err
 		}
 
 		obs, err := fetchWithRetry(ctx, src, station, w)
 		if err != nil {
-			return requested, inserted, err
+			if ctx.Err() != nil {
+				return returned, inserted, ctx.Err()
+			}
+			slog.Error("backfill: window failed, continuing with the rest of the gap",
+				"serial", station.SerialNumber, "from", w.from, "to", w.to, "error", err)
+			windowErrs = append(windowErrs, fmt.Errorf("window [%s, %s]: %w",
+				w.from.Format(time.RFC3339), w.to.Format(time.RFC3339), err))
+			continue
 		}
-		requested += len(obs)
+		returned += len(obs)
 
-		for chunk := range batches(obs, insertBatchSize) {
+		for chunk := range slices.Chunk(obs, insertBatchSize) {
 			n, err := store.InsertObservations(ctx, chunk)
 			if err != nil {
-				return requested, inserted, fmt.Errorf("insert: %w", err)
+				return returned, inserted, fmt.Errorf("insert: %w", err)
 			}
 			inserted += n
 		}
 	}
-	return requested, inserted, nil
+
+	return returned, inserted, errors.Join(windowErrs...)
 }
 
 // fetchWithRetry applies bounded exponential backoff to transient failures.
@@ -2738,18 +3165,6 @@ func fetchWithRetry(
 		}
 	}
 	return nil, fmt.Errorf("after %d attempts: %w", maxAttempts, lastErr)
-}
-
-// batches yields obs in slices of at most size.
-func batches(obs []weather.Observation, size int) func(func([]weather.Observation) bool) {
-	return func(yield func([]weather.Observation) bool) {
-		for start := 0; start < len(obs); start += size {
-			end := min(start+size, len(obs))
-			if !yield(obs[start:end]) {
-				return
-			}
-		}
-	}
 }
 ```
 
@@ -3113,7 +3528,7 @@ func runBackfill(ctx context.Context, args []string) int {
 
 	stats, err := backfill.Run(ctx, cfg, client, store, stations, time.Now().UTC())
 	slog.Info("backfill: complete",
-		"gaps", stats.Gaps, "requested", stats.Requested,
+		"gaps", stats.Gaps, "returned", stats.Returned,
 		"inserted", stats.Inserted, "failed", stats.Failed, "dry_run", cfg.DryRun)
 	if err != nil {
 		slog.Error("backfill: finished with failures", "error", err)

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -3032,6 +3032,12 @@ func TestRunNewSerialAlongsideKnownSerialIsNotAMismatch(t *testing.T) {
 // bounds={ST-OLD} does NOT overlap it, so feeding preflight the windowed key
 // set would report a false mismatch. A fixture where both inputs contain an
 // overlapping serial cannot tell the two apart and would pass either way.
+//
+// It must ALSO run on the auto-detect path (no --from/--to). Run skips the
+// SeriesBounds query entirely on the explicit-range path, so under that
+// config a mutated preflight would receive an empty slice, read it as
+// "empty store, not a mismatch", and return nil — passing for the wrong
+// reason. Do not add From/To to this test.
 func TestRunQuietSerialInRequestedWindowIsNotAMismatch(t *testing.T) {
 	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
 	store := &fakeStore{
@@ -3042,12 +3048,12 @@ func TestRunQuietSerialInRequestedWindowIsNotAMismatch(t *testing.T) {
 		bounds: []weather.Bounds{{SerialNumber: "ST-OLD", First: at(1000), Last: at(2000)}},
 	}
 
-	from := at(0)
+	// Auto-detect (no From/To) so SeriesBounds is genuinely consulted.
 	_, err := Run(t.Context(),
-		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
-		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
 	if err != nil {
-		t.Fatalf("a serial with no rows in the requested window must not be a mismatch: %v", err)
+		t.Fatalf("a serial with no rows in the detection window must not be a mismatch: %v", err)
 	}
 }
 

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -1,0 +1,3336 @@
+# API Backfill Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **For Claude:** REQUIRED EXECUTION WORKFLOW (follow in order):
+> 1. `superpowers:using-git-worktrees` — **already satisfied**; work in `~/Projects/github/tempestwx-exporter/.claude/worktrees/api-backfill` on branch `worktree-api-backfill`. Do NOT create a new worktree.
+> 2. `superpowers:subagent-driven-development` — Dispatch a fresh subagent per task
+> 3. `superpowers:test-driven-development` — All subagents use TDD
+> 4. `superpowers:verification-before-completion` — Verify all tests pass per task
+> 5. `superpowers:requesting-code-review` — Code review after each task (built in)
+> 6. After all tasks: comprehensive cold review on the full diff from branch point
+> 7. `superpowers:finishing-a-development-branch` — Complete the branch
+>
+> Skills carry their own model and effort settings. Do not override them.
+
+**Goal:** Add a `backfill` subcommand that finds holes in the local observation history and fills them from the Tempest REST API, idempotently and safely re-runnably.
+
+**Architecture:** A new leaf package `internal/weather` owns the store-neutral `Observation` and `Gap` types. The two store packages gain package-level functions (not writer methods — the writer's single-goroutine invariant forbids it) for gap detection and insertion. A new `internal/backfill` package holds a testable core with all dependencies injected, including the clock. `main.go` gains a thin shell and a real subcommand dispatch.
+
+**Tech Stack:** Go 1.25, `database/sql` + `modernc.org/sqlite` (CGO_ENABLED=0), `pgx/v5` + `pgxpool`, stdlib `flag`, `log/slog`, stdlib testing (no testify).
+
+**Design:** `docs/designs/2026-07-28-api-backfill-tool-design.md` — read it before starting. This plan implements it; where they disagree, the design wins and the plan is wrong.
+
+## Global Constraints
+
+- **Go 1.25 floor** (`go.mod` says `go 1.25.0`). **No Go 1.26-only APIs** — in particular use `errors.As`, **never** `errors.AsType`.
+- **`CGO_ENABLED=0` must stay buildable.** No new cgo dependencies.
+- **Zero new module dependencies.** Nothing gets added to `go.mod`.
+- **`log/slog` for all new code.** Do not add `log.Printf` call sites; do not convert existing ones.
+- **No goroutines** in any new package-level store function. The `sqlite.Writer.run` goroutine is documented as "the only goroutine that ever touches db" — new functions take a `*sql.DB` / `*pgxpool.Pool` directly and must not be methods on the writer types.
+- **`sqlite.Open` sets `db.SetMaxOpenConns(1)`** (`internal/sqlite/db.go:73`). Any query must fully materialize its results and close its `*sql.Rows` before another query or insert runs on the same handle. A streaming iterator would deadlock with no error and no timeout.
+- **Timestamps are UTC.** SQLite stores unix-epoch `INTEGER`; Postgres stores `TIMESTAMPTZ`. Conversion happens at the SQLite boundary only.
+- **Tests use repo idiom:** `t.Context()`, `t.TempDir()`, stdlib table-driven subtests, no testify.
+- **The full gate must pass before any task is reported complete:**
+  ```bash
+  CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+  ```
+  `gofmt -l .` must print **nothing**. Paste real output; do not assert success without it.
+- **Work in the existing worktree.** Every task begins by confirming `pwd` ends in `.claude/worktrees/api-backfill` and that `docs/designs/2026-07-28-api-backfill-tool-design.md` exists. If not, STOP and report `NEEDS_CONTEXT`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/weather/observation.go` | **Create.** Store-neutral `Observation` + `Gap` + `Bounds`. Imports nothing from this repo. |
+| `internal/tempestapi/errors.go` | **Create.** `StatusError` — the typed error the retry layer classifies on. |
+| `internal/tempestapi/client.go` | **Modify.** Export `Station.SerialNumber`/`.DeviceID`. |
+| `internal/tempestapi/observations.go` | **Create.** `Client.Observations` — nullable decode, status handling, empty windows. |
+| `internal/postgres/pool.go` | **Create.** `OpenPool` — the single source of pool tuning. |
+| `internal/postgres/writer.go` | **Modify.** `NewPostgresWriter` calls `OpenPool`. |
+| `internal/sqlite/backfill.go` | **Create.** `SeriesBounds`, `FindObservationGaps`, `InsertObservations` over `*sql.DB`. |
+| `internal/postgres/backfill.go` | **Create.** Same three functions over `*pgxpool.Pool`. |
+| `internal/backfill/window.go` | **Create.** Pure chunking + retry classification. |
+| `internal/backfill/gaps.go` | **Create.** Detection-domain assembly (head/tail/interior/empty). |
+| `internal/backfill/backfill.go` | **Create.** `Run` — the testable core, plus `Config`, `Stats`, and the two consumer-side interfaces. |
+| `main.go` | **Modify.** `runBackfill` shell + subcommand dispatch. |
+| `CLAUDE.md` | **Modify.** Resolve the name collision, document the subcommand. |
+
+**Dependency order:** T1 → (T2, T4 parallel) → T3 → (T5, T6 parallel) → T7 → T8 → T9 → T10 → T11.
+
+---
+
+### Task 1: `internal/weather` — store-neutral types
+
+**Files:**
+- Create: `internal/weather/observation.go`
+- Test: `internal/weather/observation_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `weather.Observation`, `weather.Gap`, `weather.Bounds` — used by every subsequent task.
+
+**Why this package exists:** both store packages and the REST client must name these types. They cannot live in `tempestapi` (storage would depend on the REST client), cannot live in `tempestudp` (that package is the UDP wire protocol, and `tempestudp.Gap` would be a lie), and cannot live in `internal/backfill` (`FindObservationGaps` is a package-level function *in the store packages*, so they would have to import their own consumer). `internal/weather` imports nothing from this repo, so nothing can cycle.
+
+**Nullability:** every measurement field is `*float64`. The SQLite DDL declares every column except `id`, `serial_number`, and `timestamp` as nullable (`internal/sqlite/migrations/0001_init.sql:2-14`), and the API may return JSON `null` for any element. `InsertObservations` binds these pointers straight into the query — `database/sql` and `pgx` both map a nil `*float64` to SQL NULL — so this type never funnels through the stores' private `observationRow`, whose first thirteen fields are non-pointer `float64` and would silently coerce a null to `0.0`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/weather/observation_test.go`:
+
+```go
+package weather
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGapDuration(t *testing.T) {
+	g := Gap{
+		SerialNumber: "ST-00000001",
+		From:         time.Unix(1000, 0).UTC(),
+		To:           time.Unix(4600, 0).UTC(),
+	}
+	if got, want := g.Duration(), time.Hour; got != want {
+		t.Errorf("Duration() = %v, want %v", got, want)
+	}
+}
+
+func TestObservationNullableFieldsDefaultNil(t *testing.T) {
+	var o Observation
+	if o.Pressure != nil {
+		t.Error("Pressure should default to nil (SQL NULL), not a zero value")
+	}
+	if o.TempWetbulb != nil {
+		t.Error("TempWetbulb should default to nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/weather/ -run 'TestGap|TestObservation' -v`
+Expected: FAIL — the package does not exist (`no Go files in .../internal/weather`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/weather/observation.go`:
+
+```go
+// Package weather holds the store-neutral representation of a weather
+// observation and of a hole in an observation series.
+//
+// It deliberately imports nothing else in this repository. Both store
+// packages (internal/sqlite, internal/postgres) and the REST client
+// (internal/tempestapi) name these types, so any home that imported one of
+// them would create a cycle. It is not the UDP wire protocol — that is
+// internal/tempestudp — and these types must not be added there.
+package weather
+
+import "time"
+
+// Observation is one tempest_observations row in store-neutral form.
+//
+// Every measurement is a *float64 because the SQLite and Postgres DDL declare
+// every column except id/serial_number/timestamp as nullable, and the Tempest
+// REST API may return JSON null for any element of an obs tuple. A nil here
+// means SQL NULL; database/sql and pgx both bind it that way directly.
+//
+// This is deliberately NOT the stores' private observationRow types, whose
+// leading fields are non-pointer float64: unmarshalling a JSON null into a
+// non-pointer numeric is a silent no-op that yields 0.0, which would write
+// "pressure = 0.0 mb" where the API said "unknown". See the design's
+// "Nullability — mandatory" section.
+type Observation struct {
+	// SerialNumber and Timestamp are the series key and are never NULL.
+	// An observation whose ob[0] is null cannot be keyed and is dropped
+	// at decode time rather than represented here.
+	SerialNumber string
+	Timestamp    time.Time
+
+	WindLull             *float64 // obs_st[1]
+	WindAvg              *float64 // obs_st[2]
+	WindGust             *float64 // obs_st[3]
+	WindDirection        *float64 // obs_st[4]
+	WindSampleInterval   *float64 // obs_st[5]
+	Pressure             *float64 // obs_st[6], raw mb (no conversion)
+	TempAir              *float64 // obs_st[7]
+	Humidity             *float64 // obs_st[8]
+	Illuminance          *float64 // obs_st[9]
+	UVIndex              *float64 // obs_st[10]
+	Irradiance           *float64 // obs_st[11]
+	RainRate             *float64 // obs_st[12]
+	PrecipType           *float64 // obs_st[13]
+	LightningDistance    *float64 // obs_st[14]
+	LightningStrikeCount *float64 // obs_st[15]
+	Battery              *float64 // obs_st[16]
+	ReportInterval       *float64 // obs_st[17]
+
+	// TempWetbulb is derived in Go, not returned by the API. It is computed
+	// at the store boundary with the same tempestudp.WetBulbTemperatureC +
+	// math.IsNaN guard the UDP ingest path uses, so backfilled and live rows
+	// are indistinguishable.
+	TempWetbulb *float64
+}
+
+// Gap is a half-open hole [From, To) in one station's observation series.
+// The series is keyed by (SerialNumber, Timestamp) — the same uniqueness
+// contract idempotent inserts rely on — so a Gap is meaningless without its
+// serial.
+type Gap struct {
+	SerialNumber string
+	From         time.Time
+	To           time.Time
+}
+
+// Duration is the width of the gap.
+func (g Gap) Duration() time.Duration { return g.To.Sub(g.From) }
+
+// Bounds is the first and last observation timestamp held for one serial
+// within a queried window. It is what lets the caller find head and tail
+// gaps, which a SQL LAG window function cannot see: LAG yields NULL for the
+// first row of each partition, so it finds interior gaps only.
+type Bounds struct {
+	SerialNumber string
+	First        time.Time
+	Last         time.Time
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/weather/ -v`
+Expected: PASS — both tests.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+Expected: build clean, vet clean, `gofmt -l .` prints nothing, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/weather/
+git commit -m "feat(weather): add store-neutral Observation, Gap, and Bounds types"
+```
+
+---
+
+### Task 2: `tempestapi` — export Station fields, add `StatusError`
+
+**Files:**
+- Modify: `internal/tempestapi/client.go:53-58` (struct), `:110-121` (construction), `:131` (`GetObservations` URL), `:160` (serial assignment)
+- Create: `internal/tempestapi/errors.go`
+- Test: `internal/tempestapi/errors_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `tempestapi.Station{Name string; StationID int; DeviceID int; SerialNumber string; CreatedAt time.Time}`
+  - `tempestapi.StatusError{HTTPStatus, StatusCode int; Message string}` with `func (e *StatusError) Error() string`
+
+**Why:** `Station.serialNumber` and `.deviceID` are currently **unexported** (`client.go:55-56`), so the serial pre-flight check cannot read a serial from outside the package. Export the fields rather than adding getters: `Station` is a plain data struct with three already-exported fields and no invariants to protect, so two getters would be pure ceremony.
+
+Three behaviors branch on the *kind* of error (retry on 429/5xx/network; a non-zero `status_code` is a real failure; exit non-zero if any gap failed). Without a typed error the retry layer could only string-match.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tempestapi/errors_test.go`:
+
+```go
+package tempestapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestStatusErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *StatusError
+		want string
+	}{
+		{
+			name: "api level status code",
+			err:  &StatusError{StatusCode: 404, Message: "NOT FOUND"},
+			want: "weatherflow status_code 404: NOT FOUND",
+		},
+		{
+			name: "http level status",
+			err:  &StatusError{HTTPStatus: 503},
+			want: "weatherflow API status 503",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The retry layer classifies with errors.As, so StatusError must survive
+// wrapping. NOTE: errors.As, never errors.AsType — that is Go 1.26 and
+// go.mod declares go 1.25.0.
+func TestStatusErrorUnwrapsThroughFmtErrorf(t *testing.T) {
+	wrapped := fmt.Errorf("fetch window: %w", &StatusError{HTTPStatus: 429})
+	var se *StatusError
+	if !errors.As(wrapped, &se) {
+		t.Fatal("errors.As failed to extract *StatusError from a wrapped error")
+	}
+	if se.HTTPStatus != 429 {
+		t.Errorf("HTTPStatus = %d, want 429", se.HTTPStatus)
+	}
+}
+
+func TestStationFieldsAreExported(t *testing.T) {
+	s := Station{SerialNumber: "ST-00000001", DeviceID: 42}
+	if s.SerialNumber != "ST-00000001" || s.DeviceID != 42 {
+		t.Error("Station.SerialNumber and Station.DeviceID must be settable from outside the package")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tempestapi/ -run 'TestStatusError|TestStationFields' -v`
+Expected: FAIL to compile — `undefined: StatusError`, and `unknown field SerialNumber in struct literal`.
+
+- [ ] **Step 3: Create the error type**
+
+Create `internal/tempestapi/errors.go`:
+
+```go
+package tempestapi
+
+import "fmt"
+
+// StatusError is a failed Tempest REST call, carrying enough structure for a
+// caller to decide whether retrying could help. It exists because three
+// behaviors branch on the KIND of failure — retry on 429/5xx/network, treat a
+// non-zero API status_code as a real failure, and exit non-zero if any gap
+// failed — and string-matching an opaque error is not a classification.
+//
+// Exactly one of the two codes is meaningful per instance:
+//
+//   - HTTPStatus != 0: the transport-level response was not 200. Transient
+//     for 429 and 5xx.
+//   - StatusCode != 0: the response was HTTP 200 but WeatherFlow reported an
+//     application-level failure in its status envelope. Never transient.
+//
+// Classify with errors.As, NOT errors.AsType (Go 1.26; go.mod declares 1.25.0).
+type StatusError struct {
+	HTTPStatus int    // HTTP response status, 0 when the failure is API-level
+	StatusCode int    // WeatherFlow status.status_code, 0 when purely HTTP
+	Message    string // WeatherFlow status.status_message, if any
+}
+
+func (e *StatusError) Error() string {
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("weatherflow status_code %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("weatherflow API status %d", e.HTTPStatus)
+}
+```
+
+- [ ] **Step 4: Export the Station fields**
+
+In `internal/tempestapi/client.go`, change the struct (currently at `:53-58`):
+
+```go
+type Station struct {
+	Name         string
+	StationID    int
+	DeviceID     int
+	SerialNumber string
+	CreatedAt    time.Time
+}
+```
+
+Update the construction site in `ListStations` (currently `:116-121`):
+
+```go
+		if deviceId != 0 && instance != "" {
+			out = append(out, Station{
+				Name:         station.Name,
+				DeviceID:     deviceId,
+				SerialNumber: instance,
+				StationID:    station.StationID,
+				CreatedAt:    time.Unix(station.CreatedEpoch, 0),
+			})
+		}
+```
+
+Update the two read sites in `GetObservations`:
+- `:131` — `station.deviceID` becomes `station.DeviceID`
+- `:160` — `r.SerialNumber = station.serialNumber` becomes `r.SerialNumber = station.SerialNumber`
+
+Do **not** change any other behavior in this file. In particular, leave the missing `break` in the device loop alone — `ModeAPIExport` depends on current behavior and fixing it is an explicit non-goal.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/tempestapi/ -v`
+Expected: PASS — the new tests plus the existing `client_test.go` suite unchanged.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+Expected: all clean. `go build ./...` catches any missed `station.deviceID` reference elsewhere in the repo.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/tempestapi/
+git commit -m "feat(tempestapi): export Station identity fields and add typed StatusError"
+```
+
+---
+
+### Task 3: `tempestapi.Client.Observations` — nullable decode
+
+**Files:**
+- Create: `internal/tempestapi/observations.go`
+- Test: `internal/tempestapi/observations_test.go`
+
+**Interfaces:**
+- Consumes: `weather.Observation` (Task 1), `StatusError` + exported `Station` fields (Task 2).
+- Produces: `func (c *Client) Observations(ctx context.Context, station Station, start, end time.Time) ([]weather.Observation, error)`
+
+**Naming:** `Observations`, not `GetObservationRows`. Go getters take no `Get` prefix, and "Rows" is storage vocabulary that has no business in a REST client. It coexists with the existing `GetObservations` (which returns `[]prometheus.Metric` for `ModeAPIExport` and is untouched).
+
+**Empty-window contract** (resolved from the published OpenAPI spec, so no token is needed to implement this): `ObservationSet` declares **no `required` array**, so neither `type` nor `obs` is required. Therefore `status_code == 0` is success; an absent, null, or empty `obs` is **zero rows, not an error**; an absent `type` is **not** an error. This method must **not** route through `tempestudp.ParseReport`, which dispatches on the top-level `type` and errors `unhandled message type: ""` on a status-only envelope — turning a legitimate empty window into a hard failure.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tempestapi/observations_test.go`:
+
+```go
+package tempestapi
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTestClient points a Client at an httptest.Server via the existing
+// WithBaseURL seam (client.go:35-39).
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient("test-token", WithBaseURL(srv.URL))
+}
+
+func TestObservationsMapsNullToNilNotZero(t *testing.T) {
+	// obs[6] (pressure) and obs[16] (battery) are null. They must decode to
+	// nil pointers, NOT 0.0 — a 0.0 mb pressure reads as real to
+	// SummarizeObservations' MIN(pressure) and to every chart.
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":[
+		[1700000000,0.1,0.2,0.3,180,3,null,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,null,1]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1", len(obs))
+	}
+	if obs[0].Pressure != nil {
+		t.Errorf("Pressure = %v, want nil (JSON null must not become 0.0)", *obs[0].Pressure)
+	}
+	if obs[0].Battery != nil {
+		t.Errorf("Battery = %v, want nil", *obs[0].Battery)
+	}
+	if obs[0].TempAir == nil || *obs[0].TempAir != 20.5 {
+		t.Errorf("TempAir = %v, want 20.5", obs[0].TempAir)
+	}
+	if obs[0].SerialNumber != "ST-1" {
+		t.Errorf("SerialNumber = %q, want %q", obs[0].SerialNumber, "ST-1")
+	}
+	if !obs[0].Timestamp.Equal(time.Unix(1700000000, 0).UTC()) {
+		t.Errorf("Timestamp = %v, want %v", obs[0].Timestamp, time.Unix(1700000000, 0).UTC())
+	}
+}
+
+func TestObservationsEmptyWindowIsNotAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"obs empty", `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":[]}`},
+		{"obs null", `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":null}`},
+		{"status only, no type, no obs", `{"status":{"status_code":0,"status_message":"SUCCESS - Either no capabilities or no recent observations"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			})
+			obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+			if err != nil {
+				t.Fatalf("empty window must not be an error, got %v", err)
+			}
+			if len(obs) != 0 {
+				t.Errorf("got %d observations, want 0", len(obs))
+			}
+		})
+	}
+}
+
+func TestObservationsNonZeroStatusCodeIsStatusError(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":{"status_code":404,"status_message":"NOT FOUND"}}`))
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 1}, time.Unix(0, 0), time.Unix(1, 0))
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("want *StatusError, got %T: %v", err, err)
+	}
+	if se.StatusCode != 404 || se.Message != "NOT FOUND" {
+		t.Errorf("got %+v, want StatusCode 404 / NOT FOUND", se)
+	}
+}
+
+func TestObservationsHTTPErrorIsStatusError(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 1}, time.Unix(0, 0), time.Unix(1, 0))
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("want *StatusError, got %T: %v", err, err)
+	}
+	if se.HTTPStatus != http.StatusServiceUnavailable {
+		t.Errorf("HTTPStatus = %d, want 503", se.HTTPStatus)
+	}
+}
+
+func TestObservationsSkipsRowWithNullTimestamp(t *testing.T) {
+	// A row with no timestamp cannot be keyed by (serial, timestamp) and
+	// must be dropped rather than written at the epoch.
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[
+		[null,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1],
+		[1700000000,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1 (the null-timestamp row must be dropped)", len(obs))
+	}
+}
+
+func TestObservationsRequestsCorrectWindow(t *testing.T) {
+	var gotQuery string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 77}, time.Unix(1700000000, 0), time.Unix(1700086400, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if want := "time_start=1700000000&time_end=1700086400"; gotQuery != want {
+		t.Errorf("query = %q, want %q", gotQuery, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tempestapi/ -run TestObservations -v`
+Expected: FAIL to compile — `c.Observations undefined (type *Client has no field or method Observations)`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/tempestapi/observations.go`:
+
+```go
+package tempestapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+// observationSet mirrors the Tempest ObservationSet response schema.
+//
+// Obs is [][]*float64, not [][]float64: unmarshalling a JSON null into a
+// non-pointer numeric is a silent no-op that yields 0.0, which would write a
+// physically meaningful "pressure = 0.0 mb" where the API said "unknown".
+// Backfill operates precisely on marginal windows, where nulls are most
+// likely. Do not "simplify" this to [][]float64 and do not reuse
+// tempestudp.TempestObservationReport, whose Obs is [][]float64.
+//
+// Every field is optional. The published OpenAPI schema declares no `required`
+// array for ObservationSet, so a response may legitimately omit both `type`
+// and `obs` — that is an empty window, not an error.
+type observationSet struct {
+	Status struct {
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
+	} `json:"status"`
+	Type string       `json:"type"`
+	Obs  [][]*float64 `json:"obs"`
+}
+
+// obs_st tuple indices. Indices 0-17 match the UDP layout exactly, so the
+// same field semantics apply. The REST array carries 22 elements; 18-21
+// (local-day rain accumulation, Nearcast accumulations, precip analysis type)
+// map to no column in tempest_observations and are ignored deliberately.
+const (
+	obsTimestamp = iota
+	obsWindLull
+	obsWindAvg
+	obsWindGust
+	obsWindDirection
+	obsWindSampleInterval
+	obsPressure
+	obsTempAir
+	obsHumidity
+	obsIlluminance
+	obsUVIndex
+	obsIrradiance
+	obsRainRate
+	obsPrecipType
+	obsLightningDistance
+	obsLightningStrikeCount
+	obsBattery
+	obsReportInterval
+	obsFieldCount // 18 — the number of indices this code reads
+)
+
+// Observations fetches raw historical observations for one device over
+// [start, end] and returns them in store-neutral form.
+//
+// It is deliberately separate from GetObservations, which returns
+// []prometheus.Metric for ModeAPIExport and routes through
+// tempestudp.ParseReport. ParseReport dispatches on the top-level `type` and
+// fails with `unhandled message type: ""` on a status-only envelope, which
+// would turn a legitimate empty window into a hard error.
+//
+// Derived columns are NOT computed here — this returns raw API fields only.
+// temp_wetbulb is derived at the store boundary so backfilled and live rows
+// stay indistinguishable.
+func (c *Client) Observations(ctx context.Context, station Station, start, end time.Time) ([]weather.Observation, error) {
+	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d",
+		c.baseURL, station.DeviceID, start.Unix(), end.Unix())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{HTTPStatus: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	var set observationSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("decode observation set: %w", err)
+	}
+
+	// A non-zero status_code is a real, non-transient API failure. A zero
+	// status_code with an absent/null/empty obs is an empty window: zero
+	// rows, no error.
+	if set.Status.StatusCode != 0 {
+		return nil, &StatusError{
+			StatusCode: set.Status.StatusCode,
+			Message:    set.Status.StatusMessage,
+		}
+	}
+
+	out := make([]weather.Observation, 0, len(set.Obs))
+	for _, ob := range set.Obs {
+		if len(ob) < obsFieldCount || ob[obsTimestamp] == nil {
+			// Short tuple or no timestamp: the row cannot be keyed by
+			// (serial_number, timestamp), so writing it would create an
+			// un-dedupable row at some arbitrary instant. Drop it.
+			continue
+		}
+		out = append(out, weather.Observation{
+			SerialNumber:         station.SerialNumber,
+			Timestamp:            time.Unix(int64(*ob[obsTimestamp]), 0).UTC(),
+			WindLull:             ob[obsWindLull],
+			WindAvg:              ob[obsWindAvg],
+			WindGust:             ob[obsWindGust],
+			WindDirection:        ob[obsWindDirection],
+			WindSampleInterval:   ob[obsWindSampleInterval],
+			Pressure:             ob[obsPressure],
+			TempAir:              ob[obsTempAir],
+			Humidity:             ob[obsHumidity],
+			Illuminance:          ob[obsIlluminance],
+			UVIndex:              ob[obsUVIndex],
+			Irradiance:           ob[obsIrradiance],
+			RainRate:             ob[obsRainRate],
+			PrecipType:           ob[obsPrecipType],
+			LightningDistance:    ob[obsLightningDistance],
+			LightningStrikeCount: ob[obsLightningStrikeCount],
+			Battery:              ob[obsBattery],
+			ReportInterval:       ob[obsReportInterval],
+		})
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tempestapi/ -run TestObservations -v`
+Expected: PASS — all six tests.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/tempestapi/observations.go internal/tempestapi/observations_test.go
+git commit -m "feat(tempestapi): add Observations with null-preserving decode"
+```
+
+---
+
+### Task 4: `postgres.OpenPool` — single-source the pool contract
+
+**Files:**
+- Create: `internal/postgres/pool.go`
+- Modify: `internal/postgres/writer.go:144-167`
+- Test: `internal/postgres/pool_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `func OpenPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error)`
+
+**Why:** there is currently **no way to obtain a `*pgxpool.Pool`**. `NewPostgresWriter` is the only constructor, and besides building the pool it pings, runs `CreateSchema`, and starts **four** background goroutines (`writer.go:190-199`) — all forbidden for a one-shot tool. Copying the five tuning lines out of `writer.go:151-155` would duplicate a genuine shared contract: change a pool setting and both callers must change together. So extract, and have `NewPostgresWriter` call it.
+
+`OpenPool` deliberately does **not** run `CreateSchema` — backfill calls it explicitly, so schema creation stays an observable step of the caller rather than a side effect of opening a pool.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/postgres/pool_test.go`:
+
+```go
+package postgres
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// OpenPool must reject a malformed URL before it attempts any connection, so
+// a bad POSTGRES_URL fails fast with a useful message rather than hanging.
+func TestOpenPoolRejectsBadURL(t *testing.T) {
+	pool, err := OpenPool(t.Context(), "://not-a-url")
+	if err == nil {
+		pool.Close()
+		t.Fatal("OpenPool accepted a malformed URL")
+	}
+	if !strings.Contains(err.Error(), "parse database url") {
+		t.Errorf("error = %q, want it to mention parse database url", err)
+	}
+}
+
+// The pool tuning is a shared contract between OpenPool and
+// NewPostgresWriter. This pins the values so a change has to be deliberate.
+func TestPoolConfigValues(t *testing.T) {
+	cfg, err := poolConfig("postgres://u:p@localhost:5432/db")
+	if err != nil {
+		t.Fatalf("poolConfig: %v", err)
+	}
+	if cfg.MaxConns != 10 {
+		t.Errorf("MaxConns = %d, want 10", cfg.MaxConns)
+	}
+	if cfg.MinConns != 2 {
+		t.Errorf("MinConns = %d, want 2", cfg.MinConns)
+	}
+	if cfg.MaxConnLifetime != time.Hour {
+		t.Errorf("MaxConnLifetime = %v, want 1h", cfg.MaxConnLifetime)
+	}
+	if cfg.MaxConnIdleTime != 10*time.Minute {
+		t.Errorf("MaxConnIdleTime = %v, want 10m", cfg.MaxConnIdleTime)
+	}
+	if cfg.HealthCheckPeriod != 30*time.Second {
+		t.Errorf("HealthCheckPeriod = %v, want 30s", cfg.HealthCheckPeriod)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/postgres/ -run 'TestOpenPool|TestPoolConfig' -v`
+Expected: FAIL to compile — `undefined: OpenPool`, `undefined: poolConfig`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/postgres/pool.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// poolConfig is the single authoritative representation of this application's
+// pgx pool tuning. Both NewPostgresWriter (the long-running daemon writer) and
+// OpenPool (one-shot tools such as backfill) build from it, so a change to any
+// value applies to both — which is exactly the shared-knowledge test that
+// justifies extracting it rather than copying five lines.
+func poolConfig(databaseURL string) (*pgxpool.Config, error) {
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse database url: %w", err)
+	}
+	config.MaxConns = 10
+	config.MinConns = 2
+	config.MaxConnLifetime = time.Hour
+	config.MaxConnIdleTime = 10 * time.Minute
+	config.HealthCheckPeriod = 30 * time.Second
+	return config, nil
+}
+
+// OpenPool opens and verifies a connection pool.
+//
+// It starts no goroutines and does NOT create the schema — unlike
+// NewPostgresWriter, which additionally runs CreateSchema and launches four
+// background batch workers. A one-shot tool needs the pool without any of
+// that, and calls CreateSchema explicitly so schema creation stays an
+// observable step of the caller rather than a side effect of opening a pool.
+//
+// The caller owns the returned pool and must Close it.
+func OpenPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
+	config, err := poolConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("create connection pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+	return pool, nil
+}
+```
+
+- [ ] **Step 4: Refactor `NewPostgresWriter` to call it**
+
+In `internal/postgres/writer.go`, replace the block currently at `:145-167` (from `config, err := pgxpool.ParseConfig(databaseURL)` through the `Ping` error check) with:
+
+```go
+	pool, err := OpenPool(ctx, databaseURL)
+	if err != nil {
+		return nil, err
+	}
+```
+
+Leave everything from `// Auto-create schema` onward unchanged. Then remove any import of `pgxpool` or `time` from `writer.go` **only if** `go build` reports it unused — `time` is used elsewhere in that file, so expect only `pgxpool` to possibly become unused. Let the compiler tell you; do not guess.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/postgres/ -run 'TestOpenPool|TestPoolConfig' -v`
+Expected: PASS — both tests.
+
+Run the package's existing suite: `go test ./internal/postgres/ -v`
+Expected: PASS, unchanged. (Integration tests requiring a live database skip when none is configured; that is pre-existing behavior.)
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/postgres/pool.go internal/postgres/pool_test.go internal/postgres/writer.go
+git commit -m "refactor(postgres): extract OpenPool as the single source of pool tuning"
+```
+
+---
+
+### Task 5: `internal/sqlite` — gap detection and idempotent insert
+
+**Files:**
+- Create: `internal/sqlite/backfill.go`
+- Test: `internal/sqlite/backfill_test.go`
+
+**Interfaces:**
+- Consumes: `weather.Observation`, `weather.Gap`, `weather.Bounds` (Task 1).
+- Produces (all package-level, all taking `*sql.DB`, none starting goroutines):
+  - `func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weather.Bounds, error)`
+  - `func FindObservationGaps(ctx context.Context, db *sql.DB, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)`
+  - `func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observation) (int, error)`
+
+**Why package-level functions, not `Writer` methods:** `Writer.run` is documented as "the only goroutine that ever touches db" (`writer.go:161,236`). Adding an insert method to that type would breach the single-writer invariant and make it callable from the daemon. Also, `WriteReport`'s enqueue path is non-blocking and **drops on saturation** (`writer.go:346-357`, channel cap 1000 at `:23`) — a single 1-day window is ~1440 rows, so reusing it would silently lose data.
+
+**`PARTITION BY serial_number` is not optional.** Without it, two stations phase-offset by ~30s produce a merged sequence in which no interval ever exceeds `minGap`, so a multi-hour outage on one station is undetectable and the tool reports "no gaps" and exits 0.
+
+**Do not stream.** `sqlite.Open` sets `db.SetMaxOpenConns(1)` (`db.go:73`). Both queries must fully materialize their slice and close `rows` before returning; a caller inserting while iterating would deadlock on the single connection with no error and no timeout.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/sqlite/backfill_test.go`:
+
+```go
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+)
+
+// seedObs inserts bare observation rows (serial + timestamp only; every other
+// column is nullable) so gap tests can express a series compactly.
+func seedObs(t *testing.T, db *sql.DB, serial string, epochs ...int64) {
+	t.Helper()
+	for _, e := range epochs {
+		_, err := db.ExecContext(context.Background(),
+			`INSERT INTO tempest_observations (id, serial_number, timestamp) VALUES (?, ?, ?)`,
+			uuid.Must(uuid.NewV7()).String(), serial, e)
+		if err != nil {
+			t.Fatalf("seed %s@%d: %v", serial, e, err)
+		}
+	}
+}
+
+func ts(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+
+// The regression test for the partitioning bug: two serials whose interleaved
+// timestamps mask each other. ST-A has a one-hour hole from 1000 to 4600.
+// ST-B reports throughout, offset by 30s. Merged and unpartitioned, no
+// consecutive interval exceeds minGap and the hole is invisible.
+func TestFindObservationGapsPartitionsBySerial(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 4600, 5200)
+	for e := int64(1030); e <= 5230; e += 600 {
+		seedObs(t, db, "ST-B", e)
+	}
+
+	gaps, err := FindObservationGaps(t.Context(), db, ts(0), ts(10000), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	if len(gaps) != 1 {
+		t.Fatalf("got %d gaps, want 1: %+v", len(gaps), gaps)
+	}
+	if gaps[0].SerialNumber != "ST-A" {
+		t.Errorf("SerialNumber = %q, want ST-A", gaps[0].SerialNumber)
+	}
+	if !gaps[0].From.Equal(ts(1000)) || !gaps[0].To.Equal(ts(4600)) {
+		t.Errorf("gap = [%v, %v], want [%v, %v]", gaps[0].From, gaps[0].To, ts(1000), ts(4600))
+	}
+}
+
+func TestFindObservationGapsIgnoresJitterBelowMinGap(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 1060, 1125, 1180) // ~1min apart
+	gaps, err := FindObservationGaps(t.Context(), db, ts(0), ts(10000), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	if len(gaps) != 0 {
+		t.Errorf("got %d gaps, want 0: %+v", len(gaps), gaps)
+	}
+}
+
+func TestSeriesBoundsPerSerial(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 2000, 3000)
+	seedObs(t, db, "ST-B", 5000, 6000)
+
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	got := map[string]weather.Bounds{}
+	for _, b := range bounds {
+		got[b.SerialNumber] = b
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d serials, want 2: %+v", len(got), bounds)
+	}
+	if !got["ST-A"].First.Equal(ts(1000)) || !got["ST-A"].Last.Equal(ts(3000)) {
+		t.Errorf("ST-A bounds = [%v, %v], want [1000, 3000]", got["ST-A"].First, got["ST-A"].Last)
+	}
+	if !got["ST-B"].First.Equal(ts(5000)) || !got["ST-B"].Last.Equal(ts(6000)) {
+		t.Errorf("ST-B bounds = [%v, %v], want [5000, 6000]", got["ST-B"].First, got["ST-B"].Last)
+	}
+}
+
+func TestSeriesBoundsEmptyTable(t *testing.T) {
+	db := newTestDB(t)
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds on empty table must not error: %v", err)
+	}
+	if len(bounds) != 0 {
+		t.Errorf("got %d bounds, want 0", len(bounds))
+	}
+}
+
+func f(v float64) *float64 { return &v }
+
+func TestInsertObservationsIsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+		{SerialNumber: "ST-A", Timestamp: ts(1060), TempAir: f(20.6), Humidity: f(56), Pressure: f(1013)},
+	}
+
+	n, err := InsertObservations(t.Context(), db, obs)
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("first insert = %d, want 2", n)
+	}
+
+	n, err = InsertObservations(t.Context(), db, obs)
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second insert = %d, want 0 (ON CONFLICT DO NOTHING)", n)
+	}
+
+	var count int
+	if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM tempest_observations`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("row count = %d, want 2", count)
+	}
+}
+
+func TestInsertObservationsPreservesNull(t *testing.T) {
+	db := newTestDB(t)
+	// Pressure is nil — it must land as SQL NULL, not 0.0.
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var pressure sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT pressure FROM tempest_observations`).Scan(&pressure); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if pressure.Valid {
+		t.Errorf("pressure = %v, want NULL", pressure.Float64)
+	}
+}
+
+func TestInsertObservationsDerivesWetBulb(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var wb sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT temp_wetbulb FROM tempest_observations`).Scan(&wb); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !wb.Valid {
+		t.Fatal("temp_wetbulb is NULL; it must be derived at the store boundary")
+	}
+	if wb.Float64 <= 0 || wb.Float64 >= 20.5 {
+		t.Errorf("temp_wetbulb = %v, want a plausible value below dry-bulb 20.5", wb.Float64)
+	}
+}
+
+func TestInsertObservationsWetBulbNullWhenInputsMissing(t *testing.T) {
+	db := newTestDB(t)
+	// No humidity: wet bulb is not derivable and must stay NULL rather than
+	// being computed from a zero value.
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Pressure: f(1013)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var wb sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT temp_wetbulb FROM tempest_observations`).Scan(&wb); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if wb.Valid {
+		t.Errorf("temp_wetbulb = %v, want NULL when humidity is absent", wb.Float64)
+	}
+}
+
+func TestInsertObservationsEmptyIsNoop(t *testing.T) {
+	db := newTestDB(t)
+	n, err := InsertObservations(t.Context(), db, nil)
+	if err != nil {
+		t.Fatalf("empty insert: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sqlite/ -run 'TestFindObservationGaps|TestSeriesBounds|TestInsertObservations' -v`
+Expected: FAIL to compile — `undefined: FindObservationGaps`, `undefined: SeriesBounds`, `undefined: InsertObservations`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sqlite/backfill.go`:
+
+```go
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"time"
+
+	"tempestwx-utilities/internal/tempestudp"
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+)
+
+// This file holds the backfill tool's read/write path. Everything here is a
+// package-level function taking *sql.DB, never a method on Writer:
+// Writer.run is documented as "the only goroutine that ever touches db"
+// (writer.go:161,236), so an insert method on that type would breach the
+// single-writer invariant and be callable from the daemon. Nothing here
+// starts a goroutine.
+//
+// IMPORTANT: sqlite.Open sets db.SetMaxOpenConns(1) (db.go:73). Every query
+// below fully materializes its result slice and closes its *sql.Rows before
+// returning. A streaming iterator that yielded rows while the caller inserted
+// would deadlock on the single connection with no error and no timeout. Do
+// not refactor these into iterators.
+
+// findObservationGapsSQL locates interior holes in each station's series.
+//
+// PARTITION BY serial_number is NOT optional. The series is identified by
+// (serial_number, timestamp) — the same uniqueness contract idempotency
+// relies on. Without partitioning, two stations phase-offset by ~30s produce
+// a merged sequence in which no consecutive interval ever exceeds minGap, so
+// a multi-hour outage on one station becomes undetectable and the tool
+// reports "no gaps" and exits 0. The same failure hides a hardware swap
+// (a new serial) behind an apparently continuous sequence.
+const findObservationGapsSQL = `
+	SELECT serial_number, prev, timestamp FROM (
+	  SELECT serial_number,
+	         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+	         timestamp
+	  FROM tempest_observations
+	  WHERE timestamp BETWEEN ? AND ?
+	) WHERE prev IS NOT NULL AND timestamp - prev > ?
+	ORDER BY serial_number, prev
+`
+
+// FindObservationGaps returns the interior gaps in [from, to] wider than
+// minGap, one per (serial, hole).
+//
+// LAG yields NULL for the first row of each partition, so this finds interior
+// gaps ONLY. Head and tail gaps — and the empty-table case — are assembled by
+// the caller from SeriesBounds; see internal/backfill.
+func FindObservationGaps(ctx context.Context, db *sql.DB, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	rows, err := db.QueryContext(ctx, findObservationGapsSQL, from.Unix(), to.Unix(), int64(minGap.Seconds()))
+	if err != nil {
+		return nil, fmt.Errorf("query observation gaps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var gaps []weather.Gap
+	for rows.Next() {
+		var serial string
+		var prev, next int64
+		if err := rows.Scan(&serial, &prev, &next); err != nil {
+			return nil, fmt.Errorf("scan observation gap: %w", err)
+		}
+		gaps = append(gaps, weather.Gap{
+			SerialNumber: serial,
+			From:         time.Unix(prev, 0).UTC(),
+			To:           time.Unix(next, 0).UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate observation gaps: %w", err)
+	}
+	return gaps, nil
+}
+
+const seriesBoundsSQL = `
+	SELECT serial_number, MIN(timestamp), MAX(timestamp)
+	FROM tempest_observations
+	WHERE timestamp BETWEEN ? AND ?
+	GROUP BY serial_number
+	ORDER BY serial_number
+`
+
+// SeriesBounds returns the first and last observation timestamp held for each
+// serial within [from, to]. An empty result means the store holds nothing in
+// that window — the first-run case, where the whole range is one gap.
+func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weather.Bounds, error) {
+	rows, err := db.QueryContext(ctx, seriesBoundsSQL, from.Unix(), to.Unix())
+	if err != nil {
+		return nil, fmt.Errorf("query series bounds: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []weather.Bounds
+	for rows.Next() {
+		var serial string
+		var first, last int64
+		if err := rows.Scan(&serial, &first, &last); err != nil {
+			return nil, fmt.Errorf("scan series bounds: %w", err)
+		}
+		out = append(out, weather.Bounds{
+			SerialNumber: serial,
+			First:        time.Unix(first, 0).UTC(),
+			Last:         time.Unix(last, 0).UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate series bounds: %w", err)
+	}
+	return out, nil
+}
+
+// InsertObservations writes obs idempotently and reports how many rows were
+// actually new.
+//
+// The count is what makes the permanent-hole tradeoff visible: if the station
+// was genuinely offline, the API has no data either, and inserted stays 0
+// across runs. ON CONFLICT (serial_number, timestamp) DO NOTHING is backed by
+// a real UNIQUE constraint (migrations/0001_init.sql:13), and per-row
+// RowsAffected returns 0 for a skipped conflict and 1 for an insert.
+//
+// The count is returned only after a successful Commit — execBatch rolls the
+// whole transaction back on any row error.
+//
+// The caller bounds len(obs) to keep the transaction short; see the design's
+// "Concurrency with a running daemon".
+//
+// Binding is direct from weather.Observation rather than through the private
+// observationRow used by the UDP path: that type's leading fields are
+// non-pointer float64, so routing through it would coerce a JSON null to 0.0.
+func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observation) (int, error) {
+	if len(obs) == 0 {
+		return 0, nil
+	}
+
+	inserted := 0
+	err := execBatch(ctx, db, insertObservationSQL, obs, func(stmt *sql.Stmt, o weather.Observation) error {
+		res, err := stmt.ExecContext(ctx,
+			uuid.Must(uuid.NewV7()).String(), o.SerialNumber, o.Timestamp.Unix(),
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		inserted += int(n)
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return inserted, nil
+}
+
+// wetBulb derives temp_wetbulb, which the REST API does not return.
+//
+// It uses the same tempestudp.WetBulbTemperatureC + math.IsNaN guard the UDP
+// ingest path uses (writer.go:410,432-434), single-sourced, so backfilled and
+// live rows are indistinguishable. Change the formula and both paths change
+// together: shared knowledge, not shared shape.
+//
+// Any missing input yields NULL rather than a value computed from a zero —
+// the same reason the decode preserves nulls in the first place.
+func wetBulb(o weather.Observation) *float64 {
+	if o.TempAir == nil || o.Humidity == nil || o.Pressure == nil {
+		return nil
+	}
+	v := tempestudp.WetBulbTemperatureC(*o.TempAir, *o.Humidity, *o.Pressure)
+	if math.IsNaN(v) {
+		return nil
+	}
+	return &v
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sqlite/ -run 'TestFindObservationGaps|TestSeriesBounds|TestInsertObservations' -v`
+Expected: PASS — all nine tests. In particular `TestFindObservationGapsPartitionsBySerial` must find exactly one gap on `ST-A`.
+
+- [ ] **Step 5: Sanity-check the partitioning claim by deleting it**
+
+Temporarily remove `PARTITION BY serial_number` from `findObservationGapsSQL` and re-run only that test.
+Run: `go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v`
+Expected: **FAIL** with "got 0 gaps, want 1" — proving the test actually guards the invariant. **Restore the `PARTITION BY` immediately** and re-run to confirm PASS.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/sqlite/backfill.go internal/sqlite/backfill_test.go
+git commit -m "feat(sqlite): add partitioned gap detection and idempotent backfill insert"
+```
+
+---
+
+### Task 6: `internal/postgres` — gap detection and idempotent insert
+
+**Files:**
+- Create: `internal/postgres/backfill.go`
+- Modify: `internal/postgres/writer_integration_test.go` — no change needed unless the build breaks; verify only.
+- Test: `internal/postgres/backfill_test.go`
+
+**Interfaces:**
+- Consumes: `weather.*` (Task 1), `OpenPool` (Task 4).
+- Produces (mirroring Task 5's signatures exactly, with `*pgxpool.Pool` in place of `*sql.DB`):
+  - `func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) ([]weather.Bounds, error)`
+  - `func FindObservationGaps(ctx context.Context, pool *pgxpool.Pool, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)`
+  - `func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.Observation) (int, error)`
+
+**Signatures are pinned to `time.Time` on both stores** so one interface satisfies both without a shim. The epoch conversion stays inside the SQLite implementation, matching how that package already handles timestamps; Postgres passes `time.Time` straight through to `TIMESTAMPTZ`.
+
+**Note on tests:** this package's database tests require a live Postgres and skip without one — that is pre-existing behavior. The unit-testable part here is wet-bulb derivation, which is shared logic; the SQL is verified by the integration suite when a database is available. Follow the existing skip idiom in `internal/postgres/writer_integration_test.go` for anything requiring a connection.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/postgres/backfill_test.go`:
+
+```go
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+func f(v float64) *float64 { return &v }
+
+func TestBackfillWetBulbDerivation(t *testing.T) {
+	tests := []struct {
+		name    string
+		obs     weather.Observation
+		wantNil bool
+	}{
+		{
+			name: "all inputs present",
+			obs:  weather.Observation{TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+		},
+		{
+			name:    "humidity missing",
+			obs:     weather.Observation{TempAir: f(20.5), Pressure: f(1013)},
+			wantNil: true,
+		},
+		{
+			name:    "temp missing",
+			obs:     weather.Observation{Humidity: f(55), Pressure: f(1013)},
+			wantNil: true,
+		},
+		{
+			name:    "pressure missing",
+			obs:     weather.Observation{TempAir: f(20.5), Humidity: f(55)},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wetBulb(tt.obs)
+			if tt.wantNil && got != nil {
+				t.Errorf("wetBulb = %v, want nil", *got)
+			}
+			if !tt.wantNil {
+				if got == nil {
+					t.Fatal("wetBulb = nil, want a value")
+				}
+				if *got <= 0 || *got >= 20.5 {
+					t.Errorf("wetBulb = %v, want a plausible value below dry-bulb 20.5", *got)
+				}
+			}
+		})
+	}
+}
+
+// The gap SQL must partition by serial. This pins the text so the invariant
+// cannot be dropped silently; the behavioral proof lives in the SQLite suite,
+// where the query runs against a real database without external setup.
+func TestFindObservationGapsSQLPartitionsBySerial(t *testing.T) {
+	if !strings.Contains(findObservationGapsSQL, "PARTITION BY serial_number") {
+		t.Error("findObservationGapsSQL must PARTITION BY serial_number; " +
+			"without it, two phase-offset stations mask each other's outages")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestFindObservationGapsSQL' -v`
+Expected: FAIL to compile — `undefined: wetBulb`, `undefined: findObservationGapsSQL`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/postgres/backfill.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"tempestwx-utilities/internal/tempestudp"
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// This file mirrors internal/sqlite/backfill.go function-for-function. The
+// two are deliberately NOT unified: SQLite stores timestamps as epoch INTEGER
+// and Postgres as TIMESTAMPTZ, and the two drivers bind parameters
+// differently. An abstraction over that difference would be the wrong
+// abstraction. The signatures are identical so one consumer-side interface
+// satisfies both.
+
+// insertBatchSize bounds how many rows go into one SendBatch. The daemon's
+// 5s timeout at insertObservations was sized for the 1-row live path; a
+// backfill batch needs its own budget.
+const backfillBatchTimeout = 30 * time.Second
+
+// findObservationGapsSQL locates interior holes in each station's series.
+//
+// PARTITION BY serial_number is NOT optional — see the identical comment in
+// internal/sqlite/backfill.go. Without it a multi-hour outage on one of two
+// phase-offset stations is undetectable.
+const findObservationGapsSQL = `
+	SELECT serial_number, prev, ts FROM (
+	  SELECT serial_number,
+	         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+	         timestamp AS ts
+	  FROM tempest_observations
+	  WHERE timestamp BETWEEN $1 AND $2
+	) q WHERE prev IS NOT NULL AND EXTRACT(EPOCH FROM (ts - prev)) > $3
+	ORDER BY serial_number, prev
+`
+
+// FindObservationGaps returns the interior gaps in [from, to] wider than
+// minGap. LAG yields NULL for the first row of each partition, so this finds
+// interior gaps ONLY; head/tail/empty are assembled by the caller from
+// SeriesBounds.
+func FindObservationGaps(ctx context.Context, pool *pgxpool.Pool, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	rows, err := pool.Query(ctx, findObservationGapsSQL, from, to, minGap.Seconds())
+	if err != nil {
+		return nil, fmt.Errorf("query observation gaps: %w", err)
+	}
+	defer rows.Close()
+
+	var gaps []weather.Gap
+	for rows.Next() {
+		var serial string
+		var prev, next time.Time
+		if err := rows.Scan(&serial, &prev, &next); err != nil {
+			return nil, fmt.Errorf("scan observation gap: %w", err)
+		}
+		gaps = append(gaps, weather.Gap{
+			SerialNumber: serial,
+			From:         prev.UTC(),
+			To:           next.UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate observation gaps: %w", err)
+	}
+	return gaps, nil
+}
+
+const seriesBoundsSQL = `
+	SELECT serial_number, MIN(timestamp), MAX(timestamp)
+	FROM tempest_observations
+	WHERE timestamp BETWEEN $1 AND $2
+	GROUP BY serial_number
+	ORDER BY serial_number
+`
+
+// SeriesBounds returns the first and last observation timestamp held for each
+// serial within [from, to]. An empty result means the store holds nothing in
+// that window — the first-run case.
+func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) ([]weather.Bounds, error) {
+	rows, err := pool.Query(ctx, seriesBoundsSQL, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("query series bounds: %w", err)
+	}
+	defer rows.Close()
+
+	var out []weather.Bounds
+	for rows.Next() {
+		var serial string
+		var first, last time.Time
+		if err := rows.Scan(&serial, &first, &last); err != nil {
+			return nil, fmt.Errorf("scan series bounds: %w", err)
+		}
+		out = append(out, weather.Bounds{
+			SerialNumber: serial,
+			First:        first.UTC(),
+			Last:         last.UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate series bounds: %w", err)
+	}
+	return out, nil
+}
+
+const backfillInsertSQL = `
+	INSERT INTO tempest_observations (
+		id, serial_number, timestamp,
+		wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
+		pressure, temp_air, temp_wetbulb, humidity,
+		illuminance, uv_index, irradiance, rain_rate, precip_type,
+		lightning_distance, lightning_strike_count,
+		battery, report_interval
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	ON CONFLICT (serial_number, timestamp) DO NOTHING
+`
+
+// InsertObservations writes obs idempotently and reports how many rows were
+// actually new. CommandTag.RowsAffected() is 0 for a skipped conflict and 1
+// for an insert — the same semantics as SQLite's per-row RowsAffected, and
+// the value the daemon path currently discards (writer.go:268).
+//
+// pgx SendBatch is all-or-nothing per batch, so the count is only meaningful
+// once every Exec has succeeded. The caller bounds len(obs).
+func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.Observation) (int, error) {
+	if len(obs) == 0 {
+		return 0, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, backfillBatchTimeout)
+	defer cancel()
+
+	b := &pgx.Batch{}
+	for _, o := range obs {
+		b.Queue(backfillInsertSQL,
+			uuid.Must(uuid.NewV7()), o.SerialNumber, o.Timestamp,
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
+	}
+
+	br := pool.SendBatch(ctx, b)
+	defer closeBatchResults(br)
+
+	inserted := 0
+	for i := range obs {
+		tag, err := br.Exec()
+		if err != nil {
+			return 0, fmt.Errorf("insert observation %d: %w", i, err)
+		}
+		inserted += int(tag.RowsAffected())
+	}
+	return inserted, nil
+}
+
+// wetBulb derives temp_wetbulb, which the REST API does not return. It uses
+// the same tempestudp.WetBulbTemperatureC + math.IsNaN guard the UDP ingest
+// path uses, single-sourced, so backfilled and live rows are
+// indistinguishable. Any missing input yields NULL rather than a value
+// computed from a zero.
+func wetBulb(o weather.Observation) *float64 {
+	if o.TempAir == nil || o.Humidity == nil || o.Pressure == nil {
+		return nil
+	}
+	v := tempestudp.WetBulbTemperatureC(*o.TempAir, *o.Humidity, *o.Pressure)
+	if math.IsNaN(v) {
+		return nil
+	}
+	return &v
+}
+```
+
+> **Implementer note:** `wetBulb` appears in both `internal/sqlite/backfill.go` and `internal/postgres/backfill.go`. This is deliberate and must NOT be extracted into a shared helper — the two store packages do not import each other, and the only neutral home (`internal/weather`) would then have to import `internal/tempestudp`, which pulls the UDP wire protocol into the leaf type package and creates exactly the coupling Task 1 exists to prevent. The *shared knowledge* — the wet-bulb formula — already lives in exactly one place: `tempestudp.WetBulbTemperatureC`. What is duplicated here is a four-line nil guard, which is shared shape, not shared knowledge. If `closeBatchResults` is unexported and already defined in `writer.go`, reuse it; do not redefine it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestFindObservationGapsSQL' -v`
+Expected: PASS.
+
+Run the package suite: `go test ./internal/postgres/ -v`
+Expected: PASS; integration tests skip without a database, as before.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/postgres/backfill.go internal/postgres/backfill_test.go
+git commit -m "feat(postgres): add partitioned gap detection and idempotent backfill insert"
+```
+
+---
+
+### Task 7: `internal/backfill` — chunking and retry classification
+
+**Files:**
+- Create: `internal/backfill/window.go`
+- Test: `internal/backfill/window_test.go`
+
+**Interfaces:**
+- Consumes: `tempestapi.StatusError` (Task 2).
+- Produces:
+  - `type window struct{ from, to time.Time }` (unexported)
+  - `func chunkWindow(from, to time.Time, size time.Duration) []window`
+  - `func isRetryable(err error) bool`
+
+**Chunking constraint:** the API documents that *observation data at one-minute resolution is available only for ranges of five days or less*. Chunk size is **1 day**, comfortably inside it. Exceeding the cap silently returns coarser data that would be written as if it were 1-minute observations — a data-corruption failure with no error.
+
+**Retry classification:** context cancellation is the operator's decision and is never retried. Per-attempt timeouts surface as `net.Error` from the client's own 30s `http.Client.Timeout` (`client.go:42`) and are retried through that branch, so `context.DeadlineExceeded` on the *parent* context correctly aborts rather than spinning.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/backfill/window_test.go`:
+
+```go
+package backfill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+)
+
+func TestChunkWindowSplitsMultiDayRange(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(72 * time.Hour)
+
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 3 {
+		t.Fatalf("got %d windows, want 3: %+v", len(got), got)
+	}
+	for i, w := range got {
+		wantFrom := from.Add(time.Duration(i) * 24 * time.Hour)
+		if !w.from.Equal(wantFrom) {
+			t.Errorf("window %d from = %v, want %v", i, w.from, wantFrom)
+		}
+	}
+	if !got[len(got)-1].to.Equal(to) {
+		t.Errorf("last window to = %v, want %v", got[len(got)-1].to, to)
+	}
+}
+
+func TestChunkWindowPartialTail(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(30 * time.Hour)
+
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 2 {
+		t.Fatalf("got %d windows, want 2: %+v", len(got), got)
+	}
+	if !got[1].to.Equal(to) {
+		t.Errorf("tail window to = %v, want %v (must not overshoot)", got[1].to, to)
+	}
+	if got[1].to.Sub(got[1].from) != 6*time.Hour {
+		t.Errorf("tail window width = %v, want 6h", got[1].to.Sub(got[1].from))
+	}
+}
+
+func TestChunkWindowSingleShortRange(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(time.Hour)
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 1 {
+		t.Fatalf("got %d windows, want 1", len(got))
+	}
+	if !got[0].from.Equal(from) || !got[0].to.Equal(to) {
+		t.Errorf("window = [%v, %v], want [%v, %v]", got[0].from, got[0].to, from, to)
+	}
+}
+
+func TestChunkWindowEmptyOrInvertedRange(t *testing.T) {
+	from := time.Unix(1000, 0).UTC()
+	if got := chunkWindow(from, from, 24*time.Hour); len(got) != 0 {
+		t.Errorf("zero-width range produced %d windows, want 0", len(got))
+	}
+	if got := chunkWindow(from, from.Add(-time.Hour), 24*time.Hour); len(got) != 0 {
+		t.Errorf("inverted range produced %d windows, want 0", len(got))
+	}
+}
+
+type fakeNetErr struct{}
+
+func (fakeNetErr) Error() string   { return "dial tcp: connection refused" }
+func (fakeNetErr) Timeout() bool   { return false }
+func (fakeNetErr) Temporary() bool { return true }
+
+var _ net.Error = fakeNetErr{}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"429", &tempestapi.StatusError{HTTPStatus: http.StatusTooManyRequests}, true},
+		{"500", &tempestapi.StatusError{HTTPStatus: http.StatusInternalServerError}, true},
+		{"503", &tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable}, true},
+		{"404", &tempestapi.StatusError{HTTPStatus: http.StatusNotFound}, false},
+		{"401", &tempestapi.StatusError{HTTPStatus: http.StatusUnauthorized}, false},
+		{"api level status_code is never transient", &tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}, false},
+		{"wrapped 503 still classifies", fmt.Errorf("gap 1: %w", &tempestapi.StatusError{HTTPStatus: 503}), true},
+		{"network error", fakeNetErr{}, true},
+		{"context canceled is the operator's decision", context.Canceled, false},
+		{"parent deadline exceeded aborts", context.DeadlineExceeded, false},
+		{"unknown error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/backfill/ -v`
+Expected: FAIL — the package does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/backfill/window.go`:
+
+```go
+// Package backfill finds holes in the local observation history and fills
+// them from the Tempest REST API.
+package backfill
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+)
+
+// chunkSize bounds one API request's window.
+//
+// The Tempest API documents that observation data at one-minute resolution is
+// available only for ranges of FIVE DAYS OR LESS. Exceeding that cap does not
+// error — it silently returns coarser data, which would then be written as if
+// it were 1-minute observations. One day sits comfortably inside the cap.
+// Every fetch goes through the chunker, including an explicit --from/--to.
+const chunkSize = 24 * time.Hour
+
+// window is one API request's time range.
+type window struct {
+	from time.Time
+	to   time.Time
+}
+
+// chunkWindow splits [from, to] into consecutive windows of at most size. The
+// final window is truncated to `to` rather than overshooting it. A zero-width
+// or inverted range yields no windows.
+func chunkWindow(from, to time.Time, size time.Duration) []window {
+	if !to.After(from) {
+		return nil
+	}
+	var out []window
+	for start := from; start.Before(to); start = start.Add(size) {
+		end := start.Add(size)
+		if end.After(to) {
+			end = to
+		}
+		out = append(out, window{from: start, to: end})
+	}
+	return out
+}
+
+// isRetryable reports whether retrying err could plausibly succeed.
+//
+// Classification uses errors.As, NOT errors.AsType — that is Go 1.26 and
+// go.mod declares go 1.25.0.
+//
+// Context cancellation is never retried: it is the operator's decision, and a
+// blown parent deadline would only fail again immediately. Per-attempt
+// timeouts do not arrive here as context errors — the client sets its own 30s
+// http.Client.Timeout (tempestapi/client.go:42), which surfaces as a
+// net.Error and is retried through that branch.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var se *tempestapi.StatusError
+	if errors.As(err, &se) {
+		// A non-zero API-level status_code is a real failure, not congestion.
+		if se.StatusCode != 0 {
+			return false
+		}
+		return se.HTTPStatus == http.StatusTooManyRequests || se.HTTPStatus >= 500
+	}
+
+	var ne net.Error
+	return errors.As(err, &ne)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/backfill/ -v`
+Expected: PASS — all chunking and classification cases.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backfill/
+git commit -m "feat(backfill): add API window chunking and retry classification"
+```
+
+---
+
+### Task 8: `internal/backfill` — detection domain assembly
+
+**Files:**
+- Create: `internal/backfill/gaps.go`
+- Test: `internal/backfill/gaps_test.go`
+
+**Interfaces:**
+- Consumes: `weather.Gap`, `weather.Bounds` (Task 1).
+- Produces: `func assembleGaps(interior []weather.Gap, bounds []weather.Bounds, serials []string, detectFrom, detectTo time.Time, minGap time.Duration) []weather.Gap`
+
+**Why this exists:** SQL `LAG` yields NULL for the first row of each partition, so gap detection finds **interior gaps only**. Left there, a fresh/empty store reports "no gaps" and writes nothing, and the natural "the box was down, repair it" case — whose outage is entirely in the tail — is invisible. The detection domain is the union of `[detectFrom, first_row]`, the interior gaps, and `[last_row, detectTo]`, with the **empty table** treated as one gap covering the whole range. That last case is first-class, not an edge case.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/backfill/gaps_test.go`:
+
+```go
+package backfill
+
+import (
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+func ts(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+
+func gapSet(gaps []weather.Gap) map[string][][2]int64 {
+	out := map[string][][2]int64{}
+	for _, g := range gaps {
+		out[g.SerialNumber] = append(out[g.SerialNumber], [2]int64{g.From.Unix(), g.To.Unix()})
+	}
+	return out
+}
+
+func TestAssembleGapsEmptyStoreIsOneWholeRangeGap(t *testing.T) {
+	got := assembleGaps(nil, nil, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+	if len(got) != 1 {
+		t.Fatalf("got %d gaps, want 1: %+v", len(got), got)
+	}
+	if got[0].SerialNumber != "ST-A" || !got[0].From.Equal(ts(1000)) || !got[0].To.Equal(ts(90000)) {
+		t.Errorf("gap = %+v, want ST-A [1000, 90000]", got[0])
+	}
+}
+
+func TestAssembleGapsHeadAndTail(t *testing.T) {
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(50000), Last: ts(60000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	set := gapSet(got)["ST-A"]
+	if len(set) != 2 {
+		t.Fatalf("got %d gaps, want 2 (head + tail): %+v", len(set), got)
+	}
+	if set[0] != [2]int64{1000, 50000} {
+		t.Errorf("head gap = %v, want [1000, 50000]", set[0])
+	}
+	if set[1] != [2]int64{60000, 90000} {
+		t.Errorf("tail gap = %v, want [60000, 90000]", set[1])
+	}
+}
+
+func TestAssembleGapsSkipsHeadAndTailBelowMinGap(t *testing.T) {
+	// First row is 60s after detectFrom and last row is 60s before detectTo:
+	// both edges are narrower than minGap and must not be reported.
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1060), Last: ts(89940)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+	if len(got) != 0 {
+		t.Errorf("got %d gaps, want 0: %+v", len(got), got)
+	}
+}
+
+func TestAssembleGapsPreservesInterior(t *testing.T) {
+	interior := []weather.Gap{{SerialNumber: "ST-A", From: ts(20000), To: ts(30000)}}
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1000), Last: ts(90000)}}
+	got := assembleGaps(interior, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d gaps, want 1 (interior only, no head/tail): %+v", len(got), got)
+	}
+	if !got[0].From.Equal(ts(20000)) || !got[0].To.Equal(ts(30000)) {
+		t.Errorf("gap = %+v, want [20000, 30000]", got[0])
+	}
+}
+
+func TestAssembleGapsPerSerialIndependence(t *testing.T) {
+	// ST-A has data; ST-B is a brand-new serial with nothing stored. ST-B's
+	// whole range must be a gap even though ST-A looks healthy.
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1000), Last: ts(90000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A", "ST-B"}, ts(1000), ts(90000), 30*time.Minute)
+
+	set := gapSet(got)
+	if len(set["ST-A"]) != 0 {
+		t.Errorf("ST-A got %v, want no gaps", set["ST-A"])
+	}
+	if len(set["ST-B"]) != 1 || set["ST-B"][0] != [2]int64{1000, 90000} {
+		t.Errorf("ST-B got %v, want one whole-range gap", set["ST-B"])
+	}
+}
+
+func TestAssembleGapsIgnoresBoundsForUnknownSerial(t *testing.T) {
+	// A serial present in the store but not returned by the API (a retired
+	// station) must not produce work — there is nothing to fetch for it.
+	bounds := []weather.Bounds{{SerialNumber: "ST-OLD", First: ts(1000), Last: ts(2000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	for _, g := range got {
+		if g.SerialNumber == "ST-OLD" {
+			t.Errorf("produced a gap for a serial the API does not know: %+v", g)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/backfill/ -run TestAssembleGaps -v`
+Expected: FAIL to compile — `undefined: assembleGaps`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/backfill/gaps.go`:
+
+```go
+package backfill
+
+import (
+	"sort"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+// assembleGaps builds the full detection domain from what SQL can and cannot
+// see.
+//
+// FindObservationGaps uses a LAG window function, which yields NULL for the
+// first row of each partition — so it finds INTERIOR gaps only. Left at that,
+// a fresh store reports "no gaps" and writes nothing, and the natural "the
+// box was down, repair it" case — whose outage is entirely in the tail — is
+// invisible. The domain is therefore the union of:
+//
+//   - the head gap [detectFrom, first stored row]
+//   - the interior gaps SQL found
+//   - the tail gap [last stored row, detectTo]
+//
+// with the EMPTY-store case (no bounds for a serial) treated as one gap
+// covering the whole range. That is a first-class case, not an edge case: it
+// is what every first run looks like.
+//
+// serials is the set the API knows about. A serial present in the store but
+// absent from the API (a retired station) produces no work — there is nothing
+// to fetch for it. Edges narrower than minGap are ordinary reporting jitter
+// and are dropped, matching the interior threshold.
+func assembleGaps(
+	interior []weather.Gap,
+	bounds []weather.Bounds,
+	serials []string,
+	detectFrom, detectTo time.Time,
+	minGap time.Duration,
+) []weather.Gap {
+	byserial := make(map[string]weather.Bounds, len(bounds))
+	for _, b := range bounds {
+		byserial[b.SerialNumber] = b
+	}
+
+	var out []weather.Gap
+	for _, serial := range serials {
+		b, ok := byserial[serial]
+		if !ok {
+			// Nothing stored for this serial in the detection window: the
+			// whole range is one gap.
+			if detectTo.Sub(detectFrom) > minGap {
+				out = append(out, weather.Gap{SerialNumber: serial, From: detectFrom, To: detectTo})
+			}
+			continue
+		}
+		if b.First.Sub(detectFrom) > minGap {
+			out = append(out, weather.Gap{SerialNumber: serial, From: detectFrom, To: b.First})
+		}
+		for _, g := range interior {
+			if g.SerialNumber == serial {
+				out = append(out, g)
+			}
+		}
+		if detectTo.Sub(b.Last) > minGap {
+			out = append(out, weather.Gap{SerialNumber: serial, From: b.Last, To: detectTo})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SerialNumber != out[j].SerialNumber {
+			return out[i].SerialNumber < out[j].SerialNumber
+		}
+		return out[i].From.Before(out[j].From)
+	})
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/backfill/ -run TestAssembleGaps -v`
+Expected: PASS — all six tests.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backfill/gaps.go internal/backfill/gaps_test.go
+git commit -m "feat(backfill): assemble head, tail, and empty-store gaps around LAG's interior gaps"
+```
+
+---
+
+### Task 9: `internal/backfill` — the `Run` core
+
+**Files:**
+- Create: `internal/backfill/backfill.go`
+- Test: `internal/backfill/backfill_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1, 2, 7, 8.
+- Produces:
+  ```go
+  type Config struct {
+      From, To time.Time     // zero => auto-detect
+      MinGap   time.Duration
+      DryRun   bool
+  }
+  type Stats struct{ Gaps, Requested, Inserted, Failed int }
+  type ObservationSource interface {
+      Observations(ctx context.Context, station tempestapi.Station, start, end time.Time) ([]weather.Observation, error)
+  }
+  type Store interface {
+      SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
+      FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+      InsertObservations(ctx context.Context, obs []weather.Observation) (int, error)
+  }
+  func Run(ctx context.Context, cfg Config, src ObservationSource, store Store, stations []tempestapi.Station, now time.Time) (Stats, error)
+  ```
+
+**Why `now` is a parameter:** nothing below the shell calls `time.Now()`. `detectTo` defaults to `now - minGap`, which is only testable if the clock is injected.
+
+**Why `Store` is an interface:** two concrete implementors exist on day one (SQLite and Postgres), so it is not speculative. It is defined in the consumer, Go-idiomatic; thin adapters live in the shell.
+
+**Serial pre-flight is a hard stop.** If an API serial is absent from a **non-empty** store, backfill would write a parallel series under a second serial: `UNIQUE` never fires, rows double, and the gap never closes — silently and cumulatively. Warning-then-writing-anyway is incoherent; it names an outcome as corrupting and then produces it. An **empty** store is not a mismatch — it is the first-run case.
+
+**Insert batches are bounded to 200 rows.** A long transaction contends with live ingest, whose error path only *logs* (`sqlite/writer.go:646`), so an unbounded backfill transaction could cause **live observations to be silently lost while repairing historical ones**.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/backfill/backfill_test.go`:
+
+```go
+package backfill
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+)
+
+// --- fakes ---
+
+type fakeSource struct {
+	calls   []window
+	obs     []weather.Observation
+	errs    []error // consumed one per call; nil entries succeed
+	callNum int
+}
+
+func (f *fakeSource) Observations(_ context.Context, _ tempestapi.Station, start, end time.Time) ([]weather.Observation, error) {
+	f.calls = append(f.calls, window{from: start, to: end})
+	i := f.callNum
+	f.callNum++
+	if i < len(f.errs) && f.errs[i] != nil {
+		return nil, f.errs[i]
+	}
+	return f.obs, nil
+}
+
+type fakeStore struct {
+	bounds    []weather.Bounds
+	gaps      []weather.Gap
+	inserted  [][]weather.Observation
+	insertErr error
+}
+
+func (f *fakeStore) SeriesBounds(context.Context, time.Time, time.Time) ([]weather.Bounds, error) {
+	return f.bounds, nil
+}
+
+func (f *fakeStore) FindObservationGaps(context.Context, time.Time, time.Time, time.Duration) ([]weather.Gap, error) {
+	return f.gaps, nil
+}
+
+func (f *fakeStore) InsertObservations(_ context.Context, obs []weather.Observation) (int, error) {
+	if f.insertErr != nil {
+		return 0, f.insertErr
+	}
+	f.inserted = append(f.inserted, obs)
+	return len(obs), nil
+}
+
+func station(serial string) tempestapi.Station {
+	return tempestapi.Station{
+		SerialNumber: serial,
+		DeviceID:     1,
+		CreatedAt:    time.Unix(1000, 0).UTC(),
+	}
+}
+
+func obsAt(serial string, epoch int64) weather.Observation {
+	return weather.Observation{SerialNumber: serial, Timestamp: time.Unix(epoch, 0).UTC()}
+}
+
+func at(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+
+// --- tests ---
+
+func TestRunDryRunMakesNoAPICallsAndNoWrites(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(2000)}}}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute, DryRun: true},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 0 {
+		t.Errorf("dry run made %d API calls, want 0", len(src.calls))
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("dry run made %d inserts, want 0", len(store.inserted))
+	}
+	if stats.Gaps == 0 {
+		t.Error("dry run should still report the gaps it detected")
+	}
+	if stats.Inserted != 0 {
+		t.Errorf("Inserted = %d, want 0", stats.Inserted)
+	}
+}
+
+func TestRunSerialMismatchIsHardStopWithNoWrites(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	// The store holds a DIFFERENT serial than the API reports. Writing would
+	// create a parallel series that never dedupes.
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-OTHER", First: at(1000), Last: at(2000)}}}
+
+	_, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err == nil {
+		t.Fatal("serial mismatch must be a hard stop, got nil error")
+	}
+	if !errors.Is(err, ErrSerialMismatch) {
+		t.Errorf("err = %v, want ErrSerialMismatch", err)
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("wrote %d batches despite a serial mismatch, want 0", len(store.inserted))
+	}
+	if len(src.calls) != 0 {
+		t.Errorf("made %d API calls despite a serial mismatch, want 0", len(src.calls))
+	}
+}
+
+func TestRunEmptyStoreIsNotASerialMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{} // empty: first run
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err != nil {
+		t.Fatalf("empty store must not be a mismatch: %v", err)
+	}
+	if stats.Gaps == 0 {
+		t.Error("empty store should yield the whole range as one gap")
+	}
+}
+
+func TestRunChunksExplicitRangeIntoDays(t *testing.T) {
+	src := &fakeSource{}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour)
+	_, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 3 {
+		t.Fatalf("made %d API calls, want 3 single-day requests: %+v", len(src.calls), src.calls)
+	}
+	for i, c := range src.calls {
+		if w := c.to.Sub(c.from); w > 24*time.Hour {
+			t.Errorf("call %d spans %v, want <= 24h (the API caps 1-minute resolution at 5 days)", i, w)
+		}
+	}
+}
+
+func TestRunRetriesTransientThenSucceeds(t *testing.T) {
+	src := &fakeSource{
+		obs:  []weather.Observation{obsAt("ST-A", 5000)},
+		errs: []error{&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable}},
+	}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	stats, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 2 {
+		t.Errorf("made %d calls, want 2 (one failure + one retry)", len(src.calls))
+	}
+	if stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0 after a successful retry", stats.Failed)
+	}
+	if stats.Inserted != 1 {
+		t.Errorf("Inserted = %d, want 1", stats.Inserted)
+	}
+}
+
+func TestRunDoesNotRetryNonTransient(t *testing.T) {
+	src := &fakeSource{errs: []error{&tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	stats, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err == nil {
+		t.Fatal("a failed gap must surface as an error")
+	}
+	if len(src.calls) != 1 {
+		t.Errorf("made %d calls, want 1 (an API-level status_code is never transient)", len(src.calls))
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+func TestRunContinuesAfterAFailedGapAndReportsBoth(t *testing.T) {
+	// Two gaps; the first window fails permanently, the second succeeds.
+	src := &fakeSource{
+		obs:  []weather.Observation{obsAt("ST-A", 5000)},
+		errs: []error{&tempestapi.StatusError{StatusCode: 404}},
+	}
+	store := &fakeStore{
+		bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(10000), Last: at(20000)}},
+		gaps:   nil,
+	}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err == nil {
+		t.Fatal("want a non-nil error when any gap failed")
+	}
+	if stats.Failed == 0 {
+		t.Error("Failed should count the failed gap")
+	}
+	if stats.Inserted == 0 {
+		t.Error("the surviving gap should still have inserted rows — partial progress must be preserved")
+	}
+}
+
+func TestRunBoundsInsertBatchSize(t *testing.T) {
+	// 500 observations must arrive as batches of at most 200: an unbounded
+	// transaction contends with live ingest, whose error path only logs.
+	var many []weather.Observation
+	for i := range 500 {
+		many = append(many, obsAt("ST-A", int64(5000+i*60)))
+	}
+	src := &fakeSource{obs: many}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	_, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.inserted) < 3 {
+		t.Fatalf("got %d batches, want at least 3 for 500 rows at max 200/batch", len(store.inserted))
+	}
+	for i, b := range store.inserted {
+		if len(b) > 200 {
+			t.Errorf("batch %d has %d rows, want <= 200", i, len(b))
+		}
+	}
+}
+
+func TestRunHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	_, err := Run(ctx,
+		Config{From: from, To: from.Add(72 * time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(72*time.Hour))
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/backfill/ -run TestRun -v`
+Expected: FAIL to compile — `undefined: Run`, `undefined: Config`, `undefined: ErrSerialMismatch`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/backfill/backfill.go`:
+
+```go
+package backfill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+)
+
+const (
+	// insertBatchSize bounds one insert transaction.
+	//
+	// The realistic invocation is `docker exec <running container>
+	// tempestwx-utilities backfill` against a LIVE database. A long backfill
+	// transaction contends with ingest writes; busy_timeout defaults to 5s
+	// and ingest's error path only LOGS (sqlite/writer.go:646), so an
+	// unbounded transaction could cause live observations to be silently lost
+	// while repairing historical ones. Short transactions are the mitigation.
+	insertBatchSize = 200
+
+	// maxAttempts bounds retries per window, including the first try.
+	maxAttempts = 4
+	// baseBackoff is doubled per attempt: 1s, 2s, 4s.
+	baseBackoff = time.Second
+)
+
+// ErrSerialMismatch is returned when the API reports a serial the non-empty
+// store has never seen. See preflight.
+var ErrSerialMismatch = errors.New("station serial not present in store")
+
+// Config is the backfill run's parameters. It holds no I/O handles and no
+// clock — both are passed to Run explicitly so the core is testable.
+type Config struct {
+	// From and To bound the work explicitly. Both zero means auto-detect.
+	//
+	// The override exists to BOUND API WORK, not to avoid a table scan
+	// (idx_obs_serial_time already covers detection): because permanent holes
+	// are accepted and never recorded, auto-detect re-requests every
+	// known-empty window on every run. An operator repairing a known outage
+	// can name it and skip that cost.
+	From time.Time
+	To   time.Time
+
+	// MinGap is the smallest interval that counts as a hole, keeping ordinary
+	// reporting jitter from registering.
+	MinGap time.Duration
+
+	// DryRun detects and plans only: zero API calls, zero writes. It
+	// consequently cannot validate the token or reachability.
+	DryRun bool
+}
+
+// Stats is what the run did, in aggregate.
+type Stats struct {
+	Gaps      int // holes detected
+	Requested int // observations returned by the API
+	Inserted  int // rows actually new (0 across runs => a permanent hole)
+	Failed    int // gaps that failed after retries
+}
+
+// ObservationSource is the REST client, narrowed to what backfill needs.
+// *tempestapi.Client satisfies it.
+type ObservationSource interface {
+	Observations(ctx context.Context, station tempestapi.Station, start, end time.Time) ([]weather.Observation, error)
+}
+
+// Store is the persistence side, narrowed to what backfill needs. Two
+// concrete implementors exist on day one — SQLite and Postgres — so this is
+// an earned interface, not a speculative one. It is declared here, in the
+// consumer, per Go convention; the adapters that bind a *sql.DB or
+// *pgxpool.Pool to it live in the command shell.
+type Store interface {
+	SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
+	FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+	InsertObservations(ctx context.Context, obs []weather.Observation) (int, error)
+}
+
+// Run detects gaps and fills them.
+//
+// now is injected: nothing below the command shell calls time.Now(), so
+// detectTo (now - MinGap) is deterministic under test.
+//
+// A failed gap logs and continues — partial progress must be preserved — and
+// the per-gap errors are joined into the returned error, which the shell
+// turns into a non-zero exit. Run never calls log.Fatal.
+func Run(
+	ctx context.Context,
+	cfg Config,
+	src ObservationSource,
+	store Store,
+	stations []tempestapi.Station,
+	now time.Time,
+) (Stats, error) {
+	var stats Stats
+
+	detectFrom, detectTo := detectionRange(cfg, stations, now)
+
+	bounds, err := store.SeriesBounds(ctx, detectFrom, detectTo)
+	if err != nil {
+		return stats, fmt.Errorf("series bounds: %w", err)
+	}
+
+	if err := preflight(stations, bounds); err != nil {
+		return stats, err
+	}
+
+	gaps, err := plannedGaps(ctx, cfg, store, stations, bounds, detectFrom, detectTo)
+	if err != nil {
+		return stats, err
+	}
+	stats.Gaps = len(gaps)
+
+	if cfg.DryRun {
+		for _, g := range gaps {
+			slog.Info("backfill: planned gap (dry run)",
+				"serial", g.SerialNumber, "from", g.From, "to", g.To, "duration", g.Duration())
+		}
+		return stats, nil
+	}
+
+	byserial := make(map[string]tempestapi.Station, len(stations))
+	for _, s := range stations {
+		byserial[s.SerialNumber] = s
+	}
+
+	var failures []error
+	for _, g := range gaps {
+		requested, inserted, err := fillGap(ctx, src, store, byserial[g.SerialNumber], g)
+		stats.Requested += requested
+		stats.Inserted += inserted
+
+		if err != nil {
+			if ctx.Err() != nil {
+				// Cancellation is not a gap failure. Inserted rows stay
+				// intact; idempotency makes re-running safe.
+				return stats, ctx.Err()
+			}
+			stats.Failed++
+			failures = append(failures, fmt.Errorf("gap %s [%s, %s]: %w",
+				g.SerialNumber, g.From.Format(time.RFC3339), g.To.Format(time.RFC3339), err))
+			slog.Error("backfill: gap failed",
+				"serial", g.SerialNumber, "from", g.From, "to", g.To, "error", err)
+			continue
+		}
+
+		// requested vs inserted is what makes the permanent-hole tradeoff
+		// visible: if the station was genuinely offline, the API has no data
+		// either and inserted stays 0 across runs. Structured attrs are the
+		// machine-readable surface — no bespoke summary format.
+		slog.Info("backfill: gap filled",
+			"serial", g.SerialNumber, "from", g.From, "to", g.To,
+			"requested", requested, "inserted", inserted)
+	}
+
+	if len(failures) > 0 {
+		return stats, errors.Join(failures...)
+	}
+	return stats, nil
+}
+
+// detectionRange resolves the window to work over. An explicit --from/--to
+// wins; otherwise detection runs from the earliest station creation time to
+// now-MinGap (trailing MinGap so the most recent, still-arriving interval is
+// not mistaken for a hole).
+func detectionRange(cfg Config, stations []tempestapi.Station, now time.Time) (time.Time, time.Time) {
+	if !cfg.From.IsZero() && !cfg.To.IsZero() {
+		return cfg.From, cfg.To
+	}
+	detectTo := now.Add(-cfg.MinGap)
+	detectFrom := detectTo
+	for _, s := range stations {
+		if s.CreatedAt.Before(detectFrom) {
+			detectFrom = s.CreatedAt
+		}
+	}
+	return detectFrom, detectTo
+}
+
+// plannedGaps is the whole detection domain: SQL's interior gaps plus the
+// head, tail, and empty-store cases LAG cannot see. An explicit --from/--to
+// still goes through the chunker, so it is expressed as one gap per station
+// rather than bypassing the pipeline.
+func plannedGaps(
+	ctx context.Context,
+	cfg Config,
+	store Store,
+	stations []tempestapi.Station,
+	bounds []weather.Bounds,
+	detectFrom, detectTo time.Time,
+) ([]weather.Gap, error) {
+	serials := make([]string, 0, len(stations))
+	for _, s := range stations {
+		serials = append(serials, s.SerialNumber)
+	}
+
+	if !cfg.From.IsZero() && !cfg.To.IsZero() {
+		gaps := make([]weather.Gap, 0, len(serials))
+		for _, serial := range serials {
+			gaps = append(gaps, weather.Gap{SerialNumber: serial, From: cfg.From, To: cfg.To})
+		}
+		return gaps, nil
+	}
+
+	interior, err := store.FindObservationGaps(ctx, detectFrom, detectTo, cfg.MinGap)
+	if err != nil {
+		return nil, fmt.Errorf("find observation gaps: %w", err)
+	}
+	return assembleGaps(interior, bounds, serials, detectFrom, detectTo, cfg.MinGap), nil
+}
+
+// preflight refuses to run when the API reports a serial the store has never
+// seen.
+//
+// Dedupe, gap closure, and convergence all require that the serial backfill
+// writes exactly matches the serial UDP ingest writes. If they diverge,
+// backfill writes a PARALLEL SERIES under a second serial: UNIQUE never
+// fires, rows double, and the gap never closes — silently and cumulatively.
+// So this is a hard stop, not a warning: warning-then-writing-anyway names an
+// outcome as corrupting and then produces it.
+//
+// An EMPTY store is not a mismatch. It is the first-run case, where every gap
+// is legitimately new.
+func preflight(stations []tempestapi.Station, bounds []weather.Bounds) error {
+	if len(bounds) == 0 {
+		return nil
+	}
+	stored := make(map[string]struct{}, len(bounds))
+	for _, b := range bounds {
+		stored[b.SerialNumber] = struct{}{}
+	}
+	var missing []error
+	for _, s := range stations {
+		if _, ok := stored[s.SerialNumber]; !ok {
+			missing = append(missing, fmt.Errorf("%w: API reports %q, store has none of it",
+				ErrSerialMismatch, s.SerialNumber))
+		}
+	}
+	return errors.Join(missing...)
+}
+
+// fillGap fetches and inserts one gap, chunked and retried.
+func fillGap(
+	ctx context.Context,
+	src ObservationSource,
+	store Store,
+	station tempestapi.Station,
+	g weather.Gap,
+) (requested, inserted int, err error) {
+	for _, w := range chunkWindow(g.From, g.To, chunkSize) {
+		if err := ctx.Err(); err != nil {
+			return requested, inserted, err
+		}
+
+		obs, err := fetchWithRetry(ctx, src, station, w)
+		if err != nil {
+			return requested, inserted, err
+		}
+		requested += len(obs)
+
+		for chunk := range batches(obs, insertBatchSize) {
+			n, err := store.InsertObservations(ctx, chunk)
+			if err != nil {
+				return requested, inserted, fmt.Errorf("insert: %w", err)
+			}
+			inserted += n
+		}
+	}
+	return requested, inserted, nil
+}
+
+// fetchWithRetry applies bounded exponential backoff to transient failures.
+// Context cancellation is checked between attempts as well as between
+// windows.
+func fetchWithRetry(
+	ctx context.Context,
+	src ObservationSource,
+	station tempestapi.Station,
+	w window,
+) ([]weather.Observation, error) {
+	var lastErr error
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			delay := baseBackoff << (attempt - 1)
+			slog.Warn("backfill: retrying window",
+				"serial", station.SerialNumber, "from", w.from, "to", w.to,
+				"attempt", attempt+1, "delay", delay, "error", lastErr)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		obs, err := src.Observations(ctx, station, w.from, w.to)
+		if err == nil {
+			return obs, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// batches yields obs in slices of at most size.
+func batches(obs []weather.Observation, size int) func(func([]weather.Observation) bool) {
+	return func(yield func([]weather.Observation) bool) {
+		for start := 0; start < len(obs); start += size {
+			end := min(start+size, len(obs))
+			if !yield(obs[start:end]) {
+				return
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/backfill/ -run TestRun -v`
+Expected: PASS — all nine tests.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backfill/backfill.go internal/backfill/backfill_test.go
+git commit -m "feat(backfill): add the Run core with injected clock, store, and API source"
+```
+
+---
+
+### Task 10: `main.go` — the shell and real subcommand dispatch
+
+**Files:**
+- Create: `backfill_cmd.go` (package `main`, repo root — matches the existing flat layout)
+- Modify: `main.go:188-191` (the dispatch in `main`)
+- Test: `backfill_cmd_test.go`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `func runBackfill(ctx context.Context, args []string) int`, plus the two store adapters.
+
+**Dispatch fix:** `main()` currently matches only `healthcheck` and **falls through to daemon mode** for anything else — so `tempestwx-utilities backfil` (typo) silently starts a UDP listener. Unknown non-flag first arguments must print usage and exit **2**.
+
+**Each subcommand owns its own `flag.FlagSet` parsed from `os.Args[2:]`.** That — not an abstraction — is the seam #80's `migrate` slots into: a new subcommand is a new file plus one dispatch line, with no sibling touched.
+
+**Standards divergence, recorded deliberately:** `go-standards` §6 says "all CLIs use Cobra". This project uses a hand-rolled `os.Args[1]` dispatch. We keep the established pattern — Cobra for two subcommands would be a dependency and a framework where a `switch` suffices, and the standard defers to established project patterns. Do not add Cobra.
+
+**Cleanup:** `runBackfill` performs **all** cleanup via internal defers and returns an exit code. Copying the healthcheck shape (`os.Exit` at the dispatch site) would skip `db.Close()` and the pgx pool drain.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backfill_cmd_test.go`:
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseBackfillFlagsDefaults(t *testing.T) {
+	cfg, err := parseBackfillFlags(nil)
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if cfg.MinGap != 30*time.Minute {
+		t.Errorf("MinGap = %v, want 30m", cfg.MinGap)
+	}
+	if cfg.DryRun {
+		t.Error("DryRun should default to false")
+	}
+	if !cfg.From.IsZero() || !cfg.To.IsZero() {
+		t.Error("From/To should default to zero (auto-detect)")
+	}
+}
+
+func TestParseBackfillFlagsRFC3339IsUTC(t *testing.T) {
+	cfg, err := parseBackfillFlags([]string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"})
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if cfg.From.Location() != time.UTC {
+		t.Errorf("From location = %v, want UTC", cfg.From.Location())
+	}
+	if cfg.From.Format(time.RFC3339) != "2026-01-02T03:04:05Z" {
+		t.Errorf("From = %v, want 2026-01-02T03:04:05Z", cfg.From.Format(time.RFC3339))
+	}
+}
+
+func TestParseBackfillFlagsRejectsNonRFC3339(t *testing.T) {
+	_, err := parseBackfillFlags([]string{"--from", "2026-01-02"})
+	if err == nil {
+		t.Fatal("a non-RFC3339 --from must be rejected; an ambiguous local-time parse is a quiet wrong-window bug")
+	}
+	if !strings.Contains(err.Error(), "from") {
+		t.Errorf("error = %q, want it to name the offending flag", err)
+	}
+}
+
+func TestParseBackfillFlagsRequiresBothOrNeither(t *testing.T) {
+	if _, err := parseBackfillFlags([]string{"--from", "2026-01-02T00:00:00Z"}); err == nil {
+		t.Error("--from without --to must be rejected")
+	}
+	if _, err := parseBackfillFlags([]string{"--to", "2026-01-02T00:00:00Z"}); err == nil {
+		t.Error("--to without --from must be rejected")
+	}
+}
+
+func TestParseBackfillFlagsRejectsInvertedRange(t *testing.T) {
+	_, err := parseBackfillFlags([]string{"--from", "2026-01-03T00:00:00Z", "--to", "2026-01-02T00:00:00Z"})
+	if err == nil {
+		t.Fatal("--to before --from must be rejected")
+	}
+}
+
+func TestParseBackfillFlagsDryRun(t *testing.T) {
+	cfg, err := parseBackfillFlags([]string{"--dry-run", "--min-gap", "2h"})
+	if err != nil {
+		t.Fatalf("parseBackfillFlags: %v", err)
+	}
+	if !cfg.DryRun {
+		t.Error("--dry-run not applied")
+	}
+	if cfg.MinGap != 2*time.Hour {
+		t.Errorf("MinGap = %v, want 2h", cfg.MinGap)
+	}
+}
+
+func TestRunBackfillWithoutTokenFailsFast(t *testing.T) {
+	// TOKEN is validated before any store handle is opened, so the failure
+	// costs no I/O and leaves nothing to close. SQLITE_PATH points at a
+	// location that would fail to open, proving no store was touched.
+	t.Setenv("TOKEN", "")
+	t.Setenv("SQLITE_PATH", "/nonexistent-dir-should-never-be-opened/tempest.db")
+
+	if got := runBackfill(t.Context(), nil); got != 1 {
+		t.Errorf("exit code = %d, want 1 for a missing TOKEN", got)
+	}
+}
+
+func TestRunBackfillUsageErrorExitsTwo(t *testing.T) {
+	t.Setenv("TOKEN", "x")
+	if got := runBackfill(t.Context(), []string{"--from", "not-a-time", "--to", "also-not"}); got != 2 {
+		t.Errorf("exit code = %d, want 2 for a usage error", got)
+	}
+}
+
+func TestKnownSubcommands(t *testing.T) {
+	for _, name := range []string{"healthcheck", "backfill"} {
+		if !isKnownSubcommand(name) {
+			t.Errorf("%q should be a known subcommand", name)
+		}
+	}
+	// The regression this guards: "backfil" previously fell through to daemon
+	// mode and silently started a UDP listener.
+	for _, name := range []string{"backfil", "helthcheck", "migrate", ""} {
+		if isKnownSubcommand(name) {
+			t.Errorf("%q should NOT be a known subcommand", name)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestKnownSubcommands' -v`
+Expected: FAIL to compile — `undefined: parseBackfillFlags`, `undefined: runBackfill`, `undefined: isKnownSubcommand`.
+
+- [ ] **Step 3: Write the shell**
+
+Create `backfill_cmd.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"time"
+
+	"tempestwx-utilities/internal/backfill"
+	"tempestwx-utilities/internal/config"
+	"tempestwx-utilities/internal/postgres"
+	"tempestwx-utilities/internal/sqlite"
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+
+	"database/sql"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// parseBackfillFlags reads the backfill subcommand's own FlagSet.
+//
+// Each subcommand owning its FlagSet (parsed from os.Args[2:]) is the seam a
+// future subcommand slots into: a new subcommand is a new file plus one
+// dispatch line, with no sibling touched.
+//
+// --from/--to are RFC3339 interpreted as UTC. The store is UTC epoch and the
+// API takes epoch seconds; an ambiguous local-time parse would be a quiet
+// wrong-window bug, so a non-RFC3339 value is rejected rather than guessed at.
+func parseBackfillFlags(args []string) (backfill.Config, error) {
+	fs := flag.NewFlagSet("backfill", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	fromStr := fs.String("from", "", "start of the window to repair, RFC3339 UTC (default: auto-detect)")
+	toStr := fs.String("to", "", "end of the window to repair, RFC3339 UTC (default: auto-detect)")
+	minGap := fs.Duration("min-gap", 30*time.Minute, "smallest interval that counts as a gap")
+	dryRun := fs.Bool("dry-run", false, "detect and plan only: zero API calls, zero writes")
+
+	if err := fs.Parse(args); err != nil {
+		return backfill.Config{}, err
+	}
+
+	cfg := backfill.Config{MinGap: *minGap, DryRun: *dryRun}
+
+	if (*fromStr == "") != (*toStr == "") {
+		return cfg, errors.New("--from and --to must be given together, or neither")
+	}
+	if *fromStr != "" {
+		from, err := time.Parse(time.RFC3339, *fromStr)
+		if err != nil {
+			return cfg, fmt.Errorf("--from must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+		}
+		to, err := time.Parse(time.RFC3339, *toStr)
+		if err != nil {
+			return cfg, fmt.Errorf("--to must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+		}
+		cfg.From, cfg.To = from.UTC(), to.UTC()
+		if !cfg.To.After(cfg.From) {
+			return cfg, errors.New("--to must be after --from")
+		}
+	}
+	return cfg, nil
+}
+
+// sqliteStore adapts the package-level SQLite functions to backfill.Store.
+type sqliteStore struct{ db *sql.DB }
+
+func (s sqliteStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
+	return sqlite.SeriesBounds(ctx, s.db, from, to)
+}
+
+func (s sqliteStore) FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	return sqlite.FindObservationGaps(ctx, s.db, from, to, minGap)
+}
+
+func (s sqliteStore) InsertObservations(ctx context.Context, obs []weather.Observation) (int, error) {
+	return sqlite.InsertObservations(ctx, s.db, obs)
+}
+
+// postgresStore adapts the package-level Postgres functions to backfill.Store.
+type postgresStore struct{ pool *pgxpool.Pool }
+
+func (s postgresStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
+	return postgres.SeriesBounds(ctx, s.pool, from, to)
+}
+
+func (s postgresStore) FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	return postgres.FindObservationGaps(ctx, s.pool, from, to, minGap)
+}
+
+func (s postgresStore) InsertObservations(ctx context.Context, obs []weather.Observation) (int, error) {
+	return postgres.InsertObservations(ctx, s.pool, obs)
+}
+
+// runBackfill is the backfill subcommand's shell: parse, read env, open
+// handles, wire dependencies, return an exit code.
+//
+// It performs ALL cleanup via internal defers. Copying the healthcheck shape
+// (os.Exit at the dispatch site, main.go:189-191) would skip db.Close() and
+// the pgx pool drain.
+//
+// Exit codes: 0 success (including permanent holes), 1 a gap failed or a
+// runtime error, 2 a usage error.
+func runBackfill(ctx context.Context, args []string) int {
+	cfg, err := parseBackfillFlags(args)
+	if err != nil {
+		// flag.ContinueOnError already printed the message for parse errors.
+		if !errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		return 2
+	}
+
+	// TOKEN is validated BEFORE any store handle is opened, so the failure
+	// costs no I/O and leaves nothing to close.
+	token := os.Getenv("TOKEN")
+	if token == "" {
+		slog.Error("backfill: TOKEN is required to reach the Tempest REST API")
+		return 1
+	}
+
+	// Signal wiring lives in the subcommand — the healthcheck path has none
+	// to inherit.
+	ctx, stop := signalContext(ctx, signal.NotifyContext)
+	defer stop()
+
+	enablePostgres, err := config.ParseBoolEnv("ENABLE_POSTGRES")
+	if err != nil {
+		slog.Error("backfill: bad ENABLE_POSTGRES", "error", err)
+		return 1
+	}
+	choice := selectStore(enablePostgres, os.Getenv("SQLITE_PATH"))
+
+	var store backfill.Store
+	switch {
+	case choice.postgres:
+		dbConfig, err := config.GetDatabaseConfig()
+		if err != nil {
+			slog.Error("backfill: database configuration", "error", err)
+			return 1
+		}
+		if dbConfig == "" {
+			slog.Error("backfill: POSTGRES_URL or POSTGRES_HOST is required when ENABLE_POSTGRES is true")
+			return 1
+		}
+		// Backfill opens the WRITE path: it must create the schema and
+		// insert. OpenPool starts no goroutines, unlike NewPostgresWriter.
+		pool, err := postgres.OpenPool(ctx, dbConfig)
+		if err != nil {
+			slog.Error("backfill: open postgres", "error", err)
+			return 1
+		}
+		defer pool.Close()
+		if err := postgres.CreateSchema(ctx, pool); err != nil {
+			slog.Error("backfill: create postgres schema", "error", err)
+			return 1
+		}
+		store = postgresStore{pool: pool}
+	case choice.sqlite:
+		// The write handle, not OpenReadOnly: read-only fails when the file
+		// does not exist and cannot migrate, and its ingest-contention
+		// rationale does not apply to a separate one-shot process.
+		db, err := sqlite.Open(ctx, choice.sqlitePath, sqlite.LoadConfig(os.Getenv))
+		if err != nil {
+			slog.Error("backfill: open sqlite", "path", choice.sqlitePath, "error", err)
+			return 1
+		}
+		defer func() {
+			if err := db.Close(); err != nil {
+				slog.Error("backfill: close sqlite", "error", err)
+			}
+		}()
+		store = sqliteStore{db: db}
+	default:
+		slog.Error("backfill: no store configured")
+		return 1
+	}
+
+	client := tempestapi.NewClient(token)
+	stations, err := client.ListStations(ctx)
+	if err != nil {
+		slog.Error("backfill: list stations", "error", err)
+		return 1
+	}
+	if len(stations) == 0 {
+		slog.Error("backfill: the API reported no ST devices for this token")
+		return 1
+	}
+
+	stats, err := backfill.Run(ctx, cfg, client, store, stations, time.Now().UTC())
+	slog.Info("backfill: complete",
+		"gaps", stats.Gaps, "requested", stats.Requested,
+		"inserted", stats.Inserted, "failed", stats.Failed, "dry_run", cfg.DryRun)
+	if err != nil {
+		slog.Error("backfill: finished with failures", "error", err)
+		return 1
+	}
+	return 0
+}
+```
+
+> **Verified helper names** (do not substitute others): `sqlite.LoadConfig(getenv func(string) string) Config` is at `internal/sqlite/db.go:33`, and `config.GetDatabaseConfig() (string, error)` is at `internal/config/database.go:18` — the latter already resolves `POSTGRES_URL` or the individual `POSTGRES_*` components, so nothing needs extracting from `main()`.
+
+- [ ] **Step 4: Fix the dispatch in `main()`**
+
+In `main.go`, replace the current dispatch (`:189-191`):
+
+```go
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		os.Exit(runHealthcheck())
+	}
+```
+
+with:
+
+```go
+// isKnownSubcommand reports whether name is a subcommand this binary
+// dispatches. It exists so an unrecognized argument becomes a usage error
+// instead of silently falling through to daemon mode — a typo such as
+// `tempestwx-utilities backfil` previously started a UDP listener.
+func isKnownSubcommand(name string) bool {
+	switch name {
+	case "healthcheck", "backfill":
+		return true
+	default:
+		return false
+	}
+}
+
+const usageText = `tempestwx-utilities — Tempest weather station data utilities
+
+usage:
+  tempestwx-utilities                 run the UDP listener / API export daemon (configured by env)
+  tempestwx-utilities backfill [...]  fill gaps in the observation history from the Tempest REST API
+  tempestwx-utilities healthcheck     probe the running server's /healthz endpoint
+
+run "tempestwx-utilities backfill --help" for the backfill flags
+`
+
+func main() {
+	// A non-flag first argument is a subcommand. An unknown one is a usage
+	// error, never a silent fallthrough to daemon mode.
+	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], "-") {
+		if !isKnownSubcommand(os.Args[1]) {
+			fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n%s", os.Args[1], usageText)
+			os.Exit(2)
+		}
+		switch os.Args[1] {
+		case "healthcheck":
+			os.Exit(runHealthcheck())
+		case "backfill":
+			// runBackfill owns all of its cleanup via internal defers and
+			// wires its own signal context.
+			os.Exit(runBackfill(context.Background(), os.Args[2:]))
+		}
+	}
+```
+
+Add `"strings"` to `main.go`'s import block. `context` and `fmt` are already imported.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestKnownSubcommands' -v`
+Expected: PASS — all nine tests.
+
+- [ ] **Step 6: Verify the dispatch by hand**
+
+```bash
+CGO_ENABLED=0 go build -o /tmp/twx . && /tmp/twx backfil; echo "exit=$?"
+```
+Expected: prints `unknown subcommand "backfil"` plus usage, `exit=2`, and **does not** start a UDP listener or block.
+
+```bash
+/tmp/twx backfill --help; echo "exit=$?"
+```
+Expected: prints the four backfill flags with their defaults.
+
+- [ ] **Step 7: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backfill_cmd.go backfill_cmd_test.go main.go
+git commit -m "feat: add the backfill subcommand and reject unknown subcommands"
+```
+
+---
+
+### Task 11: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md:239` (name collision), `:78` (package list), the operational-modes table
+
+**Interfaces:**
+- Consumes: the shipped behavior of Tasks 1–10.
+- Produces: nothing consumed by code.
+
+**Why this is a task and not a footnote:** `CLAUDE.md` already has a section titled "**API Export with Backfill**" (`:239`) describing the *existing* `TOKEN`-triggered `ModeAPIExport`. Shipping a `backfill` subcommand alongside a differently-meaning section of nearly the same name would leave the repo's own guidance ambiguous about which "backfill" is which.
+
+- [ ] **Step 1: Resolve the name collision**
+
+Rename the existing `### API Export with Backfill` heading (`CLAUDE.md:239`) to `### API Export Mode (TOKEN)`, and adjust its body so it clearly describes the env-var-triggered historical export — not the new subcommand.
+
+- [ ] **Step 2: Add the subcommand section**
+
+Immediately after it, add:
+
+```markdown
+### Backfill Subcommand
+
+Fills holes in the local observation history from the Tempest REST API. Unlike
+API Export Mode (which is selected by setting `TOKEN` and runs the whole export
+path), this is an explicit subcommand and can be run against a live database:
+
+```bash
+TOKEN=your_api_token tempestwx-utilities backfill
+TOKEN=... tempestwx-utilities backfill --dry-run
+TOKEN=... tempestwx-utilities backfill --from 2026-07-01T00:00:00Z --to 2026-07-05T00:00:00Z
+```
+
+It writes to whichever store is configured (SQLite by default, Postgres when
+`ENABLE_POSTGRES=true`) and is idempotent — re-running inserts nothing new.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--from`, `--to` | unset (auto-detect) | Explicit window, RFC3339 **UTC**. Must be given together. |
+| `--min-gap` | `30m` | Smallest interval that counts as a gap. Raise it for stations with a long `report_interval`. |
+| `--dry-run` | `false` | Detect and plan only: zero API calls, zero writes. Cannot validate the token. |
+
+**Exit codes:** `0` success (including permanent holes — windows the station was
+genuinely offline for, which the API cannot fill either), `1` one or more gaps
+failed or a runtime error, `2` usage error.
+
+**Scope:** `tempest_observations` only. There is no historical REST endpoint for
+rapid wind, hub status, or discrete events. Lightning is partially recovered in
+aggregate through the observation columns, but not as `tempest_events` rows.
+
+**Safety:** if the API reports a station serial the (non-empty) store has never
+seen, backfill stops and writes nothing — a mismatched serial would create a
+parallel series that never dedupes.
+```
+
+- [ ] **Step 3: Update the package list**
+
+At `CLAUDE.md:76-79`, add to the internal-package list:
+
+```markdown
+- **`internal/weather/`**: Store-neutral `Observation`, `Gap`, and `Bounds` types shared by the REST client and both stores
+- **`internal/backfill/`**: Gap detection and API backfill orchestration for the `backfill` subcommand
+```
+
+Leave the `internal/tempestudp/` line as it is — it correctly describes UDP parsing, and the backfill types deliberately live elsewhere.
+
+- [ ] **Step 4: Note that subcommands bypass mode selection**
+
+Under the "Operational Modes" table, add:
+
+```markdown
+> **Subcommands bypass mode selection.** `backfill` and `healthcheck` are chosen
+> by the first CLI argument, not by environment variables, and neither starts the
+> UDP listener or the HTTP server. Any other non-flag first argument is a usage
+> error (exit 2) rather than a silent fallthrough to daemon mode.
+```
+
+- [ ] **Step 5: Verify the docs match reality**
+
+Run each command in the new section against the built binary and confirm the flags and exit codes are exactly as documented:
+
+```bash
+CGO_ENABLED=0 go build -o /tmp/twx . && /tmp/twx backfill --help
+```
+Expected: the four flags with the documented defaults. Fix the doc if it disagrees — the binary is the source of truth.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document the backfill subcommand and resolve the API-export name collision"
+```
+
+---
+
+## After all tasks
+
+Dispatch a **fresh, non-context-sharing** review subagent per `rules/subagent-development-workflow.md` step 4. Brief it with:
+- branch `worktree-api-backfill`, diff scope `git diff 8990b88..HEAD`
+- the design document path, as the spec
+- the acceptance criteria: every row of the design's Testing table has a corresponding passing test
+
+Do **not** summarize what was built — let the reviewer reach its own conclusions from the code. Then run `superpowers:finishing-a-development-branch`.
+
+## Known scope exclusions
+
+Stated so a reviewer does not read them as omissions:
+
+- **`tempest_rapid_wind`, `tempest_hub_status`, `tempest_events` are not backfilled.** No historical REST endpoint exists for any of them.
+- **The missing `break` in `ListStations`' device loop is not fixed.** `ModeAPIExport` depends on current behavior; backfill iterates all `ST` devices itself.
+- **`ModeAPIExport` and `sqlite.WriteMetrics` are unchanged.**
+- **No `--json` output.** The bespoke summary line was cut as speculative; `slog` attrs are the machine-readable surface. Add `--json` if a caller ever needs it.
+- **`Retry-After` parsing and a fixed inter-request delay were cut.** WeatherFlow publishes no rate limits; bounded backoff already handles 429.
+- **`CLAUDE.md` staleness elsewhere** (no SQLite-default/OTel/httpserver/radar coverage; still says "Go 1.23.0+") is out of scope — flagged for a separate docs pass.

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -748,6 +748,52 @@ func TestObservationsSkipsRowWithNullTimestamp(t *testing.T) {
 	}
 }
 
+// The guards are GRADUATED, matching the UDP ingest path (>= 13 floor, tail
+// filled conditionally). A 13-element tuple must be KEPT with its core
+// measurements and NULL for the indices it does not carry — not dropped.
+func TestObservationsKeepsShortTupleWithNullTail(t *testing.T) {
+	// Exactly 13 elements: timestamp through rain_rate, nothing after.
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[
+		[1700000000,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1 — a 13-element tuple must not be dropped", len(obs))
+	}
+	if obs[0].TempAir == nil || *obs[0].TempAir != 20.5 {
+		t.Errorf("TempAir = %v, want 20.5 (core measurements must survive)", obs[0].TempAir)
+	}
+	if obs[0].Battery != nil {
+		t.Errorf("Battery = %v, want nil (index 16 absent from a 13-element tuple)", *obs[0].Battery)
+	}
+	if obs[0].ReportInterval != nil {
+		t.Errorf("ReportInterval = %v, want nil (index 17 absent)", *obs[0].ReportInterval)
+	}
+}
+
+// Below the floor there is nothing usable, so the tuple is dropped.
+func TestObservationsDropsTupleBelowFloor(t *testing.T) {
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[[1700000000,0.1,0.2]]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Errorf("got %d observations, want 0 — a 3-element tuple is below the 13 floor", len(obs))
+	}
+}
+
 func TestObservationsRequestsCorrectWindow(t *testing.T) {
 	var gotQuery string
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -781,6 +827,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -834,6 +881,17 @@ const (
 	obsFieldCount // 18 — the number of indices this code reads
 )
 
+// obsMinFields is the floor below which a tuple carries no usable core
+// measurements. It mirrors the UDP ingest path, which accepts a report at
+// len(ob) >= 13 and fills the tail conditionally (sqlite/writer.go:406-457).
+//
+// The guards here are GRADUATED, not all-or-nothing. A hard
+// "len(ob) < 18 -> drop" would silently discard a short tuple's temperature,
+// pressure and wind — a real divergence from the ingest path the design
+// forbids. Because every weather.Observation measurement is a *float64,
+// honoring the graduated rule is free: absent indices simply stay nil.
+const obsMinFields = 13
+
 // Observations fetches raw historical observations for one device over
 // [start, end] and returns them in store-neutral form.
 //
@@ -886,35 +944,58 @@ func (c *Client) Observations(ctx context.Context, station Station, start, end t
 		}
 	}
 
+	// at returns ob[i] when the tuple is long enough, nil otherwise. This is
+	// the graduated guard: a short tuple keeps its core measurements and gets
+	// NULL for the indices it does not carry.
+	at := func(ob []*float64, i int) *float64 {
+		if i < len(ob) {
+			return ob[i]
+		}
+		return nil
+	}
+
 	out := make([]weather.Observation, 0, len(set.Obs))
+	dropped := 0
 	for _, ob := range set.Obs {
-		if len(ob) < obsFieldCount || ob[obsTimestamp] == nil {
-			// Short tuple or no timestamp: the row cannot be keyed by
+		if len(ob) < obsMinFields || ob[obsTimestamp] == nil {
+			// Below the floor, or no timestamp: the row cannot be keyed by
 			// (serial_number, timestamp), so writing it would create an
-			// un-dedupable row at some arbitrary instant. Drop it.
+			// un-dedupable row at some arbitrary instant. Drop it — and count
+			// it, so an all-malformed window is distinguishable from a
+			// permanent hole.
+			dropped++
 			continue
 		}
 		out = append(out, weather.Observation{
 			SerialNumber:         station.SerialNumber,
 			Timestamp:            time.Unix(int64(*ob[obsTimestamp]), 0).UTC(),
-			WindLull:             ob[obsWindLull],
-			WindAvg:              ob[obsWindAvg],
-			WindGust:             ob[obsWindGust],
-			WindDirection:        ob[obsWindDirection],
-			WindSampleInterval:   ob[obsWindSampleInterval],
-			Pressure:             ob[obsPressure],
-			TempAir:              ob[obsTempAir],
-			Humidity:             ob[obsHumidity],
-			Illuminance:          ob[obsIlluminance],
-			UVIndex:              ob[obsUVIndex],
-			Irradiance:           ob[obsIrradiance],
-			RainRate:             ob[obsRainRate],
-			PrecipType:           ob[obsPrecipType],
-			LightningDistance:    ob[obsLightningDistance],
-			LightningStrikeCount: ob[obsLightningStrikeCount],
-			Battery:              ob[obsBattery],
-			ReportInterval:       ob[obsReportInterval],
+			WindLull:             at(ob, obsWindLull),
+			WindAvg:              at(ob, obsWindAvg),
+			WindGust:             at(ob, obsWindGust),
+			WindDirection:        at(ob, obsWindDirection),
+			WindSampleInterval:   at(ob, obsWindSampleInterval),
+			Pressure:             at(ob, obsPressure),
+			TempAir:              at(ob, obsTempAir),
+			Humidity:             at(ob, obsHumidity),
+			Illuminance:          at(ob, obsIlluminance),
+			UVIndex:              at(ob, obsUVIndex),
+			Irradiance:           at(ob, obsIrradiance),
+			RainRate:             at(ob, obsRainRate),
+			PrecipType:           at(ob, obsPrecipType),
+			LightningDistance:    at(ob, obsLightningDistance),
+			LightningStrikeCount: at(ob, obsLightningStrikeCount),
+			Battery:              at(ob, obsBattery),
+			ReportInterval:       at(ob, obsReportInterval),
 		})
+	}
+
+	if dropped > 0 {
+		// WARN, not silence: without this, a window whose tuples were all
+		// malformed reports zero rows — byte-identical to the permanent-hole
+		// signal the reporting design rests on.
+		slog.Warn("tempestapi: dropped malformed observation tuples",
+			"serial", station.SerialNumber, "dropped", dropped, "total", len(set.Obs),
+			"start", start, "end", end)
 	}
 	return out, nil
 }
@@ -1081,7 +1162,9 @@ In `internal/postgres/writer.go`, replace the block currently at `:145-167` (fro
 	}
 ```
 
-Leave everything from `// Auto-create schema` onward unchanged. Then remove any import of `pgxpool` or `time` from `writer.go` **only if** `go build` reports it unused — `time` is used elsewhere in that file, so expect only `pgxpool` to possibly become unused. Let the compiler tell you; do not guess.
+Leave everything from `// Auto-create schema` onward unchanged.
+
+**No imports become unused.** `pgxpool` is still referenced by the `pool *pgxpool.Pool` struct field (`writer.go:98`), and `time` is used throughout. Do not go hunting for imports to delete — if the compiler reports one unused, something else went wrong; re-read the edit.
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -1115,7 +1198,8 @@ git commit -m "refactor(postgres): extract OpenPool as the single source of pool
 **Interfaces:**
 - Consumes: `weather.Observation`, `weather.Gap`, `weather.Bounds` (Task 1).
 - Produces (all package-level, all taking `*sql.DB`, none starting goroutines):
-  - `func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weather.Bounds, error)`
+  - `func DistinctSerials(ctx context.Context, db *sql.DB) ([]string, error)` — **unwindowed**
+  - `func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weather.Bounds, error)` — windowed
   - `func FindObservationGaps(ctx context.Context, db *sql.DB, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)`
   - `func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observation) (int, error)`
 
@@ -1133,7 +1217,6 @@ Create `internal/sqlite/backfill_test.go`:
 package sqlite
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -1148,7 +1231,7 @@ import (
 func seedObs(t *testing.T, db *sql.DB, serial string, epochs ...int64) {
 	t.Helper()
 	for _, e := range epochs {
-		_, err := db.ExecContext(context.Background(),
+		_, err := db.ExecContext(t.Context(),
 			`INSERT INTO tempest_observations (id, serial_number, timestamp) VALUES (?, ?, ?)`,
 			uuid.Must(uuid.NewV7()).String(), serial, e)
 		if err != nil {
@@ -1218,6 +1301,43 @@ func TestSeriesBoundsPerSerial(t *testing.T) {
 	}
 	if !got["ST-B"].First.Equal(ts(5000)) || !got["ST-B"].Last.Equal(ts(6000)) {
 		t.Errorf("ST-B bounds = [%v, %v], want [5000, 6000]", got["ST-B"].First, got["ST-B"].Last)
+	}
+}
+
+// DistinctSerials must ignore the window entirely. This is the regression
+// guard for the false-mismatch bug: ST-B's only rows sit outside any window a
+// caller is likely to ask about, but it is still very much in the store.
+func TestDistinctSerialsIsUnwindowed(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 2000)
+	seedObs(t, db, "ST-B", 900000) // far outside a [0, 10000] window
+
+	serials, err := DistinctSerials(t.Context(), db)
+	if err != nil {
+		t.Fatalf("DistinctSerials: %v", err)
+	}
+	if len(serials) != 2 || serials[0] != "ST-A" || serials[1] != "ST-B" {
+		t.Errorf("got %v, want [ST-A ST-B] — the query must not be windowed", serials)
+	}
+
+	// Contrast: the windowed query legitimately does not see ST-B.
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	if len(bounds) != 1 {
+		t.Errorf("SeriesBounds returned %d serials, want 1 — this is why the two queries cannot be merged", len(bounds))
+	}
+}
+
+func TestDistinctSerialsEmptyTable(t *testing.T) {
+	db := newTestDB(t)
+	serials, err := DistinctSerials(t.Context(), db)
+	if err != nil {
+		t.Fatalf("DistinctSerials on empty table must not error: %v", err)
+	}
+	if len(serials) != 0 {
+		t.Errorf("got %d serials, want 0", len(serials))
 	}
 }
 
@@ -1462,6 +1582,34 @@ func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weathe
 	return out, nil
 }
 
+// DistinctSerials returns every serial the table has ever held.
+//
+// UNWINDOWED, deliberately. This is the pre-flight check's input, and it must
+// NOT be replaced by SeriesBounds' key set: SeriesBounds is windowed, so a
+// station that was simply quiet during the queried window would look absent
+// from the store entirely and trip a false serial mismatch — breaking
+// `backfill --from X --to Y`, which is the tool's main repair path.
+func DistinctSerials(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT DISTINCT serial_number FROM tempest_observations ORDER BY serial_number`)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct serials: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []string
+	for rows.Next() {
+		var serial string
+		if err := rows.Scan(&serial); err != nil {
+			return nil, fmt.Errorf("scan distinct serial: %w", err)
+		}
+		out = append(out, serial)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate distinct serials: %w", err)
+	}
+	return out, nil
+}
+
 // InsertObservations writes obs idempotently and reports how many rows were
 // actually new.
 //
@@ -1538,9 +1686,23 @@ Expected: PASS — all nine tests. In particular `TestFindObservationGapsPartiti
 
 - [ ] **Step 5: Sanity-check the partitioning claim by deleting it**
 
-Temporarily remove `PARTITION BY serial_number` from `findObservationGapsSQL` and re-run only that test.
-Run: `go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v`
-Expected: **FAIL** with "got 0 gaps, want 1" — proving the test actually guards the invariant. **Restore the `PARTITION BY` immediately** and re-run to confirm PASS.
+A test that guards an invariant it cannot actually detect is worse than no test. Prove this one bites — but do it so the mutation cannot survive by accident:
+
+```bash
+git add -A && git commit -m "wip: pre-mutation checkpoint"      # checkpoint first
+# now edit findObservationGapsSQL: delete " PARTITION BY serial_number"
+go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v
+```
+Expected: **FAIL** with "got 0 gaps, want 1".
+
+Then restore and **prove** the restore was exact:
+
+```bash
+git checkout -- internal/sqlite/backfill.go
+git diff --exit-code                                            # must print nothing, exit 0
+go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v
+```
+Expected: `git diff --exit-code` clean, test PASS. Do not proceed while `git diff` shows anything — a half-restored mutation in production SQL is exactly the failure this step exists to prevent.
 
 - [ ] **Step 6: Run the full gate**
 
@@ -1567,13 +1729,24 @@ git commit -m "feat(sqlite): add partitioned gap detection and idempotent backfi
 **Interfaces:**
 - Consumes: `weather.*` (Task 1), `OpenPool` (Task 4).
 - Produces (mirroring Task 5's signatures exactly, with `*pgxpool.Pool` in place of `*sql.DB`):
-  - `func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) ([]weather.Bounds, error)`
+  - `func DistinctSerials(ctx context.Context, pool *pgxpool.Pool) ([]string, error)` — **unwindowed**
+  - `func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) ([]weather.Bounds, error)` — windowed
   - `func FindObservationGaps(ctx context.Context, pool *pgxpool.Pool, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)`
   - `func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.Observation) (int, error)`
 
 **Signatures are pinned to `time.Time` on both stores** so one interface satisfies both without a shim. The epoch conversion stays inside the SQLite implementation, matching how that package already handles timestamps; Postgres passes `time.Time` straight through to `TIMESTAMPTZ`.
 
-**Note on tests:** this package's database tests require a live Postgres and skip without one — that is pre-existing behavior. The unit-testable part here is wet-bulb derivation, which is shared logic; the SQL is verified by the integration suite when a database is available. Follow the existing skip idiom in `internal/postgres/writer_integration_test.go` for anything requiring a connection.
+**This task's SQL is the least-covered code in the change, and that is a stated risk, not an oversight.** Both reviews flagged it. The unit tests here cover only wet-bulb derivation; every query is exercised solely by `TestBackfillPostgresIntegration`, which **skips** unless `POSTGRES_URL` is set.
+
+**Therefore: run it against a real database at least once before this branch merges, and paste the output.** A run in which it skipped is not evidence. If no database is available, say so explicitly when reporting this task complete — do not report the Postgres path as verified.
+
+```bash
+docker run --rm -d --name twx-itest -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+# wait for readiness, then:
+POSTGRES_URL='postgres://postgres:x@localhost:55432/weather?sslmode=disable' \
+  go test ./internal/postgres/ -run TestBackfillPostgresIntegration -v
+docker rm -f twx-itest
+```
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1583,8 +1756,11 @@ Create `internal/postgres/backfill_test.go`:
 package postgres
 
 import (
-	"strings"
+	"context"
+	"os"
+	"slices"
 	"testing"
+	"time"
 
 	"tempestwx-utilities/internal/weather"
 )
@@ -1635,21 +1811,131 @@ func TestBackfillWetBulbDerivation(t *testing.T) {
 	}
 }
 
-// The gap SQL must partition by serial. This pins the text so the invariant
-// cannot be dropped silently; the behavioral proof lives in the SQLite suite,
-// where the query runs against a real database without external setup.
-func TestFindObservationGapsSQLPartitionsBySerial(t *testing.T) {
-	if !strings.Contains(findObservationGapsSQL, "PARTITION BY serial_number") {
-		t.Error("findObservationGapsSQL must PARTITION BY serial_number; " +
-			"without it, two phase-offset stations mask each other's outages")
+// --- integration: requires a live Postgres ---
+//
+// Everything above is a pure unit test. The SQL below is the ONLY thing that
+// exercises this file's actual queries, and the Postgres dialect differs from
+// SQLite's in ways that can fail at runtime and nowhere else:
+//
+//   - EXTRACT(EPOCH FROM (ts - prev)) yields numeric in PG14+, compared here
+//     against a float64 parameter.
+//   - MIN/MAX over timestamptz scanned into time.Time.
+//   - precip_type is INTEGER in the DDL (schema.go:55) while the bind is a
+//     *float64 — pgx truncates silently rather than erroring.
+//
+// Follow the existing skip idiom in writer_integration_test.go. This must be
+// RUN AT LEAST ONCE against a real database before the branch merges; a run
+// where it skips is not evidence.
+func TestBackfillPostgresIntegration(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("POSTGRES_URL not set; skipping Postgres integration test")
+	}
+
+	ctx := t.Context()
+	pool, err := OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("OpenPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := CreateSchema(ctx, pool); err != nil {
+		t.Fatalf("CreateSchema: %v", err)
+	}
+
+	// Isolate this run from anything already in the table.
+	serialA := "ST-ITEST-A"
+	serialB := "ST-ITEST-B"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB)
+	})
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB); err != nil {
+		t.Fatalf("pre-clean: %v", err)
+	}
+
+	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC) // far from real data
+
+	// The same interleaved fixture the SQLite suite uses: ST-A has a one-hour
+	// hole; ST-B reports throughout, offset, and would mask it if the query
+	// were not partitioned.
+	var seed []weather.Observation
+	for _, off := range []time.Duration{0, time.Hour, 90 * time.Minute} {
+		seed = append(seed, weather.Observation{SerialNumber: serialA, Timestamp: base.Add(off), TempAir: f(20)})
+	}
+	for off := 30 * time.Second; off <= 95*time.Minute; off += 10 * time.Minute {
+		seed = append(seed, weather.Observation{SerialNumber: serialB, Timestamp: base.Add(off), TempAir: f(21)})
+	}
+
+	n, err := InsertObservations(ctx, pool, seed)
+	if err != nil {
+		t.Fatalf("InsertObservations: %v", err)
+	}
+	if n != len(seed) {
+		t.Errorf("inserted %d rows, want %d", n, len(seed))
+	}
+
+	// Idempotency: the same batch again must insert nothing.
+	again, err := InsertObservations(ctx, pool, seed)
+	if err != nil {
+		t.Fatalf("second InsertObservations: %v", err)
+	}
+	if again != 0 {
+		t.Errorf("re-insert added %d rows, want 0", again)
+	}
+
+	from, to := base.Add(-time.Hour), base.Add(3*time.Hour)
+
+	serials, err := DistinctSerials(ctx, pool)
+	if err != nil {
+		t.Fatalf("DistinctSerials: %v", err)
+	}
+	if !slices.Contains(serials, serialA) || !slices.Contains(serials, serialB) {
+		t.Errorf("DistinctSerials = %v, want it to contain %s and %s", serials, serialA, serialB)
+	}
+
+	bounds, err := SeriesBounds(ctx, pool, from, to)
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	var gotA bool
+	for _, b := range bounds {
+		if b.SerialNumber == serialA {
+			gotA = true
+			if !b.First.Equal(base) {
+				t.Errorf("%s First = %v, want %v", serialA, b.First, base)
+			}
+		}
+	}
+	if !gotA {
+		t.Errorf("SeriesBounds missing %s: %+v", serialA, bounds)
+	}
+
+	gaps, err := FindObservationGaps(ctx, pool, from, to, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	var found bool
+	for _, g := range gaps {
+		if g.SerialNumber == serialA && g.From.Equal(base) && g.To.Equal(base.Add(time.Hour)) {
+			found = true
+		}
+		if g.SerialNumber == serialB {
+			t.Errorf("unexpected gap for %s: %+v", serialB, g)
+		}
+	}
+	if !found {
+		t.Errorf("did not find the %s hole [%v, %v]; got %+v", serialA, base, base.Add(time.Hour), gaps)
 	}
 }
 ```
 
+The `strings.Contains(findObservationGapsSQL, "PARTITION BY serial_number")` assertion that appeared in an earlier draft of this task is **deliberately absent**. It asserts that a string constant contains a substring the same file defines — it would pass against SQL with a broken `WHERE`, a wrong comparison operator, or a missing alias, and it cannot fail for the reason its name claims. The behavioral proof is the integration test above plus the SQLite suite's mutation check.
+
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestFindObservationGapsSQL' -v`
-Expected: FAIL to compile — `undefined: wetBulb`, `undefined: findObservationGapsSQL`.
+Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestBackfillPostgresIntegration' -v`
+Expected: FAIL to compile — `undefined: wetBulb`, `undefined: DistinctSerials`, `undefined: SeriesBounds`, `undefined: FindObservationGaps`, `undefined: InsertObservations`.
 
 - [ ] **Step 3: Write the implementation**
 
@@ -1679,9 +1965,9 @@ import (
 // abstraction. The signatures are identical so one consumer-side interface
 // satisfies both.
 
-// insertBatchSize bounds how many rows go into one SendBatch. The daemon's
-// 5s timeout at insertObservations was sized for the 1-row live path; a
-// backfill batch needs its own budget.
+// backfillBatchTimeout bounds one backfill SendBatch. The daemon's hardcoded
+// 5s at insertObservations (writer.go:240) was sized for the 1-row live path;
+// a backfill batch of up to 200 rows needs its own budget.
 const backfillBatchTimeout = 30 * time.Second
 
 // findObservationGapsSQL locates interior holes in each station's series.
@@ -1767,6 +2053,32 @@ func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) (
 	return out, nil
 }
 
+// DistinctSerials returns every serial the table has ever held.
+//
+// UNWINDOWED, deliberately — see the identical comment in
+// internal/sqlite/backfill.go. Merging this into SeriesBounds causes a false
+// serial mismatch for any station that was quiet during the queried window.
+func DistinctSerials(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
+	rows, err := pool.Query(ctx, `SELECT DISTINCT serial_number FROM tempest_observations ORDER BY serial_number`)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct serials: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var serial string
+		if err := rows.Scan(&serial); err != nil {
+			return nil, fmt.Errorf("scan distinct serial: %w", err)
+		}
+		out = append(out, serial)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate distinct serials: %w", err)
+	}
+	return out, nil
+}
+
 const backfillInsertSQL = `
 	INSERT INTO tempest_observations (
 		id, serial_number, timestamp,
@@ -1836,12 +2148,14 @@ func wetBulb(o weather.Observation) *float64 {
 }
 ```
 
-> **Implementer note:** `wetBulb` appears in both `internal/sqlite/backfill.go` and `internal/postgres/backfill.go`. This is deliberate and must NOT be extracted into a shared helper — the two store packages do not import each other, and the only neutral home (`internal/weather`) would then have to import `internal/tempestudp`, which pulls the UDP wire protocol into the leaf type package and creates exactly the coupling Task 1 exists to prevent. The *shared knowledge* — the wet-bulb formula — already lives in exactly one place: `tempestudp.WetBulbTemperatureC`. What is duplicated here is a four-line nil guard, which is shared shape, not shared knowledge. If `closeBatchResults` is unexported and already defined in `writer.go`, reuse it; do not redefine it.
+> **Implementer note on the duplicated `wetBulb`.** It appears in both `internal/sqlite/backfill.go` and `internal/postgres/backfill.go`, four lines each. Keep it duplicated — but understand the *real* reason, because an earlier draft of this plan justified it with a false claim (that a shared home would force `internal/weather` to import `internal/tempestudp` and create a cycle). That is **not true**: `internal/tempestudp` imports only stdlib and `internal/tempest`, so `weather → tempestudp` is a perfectly legal acyclic edge. The honest justification is narrower: the duplicated part is a four-line nil guard, the *formula* — the actual shared knowledge — already lives in exactly one place (`tempestudp.WetBulbTemperatureC`), and four lines is cheaper than a new cross-package dependency. Note the counter-argument is real: the rule "wet bulb is NULL unless temp, humidity and pressure are all present" *is* shared knowledge under the DRY test, and if it ever changes both copies must change together. Leave a comment in each saying so.
+>
+> Also: `closeBatchResults` is already defined (unexported) at `internal/postgres/writer.go:223`. Reuse it; do not redefine it.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestFindObservationGapsSQL' -v`
-Expected: PASS.
+Run: `go test ./internal/postgres/ -run 'TestBackfillWetBulb|TestBackfillPostgresIntegration' -v`
+Expected: the wet-bulb subtests PASS; the integration test SKIPs without `POSTGRES_URL`. Then run it for real per the note at the top of this task and paste that output too.
 
 Run the package suite: `go test ./internal/postgres/ -v`
 Expected: PASS; integration tests skip without a database, as before.
@@ -2287,7 +2601,9 @@ Create `internal/backfill/gaps.go`:
 package backfill
 
 import (
-	"sort"
+	"cmp"
+	"slices"
+	"strings"
 	"time"
 
 	"tempestwx-utilities/internal/weather"
@@ -2350,11 +2666,13 @@ func assembleGaps(
 		}
 	}
 
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].SerialNumber != out[j].SerialNumber {
-			return out[i].SerialNumber < out[j].SerialNumber
-		}
-		return out[i].From.Before(out[j].From)
+	// slices.SortFunc, not sort.Slice: it is the Go 1.25 idiom, and sort.Slice
+	// is unstable while (serial, From) is not guaranteed unique.
+	slices.SortFunc(out, func(a, b weather.Gap) int {
+		return cmp.Or(
+			strings.Compare(a.SerialNumber, b.SerialNumber),
+			a.From.Compare(b.From),
+		)
 	})
 	return out
 }
@@ -2844,8 +3162,12 @@ type Config struct {
 	// reporting jitter from registering.
 	MinGap time.Duration
 
-	// DryRun detects and plans only: zero API calls, zero writes. It
-	// consequently cannot validate the token or reachability.
+	// DryRun detects and plans only: Run makes zero observation fetches and
+	// zero writes.
+	//
+	// Note the shell still calls ListDevices before invoking Run, so the
+	// COMMAND does make one API call in dry-run and therefore does validate
+	// the token. Do not document it as "zero API calls".
 	DryRun bool
 }
 
@@ -3215,13 +3537,17 @@ Create `backfill_cmd_test.go`:
 package main
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestParseBackfillFlagsDefaults(t *testing.T) {
-	cfg, err := parseBackfillFlags(nil)
+	cfg, _, err := parseBackfillFlags(nil)
 	if err != nil {
 		t.Fatalf("parseBackfillFlags: %v", err)
 	}
@@ -3237,7 +3563,7 @@ func TestParseBackfillFlagsDefaults(t *testing.T) {
 }
 
 func TestParseBackfillFlagsRFC3339IsUTC(t *testing.T) {
-	cfg, err := parseBackfillFlags([]string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"})
+	cfg, _, err := parseBackfillFlags([]string{"--from", "2026-01-02T03:04:05Z", "--to", "2026-01-03T03:04:05Z"})
 	if err != nil {
 		t.Fatalf("parseBackfillFlags: %v", err)
 	}
@@ -3250,7 +3576,7 @@ func TestParseBackfillFlagsRFC3339IsUTC(t *testing.T) {
 }
 
 func TestParseBackfillFlagsRejectsNonRFC3339(t *testing.T) {
-	_, err := parseBackfillFlags([]string{"--from", "2026-01-02"})
+	_, _, err := parseBackfillFlags([]string{"--from", "2026-01-02"})
 	if err == nil {
 		t.Fatal("a non-RFC3339 --from must be rejected; an ambiguous local-time parse is a quiet wrong-window bug")
 	}
@@ -3260,23 +3586,23 @@ func TestParseBackfillFlagsRejectsNonRFC3339(t *testing.T) {
 }
 
 func TestParseBackfillFlagsRequiresBothOrNeither(t *testing.T) {
-	if _, err := parseBackfillFlags([]string{"--from", "2026-01-02T00:00:00Z"}); err == nil {
+	if _, _, err := parseBackfillFlags([]string{"--from", "2026-01-02T00:00:00Z"}); err == nil {
 		t.Error("--from without --to must be rejected")
 	}
-	if _, err := parseBackfillFlags([]string{"--to", "2026-01-02T00:00:00Z"}); err == nil {
+	if _, _, err := parseBackfillFlags([]string{"--to", "2026-01-02T00:00:00Z"}); err == nil {
 		t.Error("--to without --from must be rejected")
 	}
 }
 
 func TestParseBackfillFlagsRejectsInvertedRange(t *testing.T) {
-	_, err := parseBackfillFlags([]string{"--from", "2026-01-03T00:00:00Z", "--to", "2026-01-02T00:00:00Z"})
+	_, _, err := parseBackfillFlags([]string{"--from", "2026-01-03T00:00:00Z", "--to", "2026-01-02T00:00:00Z"})
 	if err == nil {
 		t.Fatal("--to before --from must be rejected")
 	}
 }
 
 func TestParseBackfillFlagsDryRun(t *testing.T) {
-	cfg, err := parseBackfillFlags([]string{"--dry-run", "--min-gap", "2h"})
+	cfg, _, err := parseBackfillFlags([]string{"--dry-run", "--min-gap", "2h"})
 	if err != nil {
 		t.Fatalf("parseBackfillFlags: %v", err)
 	}
@@ -3288,15 +3614,80 @@ func TestParseBackfillFlagsDryRun(t *testing.T) {
 	}
 }
 
-func TestRunBackfillWithoutTokenFailsFast(t *testing.T) {
-	// TOKEN is validated before any store handle is opened, so the failure
-	// costs no I/O and leaves nothing to close. SQLITE_PATH points at a
-	// location that would fail to open, proving no store was touched.
+// TOKEN must be validated BEFORE any store handle is opened, so the failure
+// costs no I/O and leaves nothing to close.
+//
+// The ordering is proven by pointing SQLITE_PATH at a path inside a writable
+// temp dir and asserting the file was never created. An earlier version of
+// this test used a bogus path and asserted only exit==1 — which passes
+// identically whether TOKEN is checked before or after the store opens, since
+// a failed open also returns 1. That test could not fail for its stated
+// reason.
+func TestRunBackfillWithoutTokenFailsBeforeOpeningTheStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "should-never-be-created.db")
 	t.Setenv("TOKEN", "")
-	t.Setenv("SQLITE_PATH", "/nonexistent-dir-should-never-be-opened/tempest.db")
+	t.Setenv("ENABLE_POSTGRES", "")
+	t.Setenv("SQLITE_PATH", dbPath)
 
 	if got := runBackfill(t.Context(), nil); got != 1 {
 		t.Errorf("exit code = %d, want 1 for a missing TOKEN", got)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("SQLite database at %s was created; TOKEN must be validated before the store is opened", dbPath)
+	}
+}
+
+func TestParseBackfillFlagsStoreValidation(t *testing.T) {
+	for _, v := range []string{"sqlite", "postgres", ""} {
+		if _, got, err := parseBackfillFlags([]string{"--store", v}); err != nil || got != v {
+			t.Errorf("--store=%q: got (%q, %v), want (%q, nil)", v, got, err, v)
+		}
+	}
+	if _, _, err := parseBackfillFlags([]string{"--store", "mysql"}); err == nil {
+		t.Error("--store=mysql must be rejected")
+	}
+}
+
+func TestResolveStore(t *testing.T) {
+	both := storeChoice{sqlite: true, postgres: true}
+	onlySQLite := storeChoice{sqlite: true}
+	onlyPG := storeChoice{postgres: true}
+	none := storeChoice{}
+
+	tests := []struct {
+		name    string
+		choice  storeChoice
+		flag    string
+		want    string
+		wantErr bool
+	}{
+		{"single store needs no flag", onlySQLite, "", "sqlite", false},
+		{"single store, matching flag", onlyPG, "postgres", "postgres", false},
+		{"single store, contradicting flag", onlySQLite, "postgres", "", true},
+		{"both configured, flag chooses", both, "postgres", "postgres", false},
+		{"both configured, flag chooses sqlite", both, "sqlite", "sqlite", false},
+		// The regression: never silently pick one.
+		{"both configured, no flag", both, "", "", true},
+		{"nothing configured", none, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStore(tt.choice, tt.flag)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --help is not a usage error.
+func TestRunBackfillHelpExitsZero(t *testing.T) {
+	t.Setenv("TOKEN", "x")
+	if got := runBackfill(t.Context(), []string{"--help"}); got != 0 {
+		t.Errorf("exit code = %d, want 0 — `cmd --help` is a successful invocation", got)
 	}
 }
 
@@ -3313,20 +3704,48 @@ func TestKnownSubcommands(t *testing.T) {
 			t.Errorf("%q should be a known subcommand", name)
 		}
 	}
-	// The regression this guards: "backfil" previously fell through to daemon
-	// mode and silently started a UDP listener.
 	for _, name := range []string{"backfil", "helthcheck", "migrate", ""} {
 		if isKnownSubcommand(name) {
 			t.Errorf("%q should NOT be a known subcommand", name)
 		}
 	}
 }
+
+// TestKnownSubcommands above tests a pure predicate — it would still pass if
+// main() never called it. This one tests the BEHAVIOR the design mandates:
+// an unknown subcommand must exit 2 and must NOT start the daemon.
+//
+// The regression it guards is real: before the dispatch fix, `backfil` fell
+// through and silently started a UDP listener, which never exits — so a
+// failure here shows up as a timeout, not just a bad exit code.
+func TestUnknownSubcommandExitsTwoWithoutStartingDaemon(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "twx")
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", bin, ".")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	cmd := exec.CommandContext(t.Context(), bin, "backfil")
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected a non-zero exit, got err=%v\n%s", err, out)
+	}
+	if code := exitErr.ExitCode(); code != 2 {
+		t.Errorf("exit code = %d, want 2\n%s", code, out)
+	}
+	if !strings.Contains(string(out), "unknown subcommand") {
+		t.Errorf("output should name the bad subcommand, got:\n%s", out)
+	}
+}
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestKnownSubcommands' -v`
-Expected: FAIL to compile — `undefined: parseBackfillFlags`, `undefined: runBackfill`, `undefined: isKnownSubcommand`.
+Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestResolveStore|TestKnownSubcommands|TestUnknownSubcommand' -v`
+Expected: FAIL to compile — `undefined: parseBackfillFlags`, `undefined: runBackfill`, `undefined: resolveStore`, `undefined: isKnownSubcommand`.
 
 - [ ] **Step 3: Write the shell**
 
@@ -3343,6 +3762,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"tempestwx-utilities/internal/backfill"
@@ -3366,39 +3786,98 @@ import (
 // --from/--to are RFC3339 interpreted as UTC. The store is UTC epoch and the
 // API takes epoch seconds; an ambiguous local-time parse would be a quiet
 // wrong-window bug, so a non-RFC3339 value is rejected rather than guessed at.
-func parseBackfillFlags(args []string) (backfill.Config, error) {
+func parseBackfillFlags(args []string) (backfill.Config, string, error) {
 	fs := flag.NewFlagSet("backfill", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
 	fromStr := fs.String("from", "", "start of the window to repair, RFC3339 UTC (default: auto-detect)")
 	toStr := fs.String("to", "", "end of the window to repair, RFC3339 UTC (default: auto-detect)")
 	minGap := fs.Duration("min-gap", 30*time.Minute, "smallest interval that counts as a gap")
-	dryRun := fs.Bool("dry-run", false, "detect and plan only: zero API calls, zero writes")
+	dryRun := fs.Bool("dry-run", false, "detect and plan only: no observation fetches, no writes")
+
+	store := fs.String("store", "", "which store to repair: sqlite or postgres (required when both are configured)")
 
 	if err := fs.Parse(args); err != nil {
-		return backfill.Config{}, err
+		return backfill.Config{}, "", err
 	}
 
 	cfg := backfill.Config{MinGap: *minGap, DryRun: *dryRun}
 
+	// --store is returned separately, not folded into backfill.Config: it
+	// selects which handle the SHELL opens, and Run has no use for it. A core
+	// config struct carrying a field the core ignores is a trap.
+	switch *store {
+	case "", "sqlite", "postgres":
+	default:
+		return cfg, *store, usageErr(fs, "--store must be sqlite or postgres, got %q", *store)
+	}
+
 	if (*fromStr == "") != (*toStr == "") {
-		return cfg, errors.New("--from and --to must be given together, or neither")
+		return cfg, *store, usageErr(fs, "--from and --to must be given together, or neither")
 	}
 	if *fromStr != "" {
 		from, err := time.Parse(time.RFC3339, *fromStr)
 		if err != nil {
-			return cfg, fmt.Errorf("--from must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+			return cfg, *store, usageErr(fs, "--from must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
 		}
 		to, err := time.Parse(time.RFC3339, *toStr)
 		if err != nil {
-			return cfg, fmt.Errorf("--to must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
+			return cfg, *store, usageErr(fs, "--to must be RFC3339 (e.g. 2026-01-02T03:04:05Z): %w", err)
 		}
 		cfg.From, cfg.To = from.UTC(), to.UTC()
 		if !cfg.To.After(cfg.From) {
-			return cfg, errors.New("--to must be after --from")
+			return cfg, *store, usageErr(fs, "--to must be after --from")
 		}
 	}
-	return cfg, nil
+	return cfg, *store, nil
+}
+
+// usageErr reports a validation failure the way flag reports a parse failure:
+// message plus usage, on stderr. Centralizing it means runBackfill prints
+// nothing itself, so flag's message is never duplicated.
+func usageErr(fs *flag.FlagSet, format string, a ...any) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(fs.Output(), err)
+	fs.Usage()
+	return err
+}
+
+// resolveStore decides which single store this run repairs.
+//
+// Backfill repairs ONE store per run. selectStore returns BOTH when
+// ENABLE_POSTGRES=true and SQLITE_PATH is set — a documented fan-out the
+// daemon honors by writing every observation to both (main.go:302-336). In
+// that configuration backfill cannot infer the target, and guessing is the
+// worst option available: repairing Postgres while leaving the
+// Litestream-replicated SQLite database holed, then exiting 0, tells the
+// operator the history is fixed when it is not.
+func resolveStore(choice storeChoice, flagValue string) (string, error) {
+	var configured []string
+	if choice.sqlite {
+		configured = append(configured, "sqlite")
+	}
+	if choice.postgres {
+		configured = append(configured, "postgres")
+	}
+
+	switch len(configured) {
+	case 0:
+		return "", errors.New("backfill: no store configured; set SQLITE_PATH, or ENABLE_POSTGRES=true with POSTGRES_URL")
+	case 1:
+		if flagValue != "" && flagValue != configured[0] {
+			return "", fmt.Errorf("backfill: --store=%s, but only %s is configured", flagValue, configured[0])
+		}
+		return configured[0], nil
+	default:
+		if flagValue == "" {
+			return "", fmt.Errorf(
+				"backfill: both %s are configured; pass --store=sqlite or --store=postgres. "+
+					"Backfill repairs one store per run and will not guess — silently repairing "+
+					"only one while reporting success would leave the other permanently holed",
+				strings.Join(configured, " and "))
+		}
+		return flagValue, nil
+	}
 }
 
 // sqliteStore adapts the package-level SQLite functions to backfill.Store.
@@ -3441,12 +3920,17 @@ func (s postgresStore) InsertObservations(ctx context.Context, obs []weather.Obs
 // Exit codes: 0 success (including permanent holes), 1 a gap failed or a
 // runtime error, 2 a usage error.
 func runBackfill(ctx context.Context, args []string) int {
-	cfg, err := parseBackfillFlags(args)
+	cfg, storeFlag, err := parseBackfillFlags(args)
 	if err != nil {
-		// flag.ContinueOnError already printed the message for parse errors.
-		if !errors.Is(err, flag.ErrHelp) {
-			fmt.Fprintln(os.Stderr, err)
+		// --help is NOT a usage error. flag prints the usage itself and
+		// returns ErrHelp; exiting 2 here would break every CI smoke test
+		// that runs `cmd --help`.
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
 		}
+		// parseBackfillFlags owns the FlagSet's output and has already
+		// reported the error, so nothing is printed here — printing again
+		// would duplicate flag's own message.
 		return 2
 	}
 
@@ -3470,9 +3954,20 @@ func runBackfill(ctx context.Context, args []string) int {
 	}
 	choice := selectStore(enablePostgres, os.Getenv("SQLITE_PATH"))
 
+	// Backfill repairs ONE store per run, and must never guess which. The
+	// daemon fans out to both when ENABLE_POSTGRES and SQLITE_PATH are both
+	// set (main.go:147-154, :302-336); silently repairing Postgres while
+	// leaving the SQLite database — the one Litestream replicates to S3 —
+	// still holed, then reporting success, is the worst available outcome.
+	target, err := resolveStore(choice, storeFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
 	var store backfill.Store
-	switch {
-	case choice.postgres:
+	switch target {
+	case "postgres":
 		dbConfig, err := config.GetDatabaseConfig()
 		if err != nil {
 			slog.Error("backfill: database configuration", "error", err)
@@ -3510,23 +4005,25 @@ func runBackfill(ctx context.Context, args []string) int {
 			}
 		}()
 		store = sqliteStore{db: db}
-	default:
-		slog.Error("backfill: no store configured")
-		return 1
 	}
+	slog.Info("backfill: store selected", "store", target)
 
 	client := tempestapi.NewClient(token)
-	stations, err := client.ListStations(ctx)
+	// ListDevices, NOT ListStations: ListStations collapses each station to a
+	// single ST device, so a two-sensor station would leave one sensor's gaps
+	// permanently unrepaired and unlogged.
+	devices, err := client.ListDevices(ctx)
 	if err != nil {
-		slog.Error("backfill: list stations", "error", err)
+		slog.Error("backfill: list devices", "error", err)
 		return 1
 	}
-	if len(stations) == 0 {
+	if len(devices) == 0 {
 		slog.Error("backfill: the API reported no ST devices for this token")
 		return 1
 	}
+	slog.Info("backfill: devices discovered", "count", len(devices))
 
-	stats, err := backfill.Run(ctx, cfg, client, store, stations, time.Now().UTC())
+	stats, err := backfill.Run(ctx, cfg, client, store, devices, time.Now().UTC())
 	slog.Info("backfill: complete",
 		"gaps", stats.Gaps, "returned", stats.Returned,
 		"inserted", stats.Inserted, "failed", stats.Failed, "dry_run", cfg.DryRun)
@@ -3600,10 +4097,12 @@ Add `"strings"` to `main.go`'s import block. `context` and `fmt` are already imp
 
 - [ ] **Step 5: Run tests to verify they pass**
 
-Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestKnownSubcommands' -v`
-Expected: PASS — all nine tests.
+Run: `go test . -run 'TestParseBackfill|TestRunBackfill|TestResolveStore|TestKnownSubcommands|TestUnknownSubcommand' -v`
+Expected: PASS.
 
 - [ ] **Step 6: Verify the dispatch by hand**
+
+These behaviors also have real tests (`TestUnknownSubcommandExitsTwoWithoutStartingDaemon`, `TestRunBackfillHelpExitsZero`); run them by hand once as a sanity check on the built artifact:
 
 ```bash
 CGO_ENABLED=0 go build -o /tmp/twx . && /tmp/twx backfil; echo "exit=$?"
@@ -3613,7 +4112,12 @@ Expected: prints `unknown subcommand "backfil"` plus usage, `exit=2`, and **does
 ```bash
 /tmp/twx backfill --help; echo "exit=$?"
 ```
-Expected: prints the four backfill flags with their defaults.
+Expected: prints the five backfill flags with their defaults, and **`exit=0`** — `--help` is not a usage error.
+
+```bash
+ENABLE_POSTGRES=true SQLITE_PATH=/tmp/x.db TOKEN=x /tmp/twx backfill; echo "exit=$?"
+```
+Expected: refuses with a message naming both stores and telling you to pass `--store`; `exit=2`; nothing written.
 
 - [ ] **Step 7: Run the full gate**
 
@@ -3669,11 +4173,23 @@ It writes to whichever store is configured (SQLite by default, Postgres when
 |---|---|---|
 | `--from`, `--to` | unset (auto-detect) | Explicit window, RFC3339 **UTC**. Must be given together. |
 | `--min-gap` | `30m` | Smallest interval that counts as a gap. Raise it for stations with a long `report_interval`. |
-| `--dry-run` | `false` | Detect and plan only: zero API calls, zero writes. Cannot validate the token. |
+| `--dry-run` | `false` | Detect and plan only: zero observation fetches, zero writes. It still lists devices, so it *does* validate the token. |
+| `--store` | unset | `sqlite` or `postgres`. **Required** when both stores are configured. |
 
-**Exit codes:** `0` success (including permanent holes — windows the station was
-genuinely offline for, which the API cannot fill either), `1` one or more gaps
-failed or a runtime error, `2` usage error.
+**`--store` and the fan-out configuration.** With `ENABLE_POSTGRES=true` *and*
+`SQLITE_PATH` set, the daemon writes every observation to **both** stores.
+Backfill repairs one store per run, so in that configuration it refuses to start
+without `--store` rather than guessing — silently repairing Postgres while
+leaving the Litestream-replicated SQLite database holed, and then reporting
+success, would be worse than failing.
+
+**Multiple sensors.** `backfill` enumerates every `ST` device on the account, so a
+station with two Tempest units has both repaired. (This differs from `TOKEN`-mode
+API export, which sees one device per station.)
+
+**Exit codes:** `0` success — including `--help`, and including permanent holes
+(windows the station was genuinely offline for, which the API cannot fill
+either); `1` one or more gaps failed, or a runtime error; `2` usage error.
 
 **Scope:** `tempest_observations` only. There is no historical REST endpoint for
 rapid wind, hub status, or discrete events. Lightning is partially recovered in

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -19,7 +19,17 @@
 
 **Tech Stack:** Go 1.25, `database/sql` + `modernc.org/sqlite` (CGO_ENABLED=0), `pgx/v5` + `pgxpool`, stdlib `flag`, `log/slog`, stdlib testing (no testify).
 
-**Design:** `docs/designs/2026-07-28-api-backfill-tool-design.md` — read it before starting. This plan implements it; where they disagree, the design wins and the plan is wrong.
+**Design:** `docs/designs/2026-07-28-api-backfill-tool-design.md` — read it before starting. This plan implements it; where they disagree, the design wins and the plan is wrong — **with the settled exceptions below.**
+
+**Settled exceptions — the plan supersedes the design here. Do not "correct" toward the design:**
+
+| Topic | Design says | Use this instead |
+|---|---|---|
+| Core entry point | an unexported `backfill(ctx, cfg, client, store, now)` with unexported `backfillConfig`/`backfillStats`/`backfillStore` | **Task 9's exported `Run(ctx, cfg Config, src ObservationSource, store Store, stations []tempestapi.Station, now time.Time) (Stats, error)`** |
+| `stations` parameter | absent from the design's signature sketch | **required** — `Run` cannot resolve `detectFrom`, run the pre-flight, or key any fetch without it |
+| Summary attribute name | `requested` in one place, `returned` in another (the design contradicts itself) | **`returned`** |
+
+The design's signature sketch predates the decision to call the core from `package main`; an unexported `backfill()` is not reachable from the command shell, and one without `stations` cannot work at all. These are settled — implement the plan's version.
 
 ## Global Constraints
 
@@ -189,7 +199,7 @@ type Observation struct {
 // already exist (prev/next from LAG, First/Last from SeriesBounds), so both
 // ends get re-fetched and re-offered to the store. ON CONFLICT DO NOTHING
 // absorbs the duplicates, so this costs nothing but a slightly inflated
-// Requested count — but the doc must not claim a half-open interval it does
+// Returned count — but the doc must not claim a half-open interval it does
 // not have.
 //
 // The series is keyed by (SerialNumber, Timestamp) — the same uniqueness
@@ -223,7 +233,7 @@ Expected: PASS — both tests.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 Expected: build clean, vet clean, `gofmt -l .` prints nothing, all tests pass.
 
@@ -394,7 +404,7 @@ Do **not** change any other behavior in `client.go`. In particular, leave the mi
 
 - [ ] **Step 4b: Rename the 20 references in `client_test.go` — REQUIRED, and expected**
 
-Exporting these fields **breaks `internal/tempestapi/client_test.go` in 20 places**. This is not optional collateral to be worked around; it is a mechanical rename with no behavior change, and it is in scope for this task.
+Exporting these fields **breaks `internal/tempestapi/client_test.go` across 20 lines** (26 identifier occurrences — six of the literal lines carry both field names). This is not optional collateral to be worked around; it is a mechanical rename with no behavior change, and it is in scope for this task.
 
 - **12 composite-literal keys** — `:421, :422, :464, :465, :485, :500, :515, :542, :660, :661, :764, :787`
   `deviceID:` → `DeviceID:`, `serialNumber:` → `SerialNumber:`
@@ -625,9 +635,12 @@ Create `internal/tempestapi/observations_test.go`:
 package tempestapi
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -778,8 +791,20 @@ func TestObservationsKeepsShortTupleWithNullTail(t *testing.T) {
 	}
 }
 
-// Below the floor there is nothing usable, so the tuple is dropped.
-func TestObservationsDropsTupleBelowFloor(t *testing.T) {
+// Below the floor there is nothing usable, so the tuple is dropped — and the
+// drop MUST be logged.
+//
+// Asserting only len(obs)==0 would be insufficient: that outcome is identical
+// to an empty window, which is exactly the confusion the WARN exists to
+// prevent. A window whose tuples were all malformed would otherwise report
+// zero rows and read as a permanent hole — the one machine-readable
+// diagnostic the reporting design rests on.
+func TestObservationsDropsTupleBelowFloorAndLogsIt(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	body := `{"status":{"status_code":0},"type":"obs_st","obs":[[1700000000,0.1,0.2]]}`
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(body))
@@ -791,6 +816,33 @@ func TestObservationsDropsTupleBelowFloor(t *testing.T) {
 	}
 	if len(obs) != 0 {
 		t.Errorf("got %d observations, want 0 — a 3-element tuple is below the 13 floor", len(obs))
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "dropped=1") {
+		t.Errorf("the drop must be logged with a count; got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "ST-1") {
+		t.Errorf("the drop log must name the serial; got:\n%s", logged)
+	}
+}
+
+// The contrast case: a genuinely empty window must NOT log a drop warning,
+// or the signal is worthless.
+func TestObservationsEmptyWindowLogsNoDropWarning(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
+	})
+	if _, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0)); err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if strings.Contains(buf.String(), "dropped") {
+		t.Errorf("an empty window must not log a drop warning; got:\n%s", buf.String())
 	}
 }
 
@@ -878,7 +930,6 @@ const (
 	obsLightningStrikeCount
 	obsBattery
 	obsReportInterval
-	obsFieldCount // 18 — the number of indices this code reads
 )
 
 // obsMinFields is the floor below which a tuple carries no usable core
@@ -1009,7 +1060,7 @@ Expected: PASS — all six tests.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 6: Commit**
@@ -1177,7 +1228,7 @@ Expected: PASS, unchanged. (Integration tests requiring a live database skip whe
 - [ ] **Step 6: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 7: Commit**
@@ -1688,8 +1739,10 @@ Expected: PASS — all nine tests. In particular `TestFindObservationGapsPartiti
 
 A test that guards an invariant it cannot actually detect is worse than no test. Prove this one bites — but do it so the mutation cannot survive by accident:
 
+Use a file copy, **not** git. A `git commit` checkpoint here would leave Step 7 with nothing to stage (it exits 1, stopping the plan) and would strand a `wip:` commit in the branch that the final cold review sees; `git add -A` would also sweep in unrelated untracked files.
+
 ```bash
-git add -A && git commit -m "wip: pre-mutation checkpoint"      # checkpoint first
+cp internal/sqlite/backfill.go /tmp/backfill.go.bak
 # now edit findObservationGapsSQL: delete " PARTITION BY serial_number"
 go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v
 ```
@@ -1698,16 +1751,16 @@ Expected: **FAIL** with "got 0 gaps, want 1".
 Then restore and **prove** the restore was exact:
 
 ```bash
-git checkout -- internal/sqlite/backfill.go
-git diff --exit-code                                            # must print nothing, exit 0
+cp /tmp/backfill.go.bak internal/sqlite/backfill.go
+diff -u /tmp/backfill.go.bak internal/sqlite/backfill.go        # must print nothing
 go test ./internal/sqlite/ -run TestFindObservationGapsPartitionsBySerial -v
 ```
-Expected: `git diff --exit-code` clean, test PASS. Do not proceed while `git diff` shows anything — a half-restored mutation in production SQL is exactly the failure this step exists to prevent.
+Expected: `diff` silent, test PASS. Do not proceed while `diff` shows anything — a half-restored mutation in production SQL is exactly the failure this step exists to prevent.
 
 - [ ] **Step 6: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 7: Commit**
@@ -1861,7 +1914,20 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	// were not partitioned.
 	var seed []weather.Observation
 	for _, off := range []time.Duration{0, time.Hour, 90 * time.Minute} {
-		seed = append(seed, weather.Observation{SerialNumber: serialA, Timestamp: base.Add(off), TempAir: f(20)})
+		seed = append(seed, weather.Observation{
+			SerialNumber: serialA,
+			Timestamp:    base.Add(off),
+			TempAir:      f(20),
+			// These four map to INTEGER columns (schema.go:55 and siblings)
+			// while the bind is a *float64 — the exact hazard named at the
+			// top of this task. Seeding them is what makes the integration
+			// test exercise the risk it was written for; pgx truncates a
+			// float into int4 silently, so only a real round-trip catches it.
+			PrecipType:           f(1),
+			WindSampleInterval:   f(3),
+			LightningStrikeCount: f(0),
+			ReportInterval:       f(1),
+		})
 	}
 	for off := 30 * time.Second; off <= 95*time.Minute; off += 10 * time.Minute {
 		seed = append(seed, weather.Observation{SerialNumber: serialB, Timestamp: base.Add(off), TempAir: f(21)})
@@ -1909,6 +1975,33 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	}
 	if !gotA {
 		t.Errorf("SeriesBounds missing %s: %+v", serialA, bounds)
+	}
+
+	// Round-trip the INTEGER-typed columns: this is the named hazard.
+	var precip, interval, strikes, report *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT precip_type, wind_sample_interval, lightning_strike_count, report_interval
+		 FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serialA, base).Scan(&precip, &interval, &strikes, &report); err != nil {
+		t.Fatalf("read back INTEGER columns: %v", err)
+	}
+	for _, c := range []struct {
+		name string
+		got  *int64
+		want int64
+	}{
+		{"precip_type", precip, 1},
+		{"wind_sample_interval", interval, 3},
+		{"lightning_strike_count", strikes, 0},
+		{"report_interval", report, 1},
+	} {
+		if c.got == nil {
+			t.Errorf("%s is NULL, want %d", c.name, c.want)
+			continue
+		}
+		if *c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, *c.got, c.want)
+		}
 	}
 
 	gaps, err := FindObservationGaps(ctx, pool, from, to, 30*time.Minute)
@@ -2163,7 +2256,7 @@ Expected: PASS; integration tests skip without a database, as before.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 6: Commit**
@@ -2462,7 +2555,7 @@ Expected: PASS — all chunking and classification cases.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 6: Commit**
@@ -2686,7 +2779,7 @@ Expected: PASS — all six tests.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 6: Commit**
@@ -2718,6 +2811,7 @@ git commit -m "feat(backfill): assemble head, tail, and empty-store gaps around 
       Observations(ctx context.Context, station tempestapi.Station, start, end time.Time) ([]weather.Observation, error)
   }
   type Store interface {
+      DistinctSerials(ctx context.Context) ([]string, error)   // UNWINDOWED
       SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
       FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
       InsertObservations(ctx context.Context, obs []weather.Observation) (int, error)
@@ -2754,14 +2848,16 @@ import (
 // --- fakes ---
 
 type fakeSource struct {
-	calls   []window
-	obs     []weather.Observation
-	errs    []error // consumed one per call; nil entries succeed
-	callNum int
+	calls    []window
+	stations []tempestapi.Station // which device each call was for
+	obs      []weather.Observation
+	errs     []error // consumed one per call; nil entries succeed
+	callNum  int
 }
 
-func (f *fakeSource) Observations(_ context.Context, _ tempestapi.Station, start, end time.Time) ([]weather.Observation, error) {
+func (f *fakeSource) Observations(_ context.Context, st tempestapi.Station, start, end time.Time) ([]weather.Observation, error) {
 	f.calls = append(f.calls, window{from: start, to: end})
+	f.stations = append(f.stations, st)
 	i := f.callNum
 	f.callNum++
 	if i < len(f.errs) && f.errs[i] != nil {
@@ -2802,10 +2898,12 @@ func (f *fakeStore) InsertObservations(_ context.Context, obs []weather.Observat
 	return len(obs), nil
 }
 
+var deviceIDs = map[string]int{"ST-A": 1, "ST-B": 2}
+
 func station(serial string) tempestapi.Station {
 	return tempestapi.Station{
 		SerialNumber: serial,
-		DeviceID:     1,
+		DeviceID:     deviceIDs[serial],
 		CreatedAt:    time.Unix(1000, 0).UTC(),
 	}
 }
@@ -2914,21 +3012,56 @@ func TestRunNewSerialAlongsideKnownSerialIsNotAMismatch(t *testing.T) {
 // DistinctSerials (whole table), not SeriesBounds (windowed). A station that
 // simply had no rows inside the requested window is not missing from the
 // store, and `backfill --from X --to Y` is the tool's main repair path.
+//
+// The fixture is chosen so the two inputs DISAGREE — that is the whole point.
+// serials={ST-A, ST-OLD} overlaps the API's {ST-A}, so preflight passes; but
+// bounds={ST-OLD} does NOT overlap it, so feeding preflight the windowed key
+// set would report a false mismatch. A fixture where both inputs contain an
+// overlapping serial cannot tell the two apart and would pass either way.
 func TestRunQuietSerialInRequestedWindowIsNotAMismatch(t *testing.T) {
-	src := &fakeSource{obs: []weather.Observation{obsAt("ST-B", 5000)}}
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
 	store := &fakeStore{
-		// Both serials exist in the store...
-		serials: []string{"ST-A", "ST-B"},
-		// ...but only ST-A has rows inside the queried window.
-		bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(2000)}},
+		// Whole table: the API's ST-A IS in the store, alongside a retired
+		// serial.
+		serials: []string{"ST-A", "ST-OLD"},
+		// In-window: only ST-OLD has rows here. ST-A was quiet.
+		bounds: []weather.Bounds{{SerialNumber: "ST-OLD", First: at(1000), Last: at(2000)}},
 	}
 
 	from := at(0)
 	_, err := Run(t.Context(),
 		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
-		src, store, []tempestapi.Station{station("ST-A"), station("ST-B")}, from.Add(time.Hour))
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
 	if err != nil {
 		t.Fatalf("a serial with no rows in the requested window must not be a mismatch: %v", err)
+	}
+}
+
+// The design mandates that a station with two ST devices has BOTH backfilled.
+// Task 2's ListDevices test proves the two devices are discovered; this proves
+// Run actually fetches for each of them. Without it, the second half of that
+// requirement is untested and a regression that silently drops one sensor
+// would ship green.
+func TestRunBackfillsEveryDevice(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{} // empty: both devices get a whole-range gap
+
+	devices := []tempestapi.Station{station("ST-A"), station("ST-B")}
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute}, src, store, devices, at(200000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Gaps < 2 {
+		t.Errorf("Gaps = %d, want at least 2 — one per device", stats.Gaps)
+	}
+
+	fetched := map[string]bool{}
+	for _, s := range src.stations {
+		fetched[s.SerialNumber] = true
+	}
+	if !fetched["ST-A"] || !fetched["ST-B"] {
+		t.Errorf("fetched for %v, want both ST-A and ST-B — a two-sensor station must not lose one", fetched)
 	}
 }
 
@@ -3240,9 +3373,15 @@ func Run(
 		return stats, err
 	}
 
-	bounds, err := store.SeriesBounds(ctx, detectFrom, detectTo)
-	if err != nil {
-		return stats, fmt.Errorf("series bounds: %w", err)
+	// SeriesBounds is only needed by the auto-detect path — an explicit
+	// --from/--to names the window outright and never reads it. Querying it
+	// unconditionally would be a wasted round-trip on every explicit run.
+	var bounds []weather.Bounds
+	if cfg.From.IsZero() || cfg.To.IsZero() {
+		bounds, err = store.SeriesBounds(ctx, detectFrom, detectTo)
+		if err != nil {
+			return stats, fmt.Errorf("series bounds: %w", err)
+		}
 	}
 
 	gaps, err := plannedGaps(ctx, cfg, store, stations, bounds, detectFrom, detectTo)
@@ -3432,7 +3571,7 @@ func fillGap(
 		obs, err := fetchWithRetry(ctx, src, station, w)
 		if err != nil {
 			if ctx.Err() != nil {
-				return returned, inserted, ctx.Err()
+				return returned, inserted, errors.Join(append(windowErrs, ctx.Err())...)
 			}
 			slog.Error("backfill: window failed, continuing with the rest of the gap",
 				"serial", station.SerialNumber, "from", w.from, "to", w.to, "error", err)
@@ -3445,7 +3584,10 @@ func fillGap(
 		for chunk := range slices.Chunk(obs, insertBatchSize) {
 			n, err := store.InsertObservations(ctx, chunk)
 			if err != nil {
-				return returned, inserted, fmt.Errorf("insert: %w", err)
+				// Abort the gap — an unhealthy store will not be helped by
+				// the remaining windows — but keep any window diagnostics
+				// already accumulated rather than discarding them.
+				return returned, inserted, errors.Join(append(windowErrs, fmt.Errorf("insert: %w", err))...)
 			}
 			inserted += n
 		}
@@ -3498,7 +3640,7 @@ Expected: PASS — all nine tests.
 - [ ] **Step 5: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 6: Commit**
@@ -3720,12 +3862,14 @@ func TestKnownSubcommands(t *testing.T) {
 // failure here shows up as a timeout, not just a bad exit code.
 func TestUnknownSubcommandExitsTwoWithoutStartingDaemon(t *testing.T) {
 	bin := filepath.Join(t.TempDir(), "twx")
+	//nolint:gosec // G204: test-only; builds this package's own binary into t.TempDir()
 	build := exec.CommandContext(t.Context(), "go", "build", "-o", bin, ".")
 	build.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build: %v\n%s", err, out)
 	}
 
+	//nolint:gosec // G204: test-only; runs the binary this test just built
 	cmd := exec.CommandContext(t.Context(), bin, "backfil")
 	out, err := cmd.CombinedOutput()
 
@@ -3837,7 +3981,7 @@ func parseBackfillFlags(args []string) (backfill.Config, string, error) {
 // nothing itself, so flag's message is never duplicated.
 func usageErr(fs *flag.FlagSet, format string, a ...any) error {
 	err := fmt.Errorf(format, a...)
-	fmt.Fprintln(fs.Output(), err)
+	_, _ = fmt.Fprintln(fs.Output(), err)
 	fs.Usage()
 	return err
 }
@@ -3881,7 +4025,18 @@ func resolveStore(choice storeChoice, flagValue string) (string, error) {
 }
 
 // sqliteStore adapts the package-level SQLite functions to backfill.Store.
+//
+// backfill.Store has FOUR methods. If either adapter fails to compile with
+// "does not implement backfill.Store (missing method DistinctSerials)", the
+// fix is to ADD the method here. Do NOT remove DistinctSerials from the
+// interface — that silently reverts the pre-flight fix, because SeriesBounds
+// is windowed and would false-positive on any station quiet during the
+// queried window.
 type sqliteStore struct{ db *sql.DB }
+
+func (s sqliteStore) DistinctSerials(ctx context.Context) ([]string, error) {
+	return sqlite.DistinctSerials(ctx, s.db)
+}
 
 func (s sqliteStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
 	return sqlite.SeriesBounds(ctx, s.db, from, to)
@@ -3896,7 +4051,12 @@ func (s sqliteStore) InsertObservations(ctx context.Context, obs []weather.Obser
 }
 
 // postgresStore adapts the package-level Postgres functions to backfill.Store.
+// See sqliteStore's comment: four methods, and DistinctSerials is not optional.
 type postgresStore struct{ pool *pgxpool.Pool }
+
+func (s postgresStore) DistinctSerials(ctx context.Context) ([]string, error) {
+	return postgres.DistinctSerials(ctx, s.pool)
+}
 
 func (s postgresStore) SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error) {
 	return postgres.SeriesBounds(ctx, s.pool, from, to)
@@ -3990,7 +4150,7 @@ func runBackfill(ctx context.Context, args []string) int {
 			return 1
 		}
 		store = postgresStore{pool: pool}
-	case choice.sqlite:
+	case "sqlite":
 		// The write handle, not OpenReadOnly: read-only fails when the file
 		// does not exist and cannot migrate, and its ingest-contention
 		// rationale does not apply to a separate one-shot process.
@@ -4005,6 +4165,12 @@ func runBackfill(ctx context.Context, args []string) int {
 			}
 		}()
 		store = sqliteStore{db: db}
+	default:
+		// Unreachable today — resolveStore returns only "sqlite" or
+		// "postgres" — but a nil Store interface would panic deep inside Run,
+		// far from the cause.
+		slog.Error("backfill: unknown store target", "target", target)
+		return 1
 	}
 	slog.Info("backfill: store selected", "store", target)
 
@@ -4122,7 +4288,7 @@ Expected: refuses with a message naming both stores and telling you to pass `--s
 - [ ] **Step 7: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 8: Commit**
@@ -4229,12 +4395,12 @@ Run each command in the new section against the built binary and confirm the fla
 ```bash
 CGO_ENABLED=0 go build -o /tmp/twx . && /tmp/twx backfill --help
 ```
-Expected: the four flags with the documented defaults. Fix the doc if it disagrees — the binary is the source of truth.
+Expected: the five flags with the documented defaults, and exit 0. Fix the doc if it disagrees — the binary is the source of truth.
 
 - [ ] **Step 6: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test ./... -race
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race
 ```
 
 - [ ] **Step 7: Commit**

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -38,7 +38,7 @@ The design's signature sketch predates the decision to call the core from `packa
 - **Zero new module dependencies.** Nothing gets added to `go.mod`.
 - **`log/slog` for all new code.** Do not add `log.Printf` call sites; do not convert existing ones.
 - **No goroutines** in any new package-level store function. The `sqlite.Writer.run` goroutine is documented as "the only goroutine that ever touches db" — new functions take a `*sql.DB` / `*pgxpool.Pool` directly and must not be methods on the writer types.
-- **`sqlite.Open` sets `db.SetMaxOpenConns(1)`** (`internal/sqlite/db.go:73`). Any query must fully materialize its results and close its `*sql.Rows` before another query or insert runs on the same handle. A streaming iterator would deadlock with no error and no timeout.
+- **`sqlite.Open` sets `db.SetMaxOpenConns(1)`** (`internal/sqlite/db.go:74`). Any query must fully materialize its results and close its `*sql.Rows` before another query or insert runs on the same handle. A streaming iterator would deadlock with no error and no timeout.
 - **Timestamps are UTC.** SQLite stores unix-epoch `INTEGER`; Postgres stores `TIMESTAMPTZ`. Conversion happens at the SQLite boundary only.
 - **Tests use repo idiom:** `t.Context()`, `t.TempDir()`, stdlib table-driven subtests, no testify.
 - **The full gate must pass before any task is reported complete:**
@@ -588,7 +588,45 @@ func (c *Client) ListDevices(ctx context.Context) ([]Station, error) {
 }
 ```
 
-Then rewrite `ListStations`' body to call `fetchStations` and keep its existing collapse loop verbatim over `data.Stations`. Its observable behavior — including last-ST-wins and the `deviceId != 0 && instance != ""` filter — must not change; `TestListStationsStillCollapsesToOneDevicePerStation` is the guard.
+Then replace `ListStations`' body with exactly this — its observable behavior, including last-ST-wins and the `deviceId != 0 && instance != ""` filter, must not change. `TestListStationsStillCollapsesToOneDevicePerStation` is the guard.
+
+```go
+// ListStations returns one Station per station, collapsing each station's
+// devices to a SINGLE ST device — the last one seen, because the loop below
+// has no break. That behavior is load-bearing for ModeAPIExport and is
+// deliberately preserved; backfill uses ListDevices instead.
+func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
+	data, err := c.fetchStations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []Station
+	for _, station := range data.Stations {
+		var deviceId int
+		var instance string
+		for _, dev := range station.Devices {
+			if dev.DeviceType == "ST" {
+				deviceId = dev.DeviceID
+				instance = dev.SerialNumber
+			}
+		}
+
+		if deviceId != 0 && instance != "" {
+			out = append(out, Station{
+				Name:         station.Name,
+				DeviceID:     deviceId,
+				SerialNumber: instance,
+				StationID:    station.StationID,
+				CreatedAt:    time.Unix(station.CreatedEpoch, 0),
+			})
+		}
+	}
+	return out, nil
+}
+```
+
+Delete the now-unused inline request/decode code this replaces (`client.go:64-107` in the original) — `fetchStations` owns it. If `io`, `encoding/json`, or `net/http` become unused in `client.go` afterwards, `go build` will say so; `GetObservations` still uses all three, so expect none to.
 
 Note this changes `ListStations`' error *type* for HTTP and status failures from `fmt.Errorf` to `*StatusError`. That is an improvement (it makes them classifiable) and `errors.As` still matches; check `client_test.go` for any assertion on the exact error string and update it if present.
 
@@ -1258,7 +1296,7 @@ git commit -m "refactor(postgres): extract OpenPool as the single source of pool
 
 **`PARTITION BY serial_number` is not optional.** Without it, two stations phase-offset by ~30s produce a merged sequence in which no interval ever exceeds `minGap`, so a multi-hour outage on one station is undetectable and the tool reports "no gaps" and exits 0.
 
-**Do not stream.** `sqlite.Open` sets `db.SetMaxOpenConns(1)` (`db.go:73`). Both queries must fully materialize their slice and close `rows` before returning; a caller inserting while iterating would deadlock on the single connection with no error and no timeout.
+**Do not stream.** `sqlite.Open` sets `db.SetMaxOpenConns(1)` (`db.go:74`). Both queries must fully materialize their slice and close `rows` before returning; a caller inserting while iterating would deadlock on the single connection with no error and no timeout.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1538,7 +1576,7 @@ import (
 // single-writer invariant and be callable from the daemon. Nothing here
 // starts a goroutine.
 //
-// IMPORTANT: sqlite.Open sets db.SetMaxOpenConns(1) (db.go:73). Every query
+// IMPORTANT: sqlite.Open sets db.SetMaxOpenConns(1) (db.go:74). Every query
 // below fully materializes its result slice and closes its *sql.Rows before
 // returning. A streaming iterator that yielded rows while the caller inserted
 // would deadlock on the single connection with no error and no timeout. Do
@@ -1804,14 +1842,6 @@ docker run --rm -d --name twx-itest -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weathe
 until docker exec twx-itest pg_isready -U postgres; do sleep 1; done
 POSTGRES_URL='postgres://postgres:x@localhost:55432/weather?sslmode=disable' \
   go test ./internal/postgres/ -run TestBackfillPostgresIntegration -v -count=1
-docker rm -f twx-itest
-```
-
-```bash
-docker run --rm -d --name twx-itest -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weather -p 55432:5432 postgres:16
-# wait for readiness, then:
-POSTGRES_URL='postgres://postgres:x@localhost:55432/weather?sslmode=disable' \
-  go test ./internal/postgres/ -run TestBackfillPostgresIntegration -v
 docker rm -f twx-itest
 ```
 
@@ -2837,7 +2867,11 @@ git commit -m "feat(backfill): assemble head, tail, and empty-store gaps around 
 
 **Why `Store` is an interface:** two concrete implementors exist on day one (SQLite and Postgres), so it is not speculative. It is defined in the consumer, Go-idiomatic; thin adapters live in the shell.
 
-**Serial pre-flight is a hard stop.** If an API serial is absent from a **non-empty** store, backfill would write a parallel series under a second serial: `UNIQUE` never fires, rows double, and the gap never closes — silently and cumulatively. Warning-then-writing-anyway is incoherent; it names an outcome as corrupting and then produces it. An **empty** store is not a mismatch — it is the first-run case.
+**Serial pre-flight is a hard stop, and the rule is DISJOINT SETS.** If the API's serials and a **non-empty** store's serials have **no overlap at all**, the two are using different serial formats, and backfilling would write a parallel series under a second serial: `UNIQUE` never fires, rows double, and the gap never closes — silently and cumulatively. Warning-then-writing-anyway is incoherent; it names an outcome as corrupting and then produces it.
+
+**Do not implement "some API serial is absent from a non-empty store".** That rule is wrong, and it is the one a reader reaches for first. It fires on two ordinary situations and bricks the tool for both: a newly added station (its serial has no rows yet), and any station this host never hears over UDP — a different VLAN or subnet — whose serial will *never* enter the store. Under the disjoint rule both proceed normally and the unseen serial simply yields a whole-range gap, which is `assembleGaps`' job. `TestRunNewSerialAlongsideKnownSerialIsNotAMismatch` exists to forbid the wrong rule; if you find yourself making that test pass by changing the test, stop.
+
+An **empty** store is likewise not a mismatch — it is the first-run case.
 
 **Insert batches are bounded to 200 rows.** A long transaction contends with live ingest, whose error path only *logs* (`sqlite/writer.go:646`), so an unbounded backfill transaction could cause **live observations to be silently lost while repairing historical ones**.
 
@@ -2852,6 +2886,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -2912,12 +2947,10 @@ func (f *fakeStore) InsertObservations(_ context.Context, obs []weather.Observat
 	return len(obs), nil
 }
 
-var deviceIDs = map[string]int{"ST-A": 1, "ST-B": 2}
-
 func station(serial string) tempestapi.Station {
 	return tempestapi.Station{
 		SerialNumber: serial,
-		DeviceID:     deviceIDs[serial],
+		DeviceID:     1, // no assertion reads this; keeping it constant is honest
 		CreatedAt:    time.Unix(1000, 0).UTC(),
 	}
 }
@@ -2931,6 +2964,12 @@ func obsAt(serial string, epoch int64) weather.Observation {
 func at(epoch int64) time.Time { return ts(epoch) }
 
 // --- tests ---
+//
+// NOTE on fixtures: tests that pass an explicit Config{From, To} run the
+// path where Run does NOT query SeriesBounds, so setting store.bounds in
+// them is dead fixture data. It is left in place only where it documents
+// intent; do not infer from its presence that such a test exercises bounds.
+// TestRunAutoDetectUsesSeriesBounds is the only test that pins the fetch.
 
 func TestRunDryRunMakesNoAPICallsAndNoWrites(t *testing.T) {
 	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
@@ -3022,6 +3061,52 @@ func TestRunNewSerialAlongsideKnownSerialIsNotAMismatch(t *testing.T) {
 	}
 }
 
+// Regression guard for the CONDITIONAL SeriesBounds fetch.
+//
+// Run skips the SeriesBounds query on the explicit --from/--to path. Nothing
+// else pins that it still performs it on the auto-detect path: deleting the
+// query outright (always nil bounds) leaves every other test green, because
+// assembleGaps is unit-tested with bounds passed in directly and six Run
+// tests set store.bounds on the explicit path where it is dead fixture data.
+//
+// The consequence of nil bounds in production is not an error, which is why
+// it hides: every serial gets ONE whole-range gap from CreatedAt to
+// now-MinGap. For a two-year-old station that is ~730 sequential 24h API
+// windows on every run, forever, instead of the handful of real holes. It
+// still converges — it just silently turns a 30-second repair into hours of
+// API hammering.
+//
+// So assert the SHAPE of the gap, not the count: with a stored series ending
+// at Last, the planned tail gap must START at Last. Nil bounds would start it
+// at detectFrom instead.
+func TestRunAutoDetectUsesSeriesBounds(t *testing.T) {
+	last := at(100000)
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 150000)}}
+	store := &fakeStore{
+		serials: []string{"ST-A"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: last}},
+	}
+
+	_, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(300000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) == 0 {
+		t.Fatal("no windows fetched")
+	}
+
+	// The first fetched window must begin at the stored series' Last, not at
+	// the station's CreatedAt.
+	got := src.calls[0].from
+	if !got.Equal(last) {
+		t.Errorf("first fetch starts at %v, want %v (the stored series' Last). "+
+			"Starting at CreatedAt means SeriesBounds was not consulted, and the tool "+
+			"will re-request the station's entire history on every run.", got, last)
+	}
+}
+
 // Regression for the windowed-bounds bug: the pre-flight check must read
 // DistinctSerials (whole table), not SeriesBounds (windowed). A station that
 // simply had no rows inside the requested window is not missing from the
@@ -3082,6 +3167,39 @@ func TestRunBackfillsEveryDevice(t *testing.T) {
 	}
 	if !fetched["ST-A"] || !fetched["ST-B"] {
 		t.Errorf("fetched for %v, want both ST-A and ST-B — a two-sensor station must not lose one", fetched)
+	}
+}
+
+// The insert-abort asymmetry is deliberate and must stay: a WINDOW error
+// continues to the next window, but an INSERT error aborts the whole gap,
+// because an unhealthy store will not be helped by the remaining windows.
+//
+// fakeStore.insertErr exists precisely to test this and was previously never
+// set by any test — inverting the behavior to `continue` would have shipped
+// green while hammering a dying store with every remaining window.
+func TestFillGapAbortsGapOnInsertError(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{insertErr: errors.New("disk full")}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour) // three windows
+
+	stats, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+
+	if err == nil {
+		t.Fatal("an insert failure must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("err = %v, want it to wrap the insert error", err)
+	}
+	if len(src.calls) != 1 {
+		t.Errorf("made %d API calls, want 1 — an insert failure must abort the gap, "+
+			"not continue fetching the remaining windows", len(src.calls))
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
 	}
 }
 
@@ -3294,9 +3412,13 @@ const (
 	baseBackoff = time.Second
 )
 
-// ErrSerialMismatch is returned when the API reports a serial the non-empty
-// store has never seen. See preflight.
-var ErrSerialMismatch = errors.New("station serial not present in store")
+// ErrSerialMismatch is returned when the API's serials and a non-empty
+// store's serials are DISJOINT — no API serial appears in the store at all.
+//
+// NOT "some API serial is absent from the store": that rule is wrong and
+// bricks the tool for a newly added station, or for any station this host
+// never hears over UDP. See preflight.
+var ErrSerialMismatch = errors.New("station serials disjoint from store")
 
 // Config is the backfill run's parameters. It holds no I/O handles and no
 // clock — both are passed to Run explicitly so the core is testable.
@@ -3591,7 +3713,12 @@ func fillGap(
 		obs, err := fetchWithRetry(ctx, src, station, w)
 		if err != nil {
 			if ctx.Err() != nil {
-				return returned, inserted, errors.Join(append(windowErrs, ctx.Err())...)
+				// Bare ctx.Err(), not a join: Run owns cancellation
+				// reporting and returns ctx.Err() itself the moment it sees
+				// ctx.Err() != nil, so anything joined here is discarded.
+				// Building a richer error only to have it thrown away reads
+				// as a guarantee this code does not provide.
+				return returned, inserted, ctx.Err()
 			}
 			slog.Error("backfill: window failed, continuing with the rest of the gap",
 				"serial", station.SerialNumber, "from", w.from, "to", w.to, "error", err)
@@ -3845,6 +3972,24 @@ func TestResolveStore(t *testing.T) {
 	}
 }
 
+// The design's "Store selection" row demands exit 2 AND nothing written.
+// TestResolveStore covers the pure function; this covers the command, which
+// is what the row actually specifies. No Docker needed — resolveStore fires
+// before any handle is opened.
+func TestRunBackfillRefusesAmbiguousStoreAndWritesNothing(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "never.db")
+	t.Setenv("TOKEN", "x")
+	t.Setenv("ENABLE_POSTGRES", "true")
+	t.Setenv("SQLITE_PATH", dbPath)
+
+	if got := runBackfill(t.Context(), nil); got != 2 {
+		t.Errorf("exit code = %d, want 2 — both stores configured with no --store must refuse", got)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("SQLite database at %s was created; an ambiguous store selection must write nothing", dbPath)
+	}
+}
+
 // --help is not a usage error.
 func TestRunBackfillHelpExitsZero(t *testing.T) {
 	t.Setenv("TOKEN", "x")
@@ -3902,6 +4047,37 @@ func TestUnknownSubcommandExitsTwoWithoutStartingDaemon(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "unknown subcommand") {
 		t.Errorf("output should name the bad subcommand, got:\n%s", out)
+	}
+}
+
+// `backfill` must actually REACH runBackfill through main()'s dispatch.
+//
+// TestRunBackfillHelpExitsZero calls runBackfill directly and so never crosses
+// the dispatch — deleting `case "backfill":` from main() leaves the entire
+// suite green while the binary falls through and starts the UDP daemon. That
+// is the same silent-daemon failure Task 10 exists to eliminate, reachable by
+// a one-line edit. Only a re-exec catches it.
+func TestBackfillSubcommandReachesRunBackfill(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "twx")
+	//nolint:gosec // G204: test-only; builds this package's own binary into t.TempDir()
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", bin, ".")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	// --help exits 0 and prints the backfill flag set. The daemon prints
+	// nothing resembling this, so it discriminates cleanly.
+	//nolint:gosec // G204: test-only; runs the binary this test just built
+	cmd := exec.CommandContext(t.Context(), bin, "backfill", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("`backfill --help` should exit 0, got %v\n%s", err, out)
+	}
+	for _, flagName := range []string{"-dry-run", "-from", "-min-gap", "-store", "-to"} {
+		if !strings.Contains(string(out), flagName) {
+			t.Errorf("`backfill --help` output missing %s — dispatch may not be reaching runBackfill.\ngot:\n%s", flagName, out)
+		}
 	}
 }
 ```
@@ -4275,6 +4451,17 @@ func main() {
 			// runBackfill owns all of its cleanup via internal defers and
 			// wires its own signal context.
 			os.Exit(runBackfill(context.Background(), os.Args[2:]))
+		default:
+			// Unreachable while this switch and isKnownSubcommand agree — but
+			// the subcommand name is duplicated across the two, so they CAN
+			// desync. Without this arm a desync falls through to daemon mode
+			// and silently starts the UDP listener, which is precisely the
+			// bug the isKnownSubcommand check above exists to prevent.
+			// Fail loudly instead.
+			fmt.Fprintf(os.Stderr,
+				"internal error: %q passed isKnownSubcommand but has no dispatch case\n\n%s",
+				os.Args[1], usageText)
+			os.Exit(2)
 		}
 	}
 ```
@@ -4337,9 +4524,11 @@ Rename the existing `### API Export with Backfill` heading (`CLAUDE.md:239`) to 
 
 - [ ] **Step 2: Add the subcommand section**
 
-Immediately after it, add:
+Immediately after it, add everything between the four-backtick fences below.
+The block contains a nested ```bash fence, which is why the outer fence is four
+backticks — insert the inner fence verbatim, backticks included:
 
-```markdown
+````markdown
 ### Backfill Subcommand
 
 Fills holes in the local observation history from the Tempest REST API. Unlike
@@ -4381,10 +4570,15 @@ either); `1` one or more gaps failed, or a runtime error; `2` usage error.
 rapid wind, hub status, or discrete events. Lightning is partially recovered in
 aggregate through the observation columns, but not as `tempest_events` rows.
 
-**Safety:** if the API reports a station serial the (non-empty) store has never
-seen, backfill stops and writes nothing — a mismatched serial would create a
-parallel series that never dedupes.
-```
+**Safety:** if the API's station serials and the store's serials have **no
+overlap at all** (on a non-empty store), backfill stops and writes nothing — that
+is the signature of a serial-format mismatch, which would create a parallel
+series that never dedupes.
+
+A *newly added* station, or one this host never hears over UDP, is **not** a
+mismatch: its serial simply has no rows yet, and backfill fetches its whole
+history normally.
+````
 
 - [ ] **Step 3: Update the package list**
 
@@ -4399,7 +4593,7 @@ Leave the `internal/tempestudp/` line as it is — it correctly describes UDP pa
 
 - [ ] **Step 4: Note that subcommands bypass mode selection**
 
-Under the "Operational Modes" table, add:
+Under the "Operational Modes" **table** (`CLAUDE.md:186` — note there are two `### Operational Modes` headings, at `:69` and `:174`; only the latter has a table), add:
 
 ```markdown
 > **Subcommands bypass mode selection.** `backfill` and `healthcheck` are chosen

--- a/docs/plans/2026-07-29-api-backfill-tool-implementation.md
+++ b/docs/plans/2026-07-29-api-backfill-tool-implementation.md
@@ -1789,9 +1789,23 @@ git commit -m "feat(sqlite): add partitioned gap detection and idempotent backfi
 
 **Signatures are pinned to `time.Time` on both stores** so one interface satisfies both without a shim. The epoch conversion stays inside the SQLite implementation, matching how that package already handles timestamps; Postgres passes `time.Time` straight through to `TIMESTAMPTZ`.
 
-**This task's SQL is the least-covered code in the change, and that is a stated risk, not an oversight.** Both reviews flagged it. The unit tests here cover only wet-bulb derivation; every query is exercised solely by `TestBackfillPostgresIntegration`, which **skips** unless `POSTGRES_URL` is set.
+**This task's SQL was pre-verified against a real database on 2026-07-29** — transcribed into a scratch tree and run against PostgreSQL 16 (pgx v5, `CGO_ENABLED=0`) before implementation began. Everything below passed, and the test was mutation-checked (removing `PARTITION BY serial_number` makes it fail; so does corrupting the INTEGER round-trip). See the design's "Postgres path — verified by execution".
 
-**Therefore: run it against a real database at least once before this branch merges, and paste the output.** A run in which it skipped is not evidence. If no database is available, say so explicitly when reporting this task complete — do not report the Postgres path as verified.
+Two findings from that run, already reflected in the code below:
+
+- **pgx truncates `*float64` → `INTEGER` toward zero, silently:** `2.6→2`, `-1.5→-1`, no error. Benign here (the API supplies integral values for the four affected columns) but do not widen the pattern.
+- The seeded fixture must bind `PrecipType`, `WindSampleInterval`, `LightningStrikeCount` and `ReportInterval`, or the test skips the very hazard it exists for.
+
+**Still: `TestBackfillPostgresIntegration` skips unless `POSTGRES_URL` is set, so a run where it skipped is not evidence.** Re-run it after any change to this file's SQL:
+
+```bash
+colima start                                   # if the container host is not already up
+docker run --rm -d --name twx-itest -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+until docker exec twx-itest pg_isready -U postgres; do sleep 1; done
+POSTGRES_URL='postgres://postgres:x@localhost:55432/weather?sslmode=disable' \
+  go test ./internal/postgres/ -run TestBackfillPostgresIntegration -v -count=1
+docker rm -f twx-itest
+```
 
 ```bash
 docker run --rm -d --name twx-itest -e POSTGRES_PASSWORD=x -e POSTGRES_DB=weather -p 55432:5432 postgres:16

--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -40,7 +40,10 @@ var ErrSerialMismatch = errors.New("station serials disjoint from store")
 // Config is the backfill run's parameters. It holds no I/O handles and no
 // clock — both are passed to Run explicitly so the core is testable.
 type Config struct {
-	// From and To bound the work explicitly. Both zero means auto-detect.
+	// From and To bound the work explicitly. Both zero means auto-detect. A
+	// half-specified range (exactly one of the two zero) is rejected by Run
+	// with an error before any I/O — it is never silently treated as
+	// auto-detect.
 	//
 	// The override exists to BOUND API WORK, not to avoid a table scan
 	// (idx_obs_serial_time already covers detection): because permanent holes
@@ -121,6 +124,10 @@ func Run(
 	now time.Time,
 ) (Stats, error) {
 	var stats Stats
+
+	if cfg.From.IsZero() != cfg.To.IsZero() {
+		return stats, fmt.Errorf("backfill: From and To must both be set or both be zero, got From=%v To=%v", cfg.From, cfg.To)
+	}
 
 	detectFrom, detectTo := detectionRange(cfg, stations, now)
 

--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -1,0 +1,396 @@
+package backfill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+)
+
+const (
+	// insertBatchSize bounds one insert transaction.
+	//
+	// The realistic invocation is `docker exec <running container>
+	// tempestwx-utilities backfill` against a LIVE database. A long backfill
+	// transaction contends with ingest writes; busy_timeout defaults to 5s
+	// and ingest's error path only LOGS (sqlite/writer.go:646), so an
+	// unbounded transaction could cause live observations to be silently lost
+	// while repairing historical ones. Short transactions are the mitigation.
+	insertBatchSize = 200
+
+	// maxAttempts bounds retries per window, including the first try.
+	maxAttempts = 4
+	// baseBackoff is doubled per attempt: 1s, 2s, 4s.
+	baseBackoff = time.Second
+)
+
+// ErrSerialMismatch is returned when the API's serials and a non-empty
+// store's serials are DISJOINT — no API serial appears in the store at all.
+//
+// NOT "some API serial is absent from the store": that rule is wrong and
+// bricks the tool for a newly added station, or for any station this host
+// never hears over UDP. See preflight.
+var ErrSerialMismatch = errors.New("station serials disjoint from store")
+
+// Config is the backfill run's parameters. It holds no I/O handles and no
+// clock — both are passed to Run explicitly so the core is testable.
+type Config struct {
+	// From and To bound the work explicitly. Both zero means auto-detect.
+	//
+	// The override exists to BOUND API WORK, not to avoid a table scan
+	// (idx_obs_serial_time already covers detection): because permanent holes
+	// are accepted and never recorded, auto-detect re-requests every
+	// known-empty window on every run. An operator repairing a known outage
+	// can name it and skip that cost.
+	From time.Time
+	To   time.Time
+
+	// MinGap is the smallest interval that counts as a hole, keeping ordinary
+	// reporting jitter from registering.
+	MinGap time.Duration
+
+	// DryRun detects and plans only: Run makes zero observation fetches and
+	// zero writes.
+	//
+	// Note the shell still calls ListDevices before invoking Run, so the
+	// COMMAND does make one API call in dry-run and therefore does validate
+	// the token. Do not document it as "zero API calls".
+	DryRun bool
+}
+
+// Stats is what the run did, in aggregate.
+type Stats struct {
+	Gaps int // holes detected
+	// Returned counts observations the API actually handed back, AFTER
+	// malformed tuples were dropped. It is not "rows requested" — the closed
+	// gap interval and the shared chunk-window endpoints both mean a few
+	// observations are fetched more than once.
+	Returned int
+	Inserted int // rows actually new (0 across runs => a permanent hole)
+	Failed   int // gaps that failed after retries
+}
+
+// NOTE: dropped-tuple counts are deliberately NOT here. They are logged at
+// WARN by the decode itself (Task 3), which is where the information exists.
+// Threading a diagnostic counter up through ObservationSource would widen the
+// seam between backfill and the REST client to carry a reporting nicety, and
+// the log stream is already the machine-readable surface this design chose
+// when it cut the bespoke summary line.
+
+// ObservationSource is the REST client, narrowed to what backfill needs.
+// *tempestapi.Client satisfies it.
+type ObservationSource interface {
+	Observations(ctx context.Context, station tempestapi.Station, start, end time.Time) ([]weather.Observation, error)
+}
+
+// Store is the persistence side, narrowed to what backfill needs. Two
+// concrete implementors exist on day one — SQLite and Postgres — so this is
+// an earned interface, not a speculative one. It is declared here, in the
+// consumer, per Go convention; the adapters that bind a *sql.DB or
+// *pgxpool.Pool to it live in the command shell.
+type Store interface {
+	// DistinctSerials is UNWINDOWED — the whole table. It exists only for the
+	// pre-flight check and must NOT be replaced by SeriesBounds' key set:
+	// SeriesBounds is windowed, so a station that was simply quiet during the
+	// requested window would look absent from the store and trip the check.
+	DistinctSerials(ctx context.Context) ([]string, error)
+	SeriesBounds(ctx context.Context, from, to time.Time) ([]weather.Bounds, error)
+	FindObservationGaps(ctx context.Context, from, to time.Time, minGap time.Duration) ([]weather.Gap, error)
+	InsertObservations(ctx context.Context, obs []weather.Observation) (int, error)
+}
+
+// Run detects gaps and fills them.
+//
+// now is injected: nothing below the command shell calls time.Now(), so
+// detectTo (now - MinGap) is deterministic under test.
+//
+// A failed gap logs and continues — partial progress must be preserved — and
+// the per-gap errors are joined into the returned error, which the shell
+// turns into a non-zero exit. Run never calls log.Fatal.
+func Run(
+	ctx context.Context,
+	cfg Config,
+	src ObservationSource,
+	store Store,
+	stations []tempestapi.Station,
+	now time.Time,
+) (Stats, error) {
+	var stats Stats
+
+	detectFrom, detectTo := detectionRange(cfg, stations, now)
+
+	storedSerials, err := store.DistinctSerials(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("distinct serials: %w", err)
+	}
+	if err := preflight(stations, storedSerials); err != nil {
+		return stats, err
+	}
+
+	// SeriesBounds is only needed by the auto-detect path — an explicit
+	// --from/--to names the window outright and never reads it. Querying it
+	// unconditionally would be a wasted round-trip on every explicit run.
+	var bounds []weather.Bounds
+	if cfg.From.IsZero() || cfg.To.IsZero() {
+		bounds, err = store.SeriesBounds(ctx, detectFrom, detectTo)
+		if err != nil {
+			return stats, fmt.Errorf("series bounds: %w", err)
+		}
+	}
+
+	gaps, err := plannedGaps(ctx, cfg, store, stations, bounds, detectFrom, detectTo)
+	if err != nil {
+		return stats, err
+	}
+	stats.Gaps = len(gaps)
+
+	if cfg.DryRun {
+		for _, g := range gaps {
+			slog.Info("backfill: planned gap (dry run)",
+				"serial", g.SerialNumber, "from", g.From, "to", g.To, "duration", g.Duration())
+		}
+		return stats, nil
+	}
+
+	byserial := make(map[string]tempestapi.Station, len(stations))
+	for _, s := range stations {
+		byserial[s.SerialNumber] = s
+	}
+
+	var failures []error
+	for _, g := range gaps {
+		returned, inserted, err := fillGap(ctx, src, store, byserial[g.SerialNumber], g)
+		stats.Returned += returned
+		stats.Inserted += inserted
+
+		if err != nil {
+			if ctx.Err() != nil {
+				// Cancellation is not a gap failure. Inserted rows stay
+				// intact; idempotency makes re-running safe.
+				return stats, ctx.Err()
+			}
+			stats.Failed++
+			failures = append(failures, fmt.Errorf("gap %s [%s, %s]: %w",
+				g.SerialNumber, g.From.Format(time.RFC3339), g.To.Format(time.RFC3339), err))
+			slog.Error("backfill: gap failed",
+				"serial", g.SerialNumber, "from", g.From, "to", g.To, "error", err)
+			continue
+		}
+
+		// returned vs inserted is what makes the permanent-hole tradeoff
+		// visible: if the station was genuinely offline, the API has no data
+		// either and inserted stays 0 across runs. Structured attrs are the
+		// machine-readable surface — no bespoke summary format.
+		slog.Info("backfill: gap filled",
+			"serial", g.SerialNumber, "from", g.From, "to", g.To,
+			"returned", returned, "inserted", inserted)
+	}
+
+	if len(failures) > 0 {
+		return stats, errors.Join(failures...)
+	}
+	return stats, nil
+}
+
+// detectionRange resolves the window to work over. An explicit --from/--to
+// wins; otherwise detection runs from the earliest station creation time to
+// now-MinGap (trailing MinGap so the most recent, still-arriving interval is
+// not mistaken for a hole).
+func detectionRange(cfg Config, stations []tempestapi.Station, now time.Time) (time.Time, time.Time) {
+	if !cfg.From.IsZero() && !cfg.To.IsZero() {
+		return cfg.From, cfg.To
+	}
+	detectTo := now.Add(-cfg.MinGap)
+	detectFrom := detectTo
+	for _, s := range stations {
+		if s.CreatedAt.Before(detectFrom) {
+			detectFrom = s.CreatedAt
+		}
+	}
+	return detectFrom, detectTo
+}
+
+// plannedGaps is the whole detection domain: SQL's interior gaps plus the
+// head, tail, and empty-store cases LAG cannot see. An explicit --from/--to
+// still goes through the chunker, so it is expressed as one gap per station
+// rather than bypassing the pipeline.
+func plannedGaps(
+	ctx context.Context,
+	cfg Config,
+	store Store,
+	stations []tempestapi.Station,
+	bounds []weather.Bounds,
+	detectFrom, detectTo time.Time,
+) ([]weather.Gap, error) {
+	serials := make([]string, 0, len(stations))
+	for _, s := range stations {
+		serials = append(serials, s.SerialNumber)
+	}
+
+	if !cfg.From.IsZero() && !cfg.To.IsZero() {
+		gaps := make([]weather.Gap, 0, len(serials))
+		for _, serial := range serials {
+			gaps = append(gaps, weather.Gap{SerialNumber: serial, From: cfg.From, To: cfg.To})
+		}
+		return gaps, nil
+	}
+
+	interior, err := store.FindObservationGaps(ctx, detectFrom, detectTo, cfg.MinGap)
+	if err != nil {
+		return nil, fmt.Errorf("find observation gaps: %w", err)
+	}
+	return assembleGaps(interior, bounds, serials, detectFrom, detectTo, cfg.MinGap), nil
+}
+
+// preflight refuses to run when the API's serials and the store's serials are
+// DISJOINT — no API serial appears in the store at all.
+//
+// Dedupe, gap closure, and convergence all require that the serial backfill
+// writes exactly matches the serial UDP ingest writes. If the two formats
+// diverge, backfill writes a PARALLEL SERIES under a second serial: UNIQUE
+// never fires, rows double, and the gap never closes — silently and
+// cumulatively. So this is a hard stop, not a warning: warning-then-writing-
+// anyway names an outcome as corrupting and then produces it.
+//
+// DISJOINT is the rule, and the distinction is load-bearing. The tempting
+// version — "some API serial is absent from a non-empty store" — fires on two
+// completely ordinary situations and would brick the tool for both:
+//
+//   - A second station on the account whose broadcasts this host never hears
+//     (different VLAN/subnet). Its serial will NEVER enter the store, so
+//     backfill would refuse to run, including for the healthy station.
+//   - A newly added station, whose first backfill would exit non-zero having
+//     written nothing — permanently, until the daemon happened to ingest a row.
+//
+// Neither is format divergence. Under the disjoint rule both proceed, and a
+// serial the API knows but the store has not seen simply becomes a whole-range
+// gap, which is exactly assembleGaps' job.
+//
+// storedSerials MUST come from DistinctSerials (unwindowed), never from
+// SeriesBounds' key set — see the Store interface comment.
+//
+// An EMPTY store is not a mismatch: it is the first-run case.
+func preflight(stations []tempestapi.Station, storedSerials []string) error {
+	if len(storedSerials) == 0 {
+		return nil
+	}
+	stored := make(map[string]struct{}, len(storedSerials))
+	for _, s := range storedSerials {
+		stored[s] = struct{}{}
+	}
+	for _, st := range stations {
+		if _, ok := stored[st.SerialNumber]; ok {
+			return nil // at least one serial matches: not divergence
+		}
+	}
+
+	apiSerials := make([]string, 0, len(stations))
+	for _, st := range stations {
+		apiSerials = append(apiSerials, st.SerialNumber)
+	}
+	return fmt.Errorf("%w: API reports %v, store holds %v — no overlap at all, "+
+		"which means the two are using different serial formats; backfilling would "+
+		"create a parallel series that never dedupes",
+		ErrSerialMismatch, apiSerials, storedSerials)
+}
+
+// fillGap fetches and inserts one gap, chunked and retried.
+//
+// A failed WINDOW does not abandon the gap. Returning here on the first bad
+// window would discard every remaining window, and for a DETERMINISTIC
+// per-window failure that loss is permanent across runs, not transient:
+// once the earlier windows land, the head gap collapses and the hole
+// reappears as an interior gap starting at the same bad window, which fails
+// again — so the windows behind it are never requested on ANY run. A tool
+// whose entire premise is convergence would silently stop converging, and the
+// inserted=0 signal never even fires because those windows are never
+// requested. So: log, accumulate, keep going, and fail the gap at the end.
+//
+// An INSERT error is different and does abort the gap: it means the store is
+// unhealthy, and hammering it with the remaining windows helps nobody.
+func fillGap(
+	ctx context.Context,
+	src ObservationSource,
+	store Store,
+	station tempestapi.Station,
+	g weather.Gap,
+) (returned, inserted int, err error) {
+	var windowErrs []error
+
+	for _, w := range chunkWindow(g.From, g.To, chunkSize) {
+		if err := ctx.Err(); err != nil {
+			return returned, inserted, err
+		}
+
+		obs, err := fetchWithRetry(ctx, src, station, w)
+		if err != nil {
+			if ctx.Err() != nil {
+				// Bare ctx.Err(), not a join: Run owns cancellation
+				// reporting and returns ctx.Err() itself the moment it sees
+				// ctx.Err() != nil, so anything joined here is discarded.
+				// Building a richer error only to have it thrown away reads
+				// as a guarantee this code does not provide.
+				return returned, inserted, ctx.Err()
+			}
+			slog.Error("backfill: window failed, continuing with the rest of the gap",
+				"serial", station.SerialNumber, "from", w.from, "to", w.to, "error", err)
+			windowErrs = append(windowErrs, fmt.Errorf("window [%s, %s]: %w",
+				w.from.Format(time.RFC3339), w.to.Format(time.RFC3339), err))
+			continue
+		}
+		returned += len(obs)
+
+		for chunk := range slices.Chunk(obs, insertBatchSize) {
+			n, err := store.InsertObservations(ctx, chunk)
+			if err != nil {
+				// Abort the gap — an unhealthy store will not be helped by
+				// the remaining windows — but keep any window diagnostics
+				// already accumulated rather than discarding them.
+				return returned, inserted, errors.Join(append(windowErrs, fmt.Errorf("insert: %w", err))...)
+			}
+			inserted += n
+		}
+	}
+
+	return returned, inserted, errors.Join(windowErrs...)
+}
+
+// fetchWithRetry applies bounded exponential backoff to transient failures.
+// Context cancellation is checked between attempts as well as between
+// windows.
+func fetchWithRetry(
+	ctx context.Context,
+	src ObservationSource,
+	station tempestapi.Station,
+	w window,
+) ([]weather.Observation, error) {
+	var lastErr error
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			delay := baseBackoff << (attempt - 1)
+			slog.Warn("backfill: retrying window",
+				"serial", station.SerialNumber, "from", w.from, "to", w.to,
+				"attempt", attempt+1, "delay", delay, "error", lastErr)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		obs, err := src.Observations(ctx, station, w.from, w.to)
+		if err == nil {
+			return obs, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", maxAttempts, lastErr)
+}

--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -204,14 +204,18 @@ func Run(
 	return stats, nil
 }
 
-// detectionRange resolves the window to work over. An explicit --from/--to
-// wins; otherwise detection runs from the earliest station creation time to
-// now-MinGap (trailing MinGap so the most recent, still-arriving interval is
-// not mistaken for a hole).
+// detectionRange resolves the auto-detect window: from the earliest station
+// creation time to now-MinGap (trailing MinGap so the most recent,
+// still-arriving interval is not mistaken for a hole).
+//
+// It is called even on an explicit --from/--to run, but its result is never
+// read on that path: SeriesBounds is skipped (Run guards that call with
+// `cfg.From.IsZero() || cfg.To.IsZero()`) and plannedGaps returns its
+// cfg.From/cfg.To-derived gaps before ever reading the detectFrom/detectTo
+// parameters it was passed. There is deliberately no explicit-range branch
+// here — Run's own guard already makes From/To both-set-or-both-zero, and an
+// early return here would be dead code kept only for symmetry.
 func detectionRange(cfg Config, stations []tempestapi.Station, now time.Time) (time.Time, time.Time) {
-	if !cfg.From.IsZero() && !cfg.To.IsZero() {
-		return cfg.From, cfg.To
-	}
 	detectTo := now.Add(-cfg.MinGap)
 	detectFrom := detectTo
 	for _, s := range stations {

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -3,7 +3,10 @@ package backfill
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +14,17 @@ import (
 	"tempestwx-utilities/internal/tempestapi"
 	"tempestwx-utilities/internal/weather"
 )
+
+// TestMain silences slog for this package's test binary. Nearly every test
+// here drives Run/fillGap/fetchWithRetry, which log unconditionally by
+// design (§backfill.go), so the per-test slog.SetDefault + t.Cleanup idiom
+// used elsewhere in the repo (internal/tempestapi, internal/httpserver)
+// would mean repeating it in essentially every test in this file. A single
+// package-wide override is the less invasive form of the same idiom.
+func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	os.Exit(m.Run())
+}
 
 // --- fakes ---
 
@@ -275,8 +289,8 @@ func TestRunBackfillsEveryDevice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.Gaps < 2 {
-		t.Errorf("Gaps = %d, want at least 2 — one per device", stats.Gaps)
+	if stats.Gaps != 2 {
+		t.Errorf("Gaps = %d, want exactly 2 — one whole-range gap per device", stats.Gaps)
 	}
 
 	fetched := map[string]bool{}
@@ -349,6 +363,9 @@ func TestFillGapContinuesAfterAFailedWindow(t *testing.T) {
 	if stats.Inserted != 2 {
 		t.Errorf("Inserted = %d, want 2 (windows 1 and 3 both landed)", stats.Inserted)
 	}
+	if stats.Returned != 2 {
+		t.Errorf("Returned = %d, want 2 (windows 1 and 3 each returned one observation)", stats.Returned)
+	}
 	if stats.Failed != 1 {
 		t.Errorf("Failed = %d, want 1", stats.Failed)
 	}
@@ -398,6 +415,42 @@ func TestRunRetriesTransientThenSucceeds(t *testing.T) {
 	}
 	if stats.Inserted != 1 {
 		t.Errorf("Inserted = %d, want 1", stats.Inserted)
+	}
+}
+
+// Regression: fetchWithRetry's exhaustion path (all maxAttempts attempts
+// transient) was previously dead under the suite — nothing supplied enough
+// retryable failures to reach it, so raising maxAttempts (and the unbounded
+// baseBackoff growth that comes with it) would have shipped green.
+//
+// Real backoff applies here (1s + 2s + 4s = 7s between the 4 attempts); do
+// not add a second test like this.
+func TestRunRetryExhaustionFailsTheWindowAfterMaxAttempts(t *testing.T) {
+	src := &fakeSource{
+		errs: []error{
+			&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable},
+			&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable},
+			&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable},
+			&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable},
+		},
+	}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	stats, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err == nil {
+		t.Fatal("exhausting every retry attempt must surface as an error")
+	}
+	if len(src.calls) != 4 {
+		t.Errorf("made %d calls, want 4 (maxAttempts) — raising maxAttempts must show up here", len(src.calls))
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+	if !strings.Contains(err.Error(), "4 attempts") {
+		t.Errorf("err = %v, want it to mention the attempt count", err)
 	}
 }
 
@@ -456,11 +509,14 @@ func TestRunBoundsInsertBatchSize(t *testing.T) {
 	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
 
 	from := at(0)
-	_, err := Run(t.Context(),
+	stats, err := Run(t.Context(),
 		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
 		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
 	if err != nil {
 		t.Fatalf("Run: %v", err)
+	}
+	if stats.Returned != 500 {
+		t.Errorf("Returned = %d, want 500 (observations the API handed back, not rows requested)", stats.Returned)
 	}
 	if len(store.inserted) < 3 {
 		t.Fatalf("got %d batches, want at least 3 for 500 rows at max 200/batch", len(store.inserted))
@@ -485,5 +541,50 @@ func TestRunHonorsContextCancellation(t *testing.T) {
 		src, store, []tempestapi.Station{station("ST-A")}, from.Add(72*time.Hour))
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	// Cancellation must be honored PROMPTLY — before any window is fetched or
+	// inserted — not merely reported after the run has already done all the
+	// work. Otherwise a cancelled multi-hour backfill would still perform
+	// every API call and every insert before finally returning
+	// context.Canceled, which is indistinguishable from ignoring cancellation.
+	if len(src.calls) != 0 {
+		t.Errorf("made %d API calls under a cancelled context, want 0", len(src.calls))
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("made %d inserts under a cancelled context, want 0", len(store.inserted))
+	}
+}
+
+// A half-specified range (only From, or only To) must be rejected outright,
+// not silently discarded in favor of a full auto-detect. Auto-detect over a
+// long-lived station is hours of API hammering — exactly what an explicit
+// --from/--to is meant to let an operator avoid (see Config.From's doc
+// comment). Both subcases share one assertion set, which is why they are one
+// table rather than two near-duplicate test functions.
+func TestRunRejectsHalfSpecifiedRange(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{"From set, To zero", Config{From: at(1000), MinGap: 30 * time.Minute}},
+		{"To set, From zero", Config{To: at(1000), MinGap: 30 * time.Minute}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+			store := &fakeStore{}
+
+			_, err := Run(t.Context(), tt.cfg,
+				src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+			if err == nil {
+				t.Fatal("a half-specified range must be rejected, got nil error")
+			}
+			if len(src.calls) != 0 {
+				t.Errorf("made %d API calls for a rejected config, want 0", len(src.calls))
+			}
+			if len(store.inserted) != 0 {
+				t.Errorf("made %d inserts for a rejected config, want 0", len(store.inserted))
+			}
+		})
 	}
 }

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -47,6 +47,14 @@ func (f *fakeSource) Observations(_ context.Context, st tempestapi.Station, star
 	return f.obs, nil
 }
 
+// obsKey is the (serial, timestamp) identity the real stores' UNIQUE
+// constraint and ON CONFLICT DO NOTHING key off of (sqlite/backfill.go,
+// postgres/backfill.go).
+type obsKey struct {
+	serial string
+	ts     time.Time
+}
+
 type fakeStore struct {
 	// serials is what DistinctSerials returns — the UNWINDOWED whole-table
 	// serial set the pre-flight check uses. It is deliberately independent of
@@ -57,6 +65,15 @@ type fakeStore struct {
 	gaps      []weather.Gap
 	inserted  [][]weather.Observation
 	insertErr error
+
+	// seen tracks which (serial, timestamp) keys have already been reported
+	// as inserted, so InsertObservations can model the real store's
+	// `ON CONFLICT (serial_number, timestamp) DO NOTHING`: a row whose key
+	// was already reported returns 0 newly-inserted, not len(obs). Without
+	// this, Returned == Inserted in every Run-level test, and the plumbing
+	// between the store's real insert count and Stats.Inserted is never
+	// exercised — see TestRunSecondPassInsertsNothingWhenNothingIsNew.
+	seen map[obsKey]struct{}
 }
 
 func (f *fakeStore) DistinctSerials(context.Context) ([]string, error) {
@@ -76,7 +93,20 @@ func (f *fakeStore) InsertObservations(_ context.Context, obs []weather.Observat
 		return 0, f.insertErr
 	}
 	f.inserted = append(f.inserted, obs)
-	return len(obs), nil
+
+	if f.seen == nil {
+		f.seen = make(map[obsKey]struct{})
+	}
+	n := 0
+	for _, o := range obs {
+		key := obsKey{o.SerialNumber, o.Timestamp}
+		if _, ok := f.seen[key]; ok {
+			continue
+		}
+		f.seen[key] = struct{}{}
+		n++
+	}
+	return n, nil
 }
 
 func station(serial string) tempestapi.Station {
@@ -360,8 +390,28 @@ func TestFillGapContinuesAfterAFailedWindow(t *testing.T) {
 	if len(src.calls) != 3 {
 		t.Errorf("made %d API calls, want 3 — window 3 must still be attempted after window 2 fails", len(src.calls))
 	}
-	if stats.Inserted != 2 {
-		t.Errorf("Inserted = %d, want 2 (windows 1 and 3 both landed)", stats.Inserted)
+	// window 3 must still be OFFERED to the store even though fakeSource
+	// hands back the same static observation regardless of which window
+	// asked: two separate batches submitted to InsertObservations proves
+	// window 3's result was not silently dropped after window 2 failed.
+	if len(store.inserted) != 2 {
+		t.Errorf("submitted %d batches to InsertObservations, want 2 (windows 1 and 3 each offer their result)",
+			len(store.inserted))
+	}
+	// Inserted counts genuinely NEW rows: fakeStore dedupes on (serial,
+	// timestamp), mirroring the real stores' ON CONFLICT DO NOTHING
+	// (sqlite/backfill.go, postgres/backfill.go). Windows 1 and 3 return the
+	// IDENTICAL observation here (fakeSource always hands back the same
+	// static obs, regardless of window), so window 3's insert correctly
+	// reports 0 new — a real store would do exactly the same for the same
+	// key offered twice. This previously asserted 2, which only held because
+	// the old fake unconditionally returned len(obs) without checking
+	// whether the row had already landed; see
+	// TestRunSecondPassInsertsNothingWhenNothingIsNew for the scenario that
+	// exposed it.
+	if stats.Inserted != 1 {
+		t.Errorf("Inserted = %d, want 1 (window 1 lands the row; window 3 re-offers the identical "+
+			"serial+timestamp and correctly reports 0 new)", stats.Inserted)
 	}
 	if stats.Returned != 2 {
 		t.Errorf("Returned = %d, want 2 (windows 1 and 3 each returned one observation)", stats.Returned)
@@ -552,6 +602,49 @@ func TestRunHonorsContextCancellation(t *testing.T) {
 	}
 	if len(store.inserted) != 0 {
 		t.Errorf("made %d inserts under a cancelled context, want 0", len(store.inserted))
+	}
+}
+
+// This is the design's actual convergence scenario (Stats.Inserted's doc
+// comment): a station that is genuinely offline yields the exact same
+// observations on every run, so a second Run against the same store must
+// report Returned > 0 (the API still hands back what it has) and
+// Inserted == 0 (every row already landed). Automation watches for exactly
+// this "Inserted == 0 across runs" signal to decide a repair has converged
+// or is permanently stuck — see Stats.Inserted and fillGap's doc comments.
+//
+// This is the regression guard for `inserted += n` in fillGap: replacing it
+// with `inserted += len(chunk)` (discarding the store's real insert count)
+// leaves Returned == Inserted on every run, so a permanently-offline station
+// would report inserted>0 forever and automation would never notice.
+func TestRunSecondPassInsertsNothingWhenNothingIsNew(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{}
+
+	from := at(0)
+	to := from.Add(time.Hour)
+	cfg := Config{From: from, To: to, MinGap: 30 * time.Minute}
+	stations := []tempestapi.Station{station("ST-A")}
+
+	first, err := Run(t.Context(), cfg, src, store, stations, to)
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if first.Inserted == 0 {
+		t.Fatal("first run should have inserted the fresh row")
+	}
+
+	second, err := Run(t.Context(), cfg, src, store, stations, to)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if second.Returned == 0 {
+		t.Error("second run must still fetch — the API always returns what it has")
+	}
+	if second.Inserted != 0 {
+		t.Errorf("second run Inserted = %d, want 0 — every row already landed on the "+
+			"first run, which is the permanent-hole/already-converged signal automation "+
+			"watches for", second.Inserted)
 	}
 }
 

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -1,0 +1,489 @@
+package backfill
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+	"tempestwx-utilities/internal/weather"
+)
+
+// --- fakes ---
+
+type fakeSource struct {
+	calls    []window
+	stations []tempestapi.Station // which device each call was for
+	obs      []weather.Observation
+	errs     []error // consumed one per call; nil entries succeed
+	callNum  int
+}
+
+func (f *fakeSource) Observations(_ context.Context, st tempestapi.Station, start, end time.Time) ([]weather.Observation, error) {
+	f.calls = append(f.calls, window{from: start, to: end})
+	f.stations = append(f.stations, st)
+	i := f.callNum
+	f.callNum++
+	if i < len(f.errs) && f.errs[i] != nil {
+		return nil, f.errs[i]
+	}
+	return f.obs, nil
+}
+
+type fakeStore struct {
+	// serials is what DistinctSerials returns — the UNWINDOWED whole-table
+	// serial set the pre-flight check uses. It is deliberately independent of
+	// bounds, because the two queries genuinely differ: a serial can be in the
+	// store (serials) yet have no rows inside the queried window (bounds).
+	serials   []string
+	bounds    []weather.Bounds
+	gaps      []weather.Gap
+	inserted  [][]weather.Observation
+	insertErr error
+}
+
+func (f *fakeStore) DistinctSerials(context.Context) ([]string, error) {
+	return f.serials, nil
+}
+
+func (f *fakeStore) SeriesBounds(context.Context, time.Time, time.Time) ([]weather.Bounds, error) {
+	return f.bounds, nil
+}
+
+func (f *fakeStore) FindObservationGaps(context.Context, time.Time, time.Time, time.Duration) ([]weather.Gap, error) {
+	return f.gaps, nil
+}
+
+func (f *fakeStore) InsertObservations(_ context.Context, obs []weather.Observation) (int, error) {
+	if f.insertErr != nil {
+		return 0, f.insertErr
+	}
+	f.inserted = append(f.inserted, obs)
+	return len(obs), nil
+}
+
+func station(serial string) tempestapi.Station {
+	return tempestapi.Station{
+		SerialNumber: serial,
+		DeviceID:     1, // no assertion reads this; keeping it constant is honest
+		CreatedAt:    time.Unix(1000, 0).UTC(),
+	}
+}
+
+func obsAt(serial string, epoch int64) weather.Observation {
+	return weather.Observation{SerialNumber: serial, Timestamp: time.Unix(epoch, 0).UTC()}
+}
+
+// at is ts (defined in gaps_test.go — same package) under the name these
+// tests read better with. A one-line alias, not a second implementation.
+func at(epoch int64) time.Time { return ts(epoch) }
+
+// --- tests ---
+//
+// NOTE on fixtures: tests that pass an explicit Config{From, To} run the
+// path where Run does NOT query SeriesBounds, so setting store.bounds in
+// them is dead fixture data. It is left in place only where it documents
+// intent; do not infer from its presence that such a test exercises bounds.
+// TestRunAutoDetectUsesSeriesBounds is the only test that pins the fetch.
+
+func TestRunDryRunMakesNoAPICallsAndNoWrites(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(2000)}}}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute, DryRun: true},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 0 {
+		t.Errorf("dry run made %d API calls, want 0", len(src.calls))
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("dry run made %d inserts, want 0", len(store.inserted))
+	}
+	if stats.Gaps == 0 {
+		t.Error("dry run should still report the gaps it detected")
+	}
+	if stats.Inserted != 0 {
+		t.Errorf("Inserted = %d, want 0", stats.Inserted)
+	}
+}
+
+func TestRunSerialMismatchIsHardStopWithNoWrites(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	// The store holds ONLY a different serial than the API reports — the two
+	// sets are disjoint, which is the signature of format divergence. Writing
+	// would create a parallel series that never dedupes.
+	store := &fakeStore{
+		serials: []string{"ST-OTHER"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-OTHER", First: at(1000), Last: at(2000)}},
+	}
+
+	_, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err == nil {
+		t.Fatal("serial mismatch must be a hard stop, got nil error")
+	}
+	if !errors.Is(err, ErrSerialMismatch) {
+		t.Errorf("err = %v, want ErrSerialMismatch", err)
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("wrote %d batches despite a serial mismatch, want 0", len(store.inserted))
+	}
+	if len(src.calls) != 0 {
+		t.Errorf("made %d API calls despite a serial mismatch, want 0", len(src.calls))
+	}
+}
+
+func TestRunEmptyStoreIsNotASerialMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{} // empty: first run
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err != nil {
+		t.Fatalf("empty store must not be a mismatch: %v", err)
+	}
+	if stats.Gaps == 0 {
+		t.Error("empty store should yield the whole range as one gap")
+	}
+}
+
+// Regression: adding a second station to the account must not brick backfill.
+// The sets overlap (ST-A is in both), so this is not format divergence — and
+// ST-B, which the store has never seen, should simply get a whole-range gap.
+func TestRunNewSerialAlongsideKnownSerialIsNotAMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-B", 5000)}}
+	store := &fakeStore{
+		serials: []string{"ST-A"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: at(199000)}},
+	}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A"), station("ST-B")}, at(200000))
+	if err != nil {
+		t.Fatalf("a new serial alongside a known one must not be a mismatch: %v", err)
+	}
+	if stats.Gaps == 0 {
+		t.Error("the new serial ST-B should yield a whole-range gap")
+	}
+	if stats.Inserted == 0 {
+		t.Error("the new serial's gap should have been fetched and inserted")
+	}
+}
+
+// Regression guard for the CONDITIONAL SeriesBounds fetch.
+//
+// Run skips the SeriesBounds query on the explicit --from/--to path. Nothing
+// else pins that it still performs it on the auto-detect path: deleting the
+// query outright (always nil bounds) leaves every other test green, because
+// assembleGaps is unit-tested with bounds passed in directly and six Run
+// tests set store.bounds on the explicit path where it is dead fixture data.
+//
+// The consequence of nil bounds in production is not an error, which is why
+// it hides: every serial gets ONE whole-range gap from CreatedAt to
+// now-MinGap. For a two-year-old station that is ~730 sequential 24h API
+// windows on every run, forever, instead of the handful of real holes. It
+// still converges — it just silently turns a 30-second repair into hours of
+// API hammering.
+//
+// So assert the SHAPE of the gap, not the count: with a stored series ending
+// at Last, the planned tail gap must START at Last. Nil bounds would start it
+// at detectFrom instead.
+func TestRunAutoDetectUsesSeriesBounds(t *testing.T) {
+	last := at(100000)
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 150000)}}
+	store := &fakeStore{
+		serials: []string{"ST-A"},
+		bounds:  []weather.Bounds{{SerialNumber: "ST-A", First: at(1000), Last: last}},
+	}
+
+	_, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(300000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) == 0 {
+		t.Fatal("no windows fetched")
+	}
+
+	// The first fetched window must begin at the stored series' Last, not at
+	// the station's CreatedAt.
+	got := src.calls[0].from
+	if !got.Equal(last) {
+		t.Errorf("first fetch starts at %v, want %v (the stored series' Last). "+
+			"Starting at CreatedAt means SeriesBounds was not consulted, and the tool "+
+			"will re-request the station's entire history on every run.", got, last)
+	}
+}
+
+// Regression for the windowed-bounds bug: the pre-flight check must read
+// DistinctSerials (whole table), not SeriesBounds (windowed). A station that
+// simply had no rows inside the requested window is not missing from the
+// store, and `backfill --from X --to Y` is the tool's main repair path.
+//
+// The fixture is chosen so the two inputs DISAGREE — that is the whole point.
+// serials={ST-A, ST-OLD} overlaps the API's {ST-A}, so preflight passes; but
+// bounds={ST-OLD} does NOT overlap it, so feeding preflight the windowed key
+// set would report a false mismatch. A fixture where both inputs contain an
+// overlapping serial cannot tell the two apart and would pass either way.
+//
+// It must ALSO run on the auto-detect path (no --from/--to). Run skips the
+// SeriesBounds query entirely on the explicit-range path, so under that
+// config a mutated preflight would receive an empty slice, read it as
+// "empty store, not a mismatch", and return nil — passing for the wrong
+// reason. Do not add From/To to this test.
+func TestRunQuietSerialInRequestedWindowIsNotAMismatch(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{
+		// Whole table: the API's ST-A IS in the store, alongside a retired
+		// serial.
+		serials: []string{"ST-A", "ST-OLD"},
+		// In-window: only ST-OLD has rows here. ST-A was quiet.
+		bounds: []weather.Bounds{{SerialNumber: "ST-OLD", First: at(1000), Last: at(2000)}},
+	}
+
+	// Auto-detect (no From/To) so SeriesBounds is genuinely consulted.
+	_, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err != nil {
+		t.Fatalf("a serial with no rows in the detection window must not be a mismatch: %v", err)
+	}
+}
+
+// The design mandates that a station with two ST devices has BOTH backfilled.
+// Task 2's ListDevices test proves the two devices are discovered; this proves
+// Run actually fetches for each of them. Without it, the second half of that
+// requirement is untested and a regression that silently drops one sensor
+// would ship green.
+func TestRunBackfillsEveryDevice(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{} // empty: both devices get a whole-range gap
+
+	devices := []tempestapi.Station{station("ST-A"), station("ST-B")}
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute}, src, store, devices, at(200000))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Gaps < 2 {
+		t.Errorf("Gaps = %d, want at least 2 — one per device", stats.Gaps)
+	}
+
+	fetched := map[string]bool{}
+	for _, s := range src.stations {
+		fetched[s.SerialNumber] = true
+	}
+	if !fetched["ST-A"] || !fetched["ST-B"] {
+		t.Errorf("fetched for %v, want both ST-A and ST-B — a two-sensor station must not lose one", fetched)
+	}
+}
+
+// The insert-abort asymmetry is deliberate and must stay: a WINDOW error
+// continues to the next window, but an INSERT error aborts the whole gap,
+// because an unhealthy store will not be helped by the remaining windows.
+//
+// fakeStore.insertErr exists precisely to test this and was previously never
+// set by any test — inverting the behavior to `continue` would have shipped
+// green while hammering a dying store with every remaining window.
+func TestFillGapAbortsGapOnInsertError(t *testing.T) {
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{insertErr: errors.New("disk full")}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour) // three windows
+
+	stats, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+
+	if err == nil {
+		t.Fatal("an insert failure must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("err = %v, want it to wrap the insert error", err)
+	}
+	if len(src.calls) != 1 {
+		t.Errorf("made %d API calls, want 1 — an insert failure must abort the gap, "+
+			"not continue fetching the remaining windows", len(src.calls))
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+// A permanently failing window must not abandon the windows behind it. If it
+// does, those windows are never requested on ANY future run and the tool
+// silently stops converging.
+func TestFillGapContinuesAfterAFailedWindow(t *testing.T) {
+	src := &fakeSource{
+		obs: []weather.Observation{obsAt("ST-A", 5000)},
+		// Window 1 succeeds, window 2 fails permanently (a status_code is not
+		// retryable, so exactly one call), window 3 succeeds.
+		errs: []error{nil, &tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}, nil},
+	}
+	store := &fakeStore{}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour) // three 24h windows
+
+	stats, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+
+	if err == nil {
+		t.Fatal("the gap must still be reported failed")
+	}
+	if len(src.calls) != 3 {
+		t.Errorf("made %d API calls, want 3 — window 3 must still be attempted after window 2 fails", len(src.calls))
+	}
+	if stats.Inserted != 2 {
+		t.Errorf("Inserted = %d, want 2 (windows 1 and 3 both landed)", stats.Inserted)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+func TestRunChunksExplicitRangeIntoDays(t *testing.T) {
+	src := &fakeSource{}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	to := from.Add(72 * time.Hour)
+	_, err := Run(t.Context(),
+		Config{From: from, To: to, MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, to)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 3 {
+		t.Fatalf("made %d API calls, want 3 single-day requests: %+v", len(src.calls), src.calls)
+	}
+	for i, c := range src.calls {
+		if w := c.to.Sub(c.from); w > 24*time.Hour {
+			t.Errorf("call %d spans %v, want <= 24h (the API caps 1-minute resolution at 5 days)", i, w)
+		}
+	}
+}
+
+func TestRunRetriesTransientThenSucceeds(t *testing.T) {
+	src := &fakeSource{
+		obs:  []weather.Observation{obsAt("ST-A", 5000)},
+		errs: []error{&tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable}},
+	}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	stats, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(src.calls) != 2 {
+		t.Errorf("made %d calls, want 2 (one failure + one retry)", len(src.calls))
+	}
+	if stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0 after a successful retry", stats.Failed)
+	}
+	if stats.Inserted != 1 {
+		t.Errorf("Inserted = %d, want 1", stats.Inserted)
+	}
+}
+
+func TestRunDoesNotRetryNonTransient(t *testing.T) {
+	src := &fakeSource{errs: []error{&tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	stats, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err == nil {
+		t.Fatal("a failed gap must surface as an error")
+	}
+	if len(src.calls) != 1 {
+		t.Errorf("made %d calls, want 1 (an API-level status_code is never transient)", len(src.calls))
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+func TestRunContinuesAfterAFailedGapAndReportsBoth(t *testing.T) {
+	// Two gaps; the first window fails permanently, the second succeeds.
+	src := &fakeSource{
+		obs:  []weather.Observation{obsAt("ST-A", 5000)},
+		errs: []error{&tempestapi.StatusError{StatusCode: 404}},
+	}
+	store := &fakeStore{
+		bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(10000), Last: at(20000)}},
+		gaps:   nil,
+	}
+
+	stats, err := Run(t.Context(),
+		Config{MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, at(200000))
+	if err == nil {
+		t.Fatal("want a non-nil error when any gap failed")
+	}
+	if stats.Failed == 0 {
+		t.Error("Failed should count the failed gap")
+	}
+	if stats.Inserted == 0 {
+		t.Error("the surviving gap should still have inserted rows — partial progress must be preserved")
+	}
+}
+
+func TestRunBoundsInsertBatchSize(t *testing.T) {
+	// 500 observations must arrive as batches of at most 200: an unbounded
+	// transaction contends with live ingest, whose error path only logs.
+	var many []weather.Observation
+	for i := range 500 {
+		many = append(many, obsAt("ST-A", int64(5000+i*60)))
+	}
+	src := &fakeSource{obs: many}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	_, err := Run(t.Context(),
+		Config{From: from, To: from.Add(time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.inserted) < 3 {
+		t.Fatalf("got %d batches, want at least 3 for 500 rows at max 200/batch", len(store.inserted))
+	}
+	for i, b := range store.inserted {
+		if len(b) > 200 {
+			t.Errorf("batch %d has %d rows, want <= 200", i, len(b))
+		}
+	}
+}
+
+func TestRunHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{bounds: []weather.Bounds{{SerialNumber: "ST-A", First: at(0), Last: at(1)}}}
+
+	from := at(0)
+	_, err := Run(ctx,
+		Config{From: from, To: from.Add(72 * time.Hour), MinGap: 30 * time.Minute},
+		src, store, []tempestapi.Station{station("ST-A")}, from.Add(72*time.Hour))
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}

--- a/internal/backfill/gaps.go
+++ b/internal/backfill/gaps.go
@@ -1,0 +1,78 @@
+package backfill
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+// assembleGaps builds the full detection domain from what SQL can and cannot
+// see.
+//
+// FindObservationGaps uses a LAG window function, which yields NULL for the
+// first row of each partition — so it finds INTERIOR gaps only. Left at that,
+// a fresh store reports "no gaps" and writes nothing, and the natural "the
+// box was down, repair it" case — whose outage is entirely in the tail — is
+// invisible. The domain is therefore the union of:
+//
+//   - the head gap [detectFrom, first stored row]
+//   - the interior gaps SQL found
+//   - the tail gap [last stored row, detectTo]
+//
+// with the EMPTY-store case (no bounds for a serial) treated as one gap
+// covering the whole range. That is a first-class case, not an edge case: it
+// is what every first run looks like.
+//
+// serials is the set the API knows about. A serial present in the store but
+// absent from the API (a retired station) produces no work — there is nothing
+// to fetch for it. Edges narrower than minGap are ordinary reporting jitter
+// and are dropped, matching the interior threshold.
+func assembleGaps(
+	interior []weather.Gap,
+	bounds []weather.Bounds,
+	serials []string,
+	detectFrom, detectTo time.Time,
+	minGap time.Duration,
+) []weather.Gap {
+	byserial := make(map[string]weather.Bounds, len(bounds))
+	for _, b := range bounds {
+		byserial[b.SerialNumber] = b
+	}
+
+	var out []weather.Gap
+	for _, serial := range serials {
+		b, ok := byserial[serial]
+		if !ok {
+			// Nothing stored for this serial in the detection window: the
+			// whole range is one gap.
+			if detectTo.Sub(detectFrom) > minGap {
+				out = append(out, weather.Gap{SerialNumber: serial, From: detectFrom, To: detectTo})
+			}
+			continue
+		}
+		if b.First.Sub(detectFrom) > minGap {
+			out = append(out, weather.Gap{SerialNumber: serial, From: detectFrom, To: b.First})
+		}
+		for _, g := range interior {
+			if g.SerialNumber == serial {
+				out = append(out, g)
+			}
+		}
+		if detectTo.Sub(b.Last) > minGap {
+			out = append(out, weather.Gap{SerialNumber: serial, From: b.Last, To: detectTo})
+		}
+	}
+
+	// slices.SortFunc, not sort.Slice: it is the Go 1.25 idiom, and sort.Slice
+	// is unstable while (serial, From) is not guaranteed unique.
+	slices.SortFunc(out, func(a, b weather.Gap) int {
+		return cmp.Or(
+			strings.Compare(a.SerialNumber, b.SerialNumber),
+			a.From.Compare(b.From),
+		)
+	})
+	return out
+}

--- a/internal/backfill/gaps.go
+++ b/internal/backfill/gaps.go
@@ -30,6 +30,10 @@ import (
 // absent from the API (a retired station) produces no work — there is nothing
 // to fetch for it. Edges narrower than minGap are ordinary reporting jitter
 // and are dropped, matching the interior threshold.
+//
+// serials must not contain duplicates — the caller's contract, not this
+// function's: a repeated serial yields repeated gaps. serials is derived
+// from ListDevices, which does not repeat a station.
 func assembleGaps(
 	interior []weather.Gap,
 	bounds []weather.Bounds,
@@ -37,14 +41,14 @@ func assembleGaps(
 	detectFrom, detectTo time.Time,
 	minGap time.Duration,
 ) []weather.Gap {
-	byserial := make(map[string]weather.Bounds, len(bounds))
+	bySerial := make(map[string]weather.Bounds, len(bounds))
 	for _, b := range bounds {
-		byserial[b.SerialNumber] = b
+		bySerial[b.SerialNumber] = b
 	}
 
 	var out []weather.Gap
 	for _, serial := range serials {
-		b, ok := byserial[serial]
+		b, ok := bySerial[serial]
 		if !ok {
 			// Nothing stored for this serial in the detection window: the
 			// whole range is one gap.

--- a/internal/backfill/gaps_test.go
+++ b/internal/backfill/gaps_test.go
@@ -93,3 +93,98 @@ func TestAssembleGapsIgnoresBoundsForUnknownSerial(t *testing.T) {
 		}
 	}
 }
+
+func TestAssembleGapsInteriorGapIsScopedToItsSerial(t *testing.T) {
+	// Two serials, but the interior gap belongs only to ST-A. Without the
+	// SerialNumber guard, ST-B would wrongly inherit ST-A's outage.
+	interior := []weather.Gap{{SerialNumber: "ST-A", From: ts(20000), To: ts(30000)}}
+	bounds := []weather.Bounds{
+		{SerialNumber: "ST-A", First: ts(1000), Last: ts(90000)},
+		{SerialNumber: "ST-B", First: ts(1000), Last: ts(90000)},
+	}
+	got := assembleGaps(interior, bounds, []string{"ST-A", "ST-B"}, ts(1000), ts(90000), 30*time.Minute)
+
+	set := gapSet(got)
+	if len(set["ST-A"]) != 1 || set["ST-A"][0] != [2]int64{20000, 30000} {
+		t.Errorf("ST-A got %v, want one interior gap [20000, 30000]", set["ST-A"])
+	}
+	if len(set["ST-B"]) != 0 {
+		t.Errorf("ST-B got %v, want no gaps (ST-A's interior gap must not leak)", set["ST-B"])
+	}
+}
+
+func TestAssembleGapsSortsAcrossAndWithinSerials(t *testing.T) {
+	// serials is deliberately out of lexicographic order, and ST-A's interior
+	// gaps are deliberately out of chronological order in the input slice —
+	// both must be corrected by the trailing sort, not by input order.
+	interior := []weather.Gap{
+		{SerialNumber: "ST-A", From: ts(56000), To: ts(58000)},
+		{SerialNumber: "ST-A", From: ts(52000), To: ts(54000)},
+	}
+	bounds := []weather.Bounds{
+		{SerialNumber: "ST-A", First: ts(50000), Last: ts(60000)},
+	}
+	got := assembleGaps(interior, bounds, []string{"ST-B", "ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	want := []struct {
+		serial   string
+		from, to int64
+	}{
+		{"ST-A", 1000, 50000},
+		{"ST-A", 52000, 54000},
+		{"ST-A", 56000, 58000},
+		{"ST-A", 60000, 90000},
+		{"ST-B", 1000, 90000},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d gaps, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].SerialNumber != w.serial || !got[i].From.Equal(ts(w.from)) || !got[i].To.Equal(ts(w.to)) {
+			t.Errorf("gap[%d] = %+v, want {%s [%d, %d]}", i, got[i], w.serial, w.from, w.to)
+		}
+	}
+}
+
+func TestAssembleGapsHeadInteriorAndTailTogether(t *testing.T) {
+	// All three sources contribute for one serial at once — the case the
+	// other tests deliberately avoid by spanning bounds over the full range.
+	interior := []weather.Gap{{SerialNumber: "ST-A", From: ts(52000), To: ts(58000)}}
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(50000), Last: ts(60000)}}
+	got := assembleGaps(interior, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	want := [][2]int64{{1000, 50000}, {52000, 58000}, {60000, 90000}}
+	set := gapSet(got)["ST-A"]
+	if len(set) != len(want) {
+		t.Fatalf("got %d gaps, want %d (head + interior + tail): %+v", len(set), len(want), got)
+	}
+	for i, w := range want {
+		if set[i] != w {
+			t.Errorf("gap[%d] = %v, want %v", i, set[i], w)
+		}
+	}
+}
+
+func TestAssembleGapsHeadEdgeExactlyMinGapIsDropped(t *testing.T) {
+	// First is exactly detectFrom + minGap: the strict '>' check must drop
+	// this edge, not include it.
+	minGap := 30 * time.Minute
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1000).Add(minGap), Last: ts(80000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), minGap)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d gaps, want 1 (tail only, head dropped at the boundary): %+v", len(got), got)
+	}
+	if got[0].SerialNumber != "ST-A" || !got[0].From.Equal(ts(80000)) || !got[0].To.Equal(ts(90000)) {
+		t.Errorf("gap = %+v, want ST-A [80000, 90000]", got[0])
+	}
+}
+
+func TestAssembleGapsEmptyStoreNarrowerThanMinGapProducesNoGap(t *testing.T) {
+	// The detection window itself is narrower than minGap, so even the
+	// empty-store whole-range gap must be dropped.
+	got := assembleGaps(nil, nil, []string{"ST-A"}, ts(1000), ts(2000), 30*time.Minute)
+	if len(got) != 0 {
+		t.Errorf("got %d gaps, want 0: %+v", len(got), got)
+	}
+}

--- a/internal/backfill/gaps_test.go
+++ b/internal/backfill/gaps_test.go
@@ -1,0 +1,95 @@
+package backfill
+
+import (
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+func ts(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+
+func gapSet(gaps []weather.Gap) map[string][][2]int64 {
+	out := map[string][][2]int64{}
+	for _, g := range gaps {
+		out[g.SerialNumber] = append(out[g.SerialNumber], [2]int64{g.From.Unix(), g.To.Unix()})
+	}
+	return out
+}
+
+func TestAssembleGapsEmptyStoreIsOneWholeRangeGap(t *testing.T) {
+	got := assembleGaps(nil, nil, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+	if len(got) != 1 {
+		t.Fatalf("got %d gaps, want 1: %+v", len(got), got)
+	}
+	if got[0].SerialNumber != "ST-A" || !got[0].From.Equal(ts(1000)) || !got[0].To.Equal(ts(90000)) {
+		t.Errorf("gap = %+v, want ST-A [1000, 90000]", got[0])
+	}
+}
+
+func TestAssembleGapsHeadAndTail(t *testing.T) {
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(50000), Last: ts(60000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	set := gapSet(got)["ST-A"]
+	if len(set) != 2 {
+		t.Fatalf("got %d gaps, want 2 (head + tail): %+v", len(set), got)
+	}
+	if set[0] != [2]int64{1000, 50000} {
+		t.Errorf("head gap = %v, want [1000, 50000]", set[0])
+	}
+	if set[1] != [2]int64{60000, 90000} {
+		t.Errorf("tail gap = %v, want [60000, 90000]", set[1])
+	}
+}
+
+func TestAssembleGapsSkipsHeadAndTailBelowMinGap(t *testing.T) {
+	// First row is 60s after detectFrom and last row is 60s before detectTo:
+	// both edges are narrower than minGap and must not be reported.
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1060), Last: ts(89940)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+	if len(got) != 0 {
+		t.Errorf("got %d gaps, want 0: %+v", len(got), got)
+	}
+}
+
+func TestAssembleGapsPreservesInterior(t *testing.T) {
+	interior := []weather.Gap{{SerialNumber: "ST-A", From: ts(20000), To: ts(30000)}}
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1000), Last: ts(90000)}}
+	got := assembleGaps(interior, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d gaps, want 1 (interior only, no head/tail): %+v", len(got), got)
+	}
+	if !got[0].From.Equal(ts(20000)) || !got[0].To.Equal(ts(30000)) {
+		t.Errorf("gap = %+v, want [20000, 30000]", got[0])
+	}
+}
+
+func TestAssembleGapsPerSerialIndependence(t *testing.T) {
+	// ST-A has data; ST-B is a brand-new serial with nothing stored. ST-B's
+	// whole range must be a gap even though ST-A looks healthy.
+	bounds := []weather.Bounds{{SerialNumber: "ST-A", First: ts(1000), Last: ts(90000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A", "ST-B"}, ts(1000), ts(90000), 30*time.Minute)
+
+	set := gapSet(got)
+	if len(set["ST-A"]) != 0 {
+		t.Errorf("ST-A got %v, want no gaps", set["ST-A"])
+	}
+	if len(set["ST-B"]) != 1 || set["ST-B"][0] != [2]int64{1000, 90000} {
+		t.Errorf("ST-B got %v, want one whole-range gap", set["ST-B"])
+	}
+}
+
+func TestAssembleGapsIgnoresBoundsForUnknownSerial(t *testing.T) {
+	// A serial present in the store but not returned by the API (a retired
+	// station) must not produce work — there is nothing to fetch for it.
+	bounds := []weather.Bounds{{SerialNumber: "ST-OLD", First: ts(1000), Last: ts(2000)}}
+	got := assembleGaps(nil, bounds, []string{"ST-A"}, ts(1000), ts(90000), 30*time.Minute)
+
+	for _, g := range got {
+		if g.SerialNumber == "ST-OLD" {
+			t.Errorf("produced a gap for a serial the API does not know: %+v", g)
+		}
+	}
+}

--- a/internal/backfill/window.go
+++ b/internal/backfill/window.go
@@ -1,0 +1,92 @@
+// Package backfill finds holes in the local observation history and fills
+// them from the Tempest REST API.
+package backfill
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+)
+
+// chunkSize bounds one API request's window.
+//
+// The Tempest API documents that observation data at one-minute resolution is
+// available only for ranges of FIVE DAYS OR LESS. Exceeding that cap does not
+// error — it silently returns coarser data, which would then be written as if
+// it were 1-minute observations. One day sits comfortably inside the cap.
+// Every fetch goes through the chunker, including an explicit --from/--to.
+//
+//nolint:unused // consumed by fillGap's chunkWindow call, added in Task 9
+const chunkSize = 24 * time.Hour
+
+// window is one API request's time range.
+type window struct {
+	from time.Time
+	to   time.Time
+}
+
+// chunkWindow splits [from, to] into consecutive windows of at most size. The
+// final window is truncated to `to` rather than overshooting it. A zero-width
+// or inverted range yields no windows.
+func chunkWindow(from, to time.Time, size time.Duration) []window {
+	if !to.After(from) {
+		return nil
+	}
+	var out []window
+	for start := from; start.Before(to); start = start.Add(size) {
+		end := start.Add(size)
+		if end.After(to) {
+			end = to
+		}
+		out = append(out, window{from: start, to: end})
+	}
+	return out
+}
+
+// isRetryable reports whether retrying err could plausibly succeed.
+//
+// Classification uses errors.As, NOT errors.AsType — that is Go 1.26 and
+// go.mod declares go 1.25.0.
+//
+// DO NOT add a `errors.Is(err, context.DeadlineExceeded) -> false` guard here.
+// It looks obviously correct and it is a serious bug. http.Client.Timeout is
+// IMPLEMENTED as a context deadline, so a per-attempt timeout produces a
+// *url.Error that satisfies BOTH errors.Is(err, context.DeadlineExceeded) AND
+// errors.As(err, &netErr):
+//
+//	Get "...": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+//	errors.Is(err, context.DeadlineExceeded) = true
+//	errors.As(err, &net.Error)               = true
+//
+// Such a guard therefore classifies EVERY slow API response as permanent,
+// failing the whole gap on the first try with zero retries — the single most
+// likely transient failure in a tool issuing thousands of sequential requests.
+// Timeouts must fall through to the net.Error branch below.
+//
+// Whether the PARENT context is done is a separate question, answered at the
+// call site with ctx.Err(), not by inspecting this error's identity.
+// context.Canceled is the one blanket signal: it is the operator's decision.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	var se *tempestapi.StatusError
+	if errors.As(err, &se) {
+		// A non-zero API-level status_code is a real failure, not congestion.
+		if se.StatusCode != 0 {
+			return false
+		}
+		return se.HTTPStatus == http.StatusTooManyRequests || se.HTTPStatus >= 500
+	}
+
+	var ne net.Error
+	return errors.As(err, &ne)
+}

--- a/internal/backfill/window.go
+++ b/internal/backfill/window.go
@@ -19,8 +19,6 @@ import (
 // error — it silently returns coarser data, which would then be written as if
 // it were 1-minute observations. One day sits comfortably inside the cap.
 // Every fetch goes through the chunker, including an explicit --from/--to.
-//
-//nolint:unused // consumed by fillGap's chunkWindow call, added in Task 9
 const chunkSize = 24 * time.Hour
 
 // window is one API request's time range.

--- a/internal/backfill/window.go
+++ b/internal/backfill/window.go
@@ -31,9 +31,9 @@ type window struct {
 
 // chunkWindow splits [from, to] into consecutive windows of at most size. The
 // final window is truncated to `to` rather than overshooting it. A zero-width
-// or inverted range yields no windows.
+// or inverted range, or a non-positive size, yields no windows.
 func chunkWindow(from, to time.Time, size time.Duration) []window {
-	if !to.After(from) {
+	if size <= 0 || !to.After(from) {
 		return nil
 	}
 	var out []window

--- a/internal/backfill/window_test.go
+++ b/internal/backfill/window_test.go
@@ -1,0 +1,153 @@
+package backfill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
+)
+
+func TestChunkWindowSplitsMultiDayRange(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(72 * time.Hour)
+
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 3 {
+		t.Fatalf("got %d windows, want 3: %+v", len(got), got)
+	}
+	for i, w := range got {
+		wantFrom := from.Add(time.Duration(i) * 24 * time.Hour)
+		if !w.from.Equal(wantFrom) {
+			t.Errorf("window %d from = %v, want %v", i, w.from, wantFrom)
+		}
+	}
+	if !got[len(got)-1].to.Equal(to) {
+		t.Errorf("last window to = %v, want %v", got[len(got)-1].to, to)
+	}
+}
+
+func TestChunkWindowPartialTail(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(30 * time.Hour)
+
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 2 {
+		t.Fatalf("got %d windows, want 2: %+v", len(got), got)
+	}
+	if !got[1].to.Equal(to) {
+		t.Errorf("tail window to = %v, want %v (must not overshoot)", got[1].to, to)
+	}
+	if got[1].to.Sub(got[1].from) != 6*time.Hour {
+		t.Errorf("tail window width = %v, want 6h", got[1].to.Sub(got[1].from))
+	}
+}
+
+func TestChunkWindowSingleShortRange(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(time.Hour)
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 1 {
+		t.Fatalf("got %d windows, want 1", len(got))
+	}
+	if !got[0].from.Equal(from) || !got[0].to.Equal(to) {
+		t.Errorf("window = [%v, %v], want [%v, %v]", got[0].from, got[0].to, from, to)
+	}
+}
+
+func TestChunkWindowEmptyOrInvertedRange(t *testing.T) {
+	from := time.Unix(1000, 0).UTC()
+	if got := chunkWindow(from, from, 24*time.Hour); len(got) != 0 {
+		t.Errorf("zero-width range produced %d windows, want 0", len(got))
+	}
+	if got := chunkWindow(from, from.Add(-time.Hour), 24*time.Hour); len(got) != 0 {
+		t.Errorf("inverted range produced %d windows, want 0", len(got))
+	}
+}
+
+type fakeNetErr struct{}
+
+func (fakeNetErr) Error() string   { return "dial tcp: connection refused" }
+func (fakeNetErr) Timeout() bool   { return false }
+func (fakeNetErr) Temporary() bool { return true }
+
+var _ net.Error = fakeNetErr{}
+
+// realTimeoutError produces the error an actual per-attempt HTTP timeout
+// yields — NOT a synthetic fake.
+//
+// This distinction is the whole point. http.Client.Timeout is implemented as a
+// context deadline, so the resulting *url.Error satisfies BOTH
+// errors.Is(err, context.DeadlineExceeded) AND errors.As(err, &netErr). A
+// hand-rolled net.Error fake satisfies only the second, so it cannot
+// reproduce the bug and would pass against a classifier that returns false for
+// every timeout. Build the real thing.
+func realTimeoutError(t *testing.T) error {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // stall until the client gives up
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected a timeout error, got none")
+	}
+	return err
+}
+
+// Regression test for the classifier bug: a per-attempt HTTP timeout MUST be
+// retried. If this fails, isRetryable is short-circuiting on
+// context.DeadlineExceeded before reaching the net.Error branch, and every
+// slow API response will fail its entire gap with zero retries.
+func TestIsRetryableRealHTTPTimeoutIsRetried(t *testing.T) {
+	err := realTimeoutError(t)
+
+	// Document the dual-predicate property that makes this subtle.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("precondition changed: a Client.Timeout error should satisfy errors.Is(DeadlineExceeded); got %v", err)
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) {
+		t.Fatalf("precondition changed: a Client.Timeout error should satisfy errors.As(net.Error); got %v", err)
+	}
+
+	if !isRetryable(err) {
+		t.Error("a per-attempt HTTP timeout must be retryable; " +
+			"isRetryable is short-circuiting on context.DeadlineExceeded")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"429", &tempestapi.StatusError{HTTPStatus: http.StatusTooManyRequests}, true},
+		{"500", &tempestapi.StatusError{HTTPStatus: http.StatusInternalServerError}, true},
+		{"503", &tempestapi.StatusError{HTTPStatus: http.StatusServiceUnavailable}, true},
+		{"404", &tempestapi.StatusError{HTTPStatus: http.StatusNotFound}, false},
+		{"401", &tempestapi.StatusError{HTTPStatus: http.StatusUnauthorized}, false},
+		{"api level status_code is never transient", &tempestapi.StatusError{StatusCode: 404, Message: "NOT FOUND"}, false},
+		{"wrapped 503 still classifies", fmt.Errorf("gap 1: %w", &tempestapi.StatusError{HTTPStatus: 503}), true},
+		{"network error", fakeNetErr{}, true},
+		{"context canceled is the operator's decision", context.Canceled, false},
+		{"unknown error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backfill/window_test.go
+++ b/internal/backfill/window_test.go
@@ -32,6 +32,31 @@ func TestChunkWindowSplitsMultiDayRange(t *testing.T) {
 	}
 }
 
+// TestChunkWindowPinsMaxWidthInvariant exercises a range well past the
+// Tempest API's five-day one-minute-resolution cap. The 1-day chunkSize is a
+// data-integrity control, not a performance knob: a window wider than `size`
+// would silently receive coarser-resolution data from the API, which then
+// gets written as if it were 1-minute observations. Checking only the tail's
+// width (as the other tests here do) cannot catch a chunker that lets every
+// *intermediate* window run unbounded to `to` — this test pins exactly that.
+func TestChunkWindowPinsMaxWidthInvariant(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(30 * 24 * time.Hour) // 30 days, well past the 5-day cap
+
+	got := chunkWindow(from, to, 24*time.Hour)
+	if len(got) != 30 {
+		t.Errorf("got %d windows, want 30: %+v", len(got), got)
+	}
+	for i, w := range got {
+		if w.to.Sub(w.from) > 24*time.Hour {
+			t.Errorf("window %d width = %v, exceeds size 24h", i, w.to.Sub(w.from))
+		}
+		if i > 0 && !w.from.Equal(got[i-1].to) {
+			t.Errorf("window %d from = %v, want contiguous with previous to = %v", i, w.from, got[i-1].to)
+		}
+	}
+}
+
 func TestChunkWindowPartialTail(t *testing.T) {
 	from := time.Unix(0, 0).UTC()
 	to := from.Add(30 * time.Hour)
@@ -67,6 +92,31 @@ func TestChunkWindowEmptyOrInvertedRange(t *testing.T) {
 	}
 	if got := chunkWindow(from, from.Add(-time.Hour), 24*time.Hour); len(got) != 0 {
 		t.Errorf("inverted range produced %d windows, want 0", len(got))
+	}
+}
+
+// TestChunkWindowNonPositiveSizeYieldsNoWindows guards against an infinite
+// loop: with size <= 0, start.Add(size) never advances start past `to`, so
+// the loop would otherwise grow the output slice without bound until the
+// process is OOM-killed. Unreachable today (the only caller passes the
+// chunkSize constant), but the guard is free.
+func TestChunkWindowNonPositiveSizeYieldsNoWindows(t *testing.T) {
+	from := time.Unix(0, 0).UTC()
+	to := from.Add(72 * time.Hour)
+
+	tests := []struct {
+		name string
+		size time.Duration
+	}{
+		{"zero size", 0},
+		{"negative size", -time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chunkWindow(from, to, tt.size); len(got) != 0 {
+				t.Errorf("got %d windows, want 0", len(got))
+			}
+		})
 	}
 }
 

--- a/internal/postgres/backfill.go
+++ b/internal/postgres/backfill.go
@@ -1,0 +1,212 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"tempestwx-utilities/internal/tempestudp"
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// This file mirrors internal/sqlite/backfill.go function-for-function. The
+// two are deliberately NOT unified: SQLite stores timestamps as epoch INTEGER
+// and Postgres as TIMESTAMPTZ, and the two drivers bind parameters
+// differently. An abstraction over that difference would be the wrong
+// abstraction. The signatures are identical so one consumer-side interface
+// satisfies both.
+
+// backfillBatchTimeout bounds one backfill SendBatch. The daemon's hardcoded
+// 5s at insertObservations (writer.go:222) was sized for the 1-row live path;
+// a backfill batch of up to 200 rows needs its own budget.
+const backfillBatchTimeout = 30 * time.Second
+
+// findObservationGapsSQL locates interior holes in each station's series.
+//
+// PARTITION BY serial_number is NOT optional — see the identical comment in
+// internal/sqlite/backfill.go. Without it a multi-hour outage on one of two
+// phase-offset stations is undetectable.
+const findObservationGapsSQL = `
+	SELECT serial_number, prev, ts FROM (
+	  SELECT serial_number,
+	         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+	         timestamp AS ts
+	  FROM tempest_observations
+	  WHERE timestamp BETWEEN $1 AND $2
+	) q WHERE prev IS NOT NULL AND EXTRACT(EPOCH FROM (ts - prev)) > $3
+	ORDER BY serial_number, prev
+`
+
+// FindObservationGaps returns the interior gaps in [from, to] wider than
+// minGap. LAG yields NULL for the first row of each partition, so this finds
+// interior gaps ONLY; head/tail/empty are assembled by the caller from
+// SeriesBounds.
+func FindObservationGaps(ctx context.Context, pool *pgxpool.Pool, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	rows, err := pool.Query(ctx, findObservationGapsSQL, from, to, minGap.Seconds())
+	if err != nil {
+		return nil, fmt.Errorf("query observation gaps: %w", err)
+	}
+	defer rows.Close()
+
+	var gaps []weather.Gap
+	for rows.Next() {
+		var serial string
+		var prev, next time.Time
+		if err := rows.Scan(&serial, &prev, &next); err != nil {
+			return nil, fmt.Errorf("scan observation gap: %w", err)
+		}
+		gaps = append(gaps, weather.Gap{
+			SerialNumber: serial,
+			From:         prev.UTC(),
+			To:           next.UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate observation gaps: %w", err)
+	}
+	return gaps, nil
+}
+
+const seriesBoundsSQL = `
+	SELECT serial_number, MIN(timestamp), MAX(timestamp)
+	FROM tempest_observations
+	WHERE timestamp BETWEEN $1 AND $2
+	GROUP BY serial_number
+	ORDER BY serial_number
+`
+
+// SeriesBounds returns the first and last observation timestamp held for each
+// serial within [from, to]. An empty result means the store holds nothing in
+// that window — the first-run case.
+func SeriesBounds(ctx context.Context, pool *pgxpool.Pool, from, to time.Time) ([]weather.Bounds, error) {
+	rows, err := pool.Query(ctx, seriesBoundsSQL, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("query series bounds: %w", err)
+	}
+	defer rows.Close()
+
+	var out []weather.Bounds
+	for rows.Next() {
+		var serial string
+		var first, last time.Time
+		if err := rows.Scan(&serial, &first, &last); err != nil {
+			return nil, fmt.Errorf("scan series bounds: %w", err)
+		}
+		out = append(out, weather.Bounds{
+			SerialNumber: serial,
+			First:        first.UTC(),
+			Last:         last.UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate series bounds: %w", err)
+	}
+	return out, nil
+}
+
+// DistinctSerials returns every serial the table has ever held.
+//
+// UNWINDOWED, deliberately — see the identical comment in
+// internal/sqlite/backfill.go. Merging this into SeriesBounds causes a false
+// serial mismatch for any station that was quiet during the queried window.
+func DistinctSerials(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
+	rows, err := pool.Query(ctx, `SELECT DISTINCT serial_number FROM tempest_observations ORDER BY serial_number`)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct serials: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var serial string
+		if err := rows.Scan(&serial); err != nil {
+			return nil, fmt.Errorf("scan distinct serial: %w", err)
+		}
+		out = append(out, serial)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate distinct serials: %w", err)
+	}
+	return out, nil
+}
+
+const backfillInsertSQL = `
+	INSERT INTO tempest_observations (
+		id, serial_number, timestamp,
+		wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
+		pressure, temp_air, temp_wetbulb, humidity,
+		illuminance, uv_index, irradiance, rain_rate, precip_type,
+		lightning_distance, lightning_strike_count,
+		battery, report_interval
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	ON CONFLICT (serial_number, timestamp) DO NOTHING
+`
+
+// InsertObservations writes obs idempotently and reports how many rows were
+// actually new. CommandTag.RowsAffected() is 0 for a skipped conflict and 1
+// for an insert — the same semantics as SQLite's per-row RowsAffected, and
+// the value the daemon path currently discards (writer.go:250).
+//
+// pgx SendBatch is all-or-nothing per batch, so the count is only meaningful
+// once every Exec has succeeded. The caller bounds len(obs).
+func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.Observation) (int, error) {
+	if len(obs) == 0 {
+		return 0, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, backfillBatchTimeout)
+	defer cancel()
+
+	b := &pgx.Batch{}
+	for _, o := range obs {
+		b.Queue(backfillInsertSQL,
+			uuid.Must(uuid.NewV7()), o.SerialNumber, o.Timestamp,
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
+	}
+
+	br := pool.SendBatch(ctx, b)
+	defer closeBatchResults(br)
+
+	inserted := 0
+	for i := range obs {
+		tag, err := br.Exec()
+		if err != nil {
+			return 0, fmt.Errorf("insert observation %d: %w", i, err)
+		}
+		inserted += int(tag.RowsAffected())
+	}
+	return inserted, nil
+}
+
+// wetBulb derives temp_wetbulb, which the REST API does not return. It uses
+// the same tempestudp.WetBulbTemperatureC + math.IsNaN guard the UDP ingest
+// path uses, single-sourced, so backfilled and live rows are
+// indistinguishable. Any missing input yields NULL rather than a value
+// computed from a zero.
+//
+// This is duplicated (four lines) in internal/sqlite/backfill.go rather than
+// shared. The formula itself already lives in exactly one place
+// (tempestudp.WetBulbTemperatureC); what's duplicated here is only the nil
+// guard, and four lines is cheaper than a new cross-package dependency. Note
+// the counter-argument is real: "wet bulb is NULL unless temp, humidity and
+// pressure are all present" is shared knowledge under the DRY test, and if it
+// ever changes both copies must change together.
+func wetBulb(o weather.Observation) *float64 {
+	if o.TempAir == nil || o.Humidity == nil || o.Pressure == nil {
+		return nil
+	}
+	v := tempestudp.WetBulbTemperatureC(*o.TempAir, *o.Humidity, *o.Pressure)
+	if math.IsNaN(v) {
+		return nil
+	}
+	return &v
+}

--- a/internal/postgres/backfill.go
+++ b/internal/postgres/backfill.go
@@ -135,18 +135,6 @@ func DistinctSerials(ctx context.Context, pool *pgxpool.Pool) ([]string, error) 
 	return out, nil
 }
 
-const backfillInsertSQL = `
-	INSERT INTO tempest_observations (
-		id, serial_number, timestamp,
-		wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
-		pressure, temp_air, temp_wetbulb, humidity,
-		illuminance, uv_index, irradiance, rain_rate, precip_type,
-		lightning_distance, lightning_strike_count,
-		battery, report_interval
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
-	ON CONFLICT (serial_number, timestamp) DO NOTHING
-`
-
 // InsertObservations writes obs idempotently and reports how many rows were
 // actually new. CommandTag.RowsAffected() is 0 for a skipped conflict and 1
 // for an insert — the same semantics as SQLite's per-row RowsAffected, and
@@ -164,7 +152,7 @@ func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.O
 
 	b := &pgx.Batch{}
 	for _, o := range obs {
-		b.Queue(backfillInsertSQL,
+		b.Queue(insertObservationSQL,
 			uuid.Must(uuid.NewV7()), o.SerialNumber, o.Timestamp,
 			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
 			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,

--- a/internal/postgres/backfill_test.go
+++ b/internal/postgres/backfill_test.go
@@ -1,0 +1,215 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+func f(v float64) *float64 { return &v }
+
+func TestBackfillWetBulbDerivation(t *testing.T) {
+	tests := []struct {
+		name    string
+		obs     weather.Observation
+		wantNil bool
+	}{
+		{
+			name: "all inputs present",
+			obs:  weather.Observation{TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+		},
+		{
+			name:    "humidity missing",
+			obs:     weather.Observation{TempAir: f(20.5), Pressure: f(1013)},
+			wantNil: true,
+		},
+		{
+			name:    "temp missing",
+			obs:     weather.Observation{Humidity: f(55), Pressure: f(1013)},
+			wantNil: true,
+		},
+		{
+			name:    "pressure missing",
+			obs:     weather.Observation{TempAir: f(20.5), Humidity: f(55)},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wetBulb(tt.obs)
+			if tt.wantNil && got != nil {
+				t.Errorf("wetBulb = %v, want nil", *got)
+			}
+			if !tt.wantNil {
+				if got == nil {
+					t.Fatal("wetBulb = nil, want a value")
+				}
+				if *got <= 0 || *got >= 20.5 {
+					t.Errorf("wetBulb = %v, want a plausible value below dry-bulb 20.5", *got)
+				}
+			}
+		})
+	}
+}
+
+// --- integration: requires a live Postgres ---
+//
+// Everything above is a pure unit test. The SQL below is the ONLY thing that
+// exercises this file's actual queries, and the Postgres dialect differs from
+// SQLite's in ways that can fail at runtime and nowhere else:
+//
+//   - EXTRACT(EPOCH FROM (ts - prev)) yields numeric in PG14+, compared here
+//     against a float64 parameter.
+//   - MIN/MAX over timestamptz scanned into time.Time.
+//   - precip_type is INTEGER in the DDL (schema.go:55) while the bind is a
+//     *float64 — pgx truncates silently rather than erroring.
+//
+// Follow the existing skip idiom in writer_integration_test.go. This must be
+// RUN AT LEAST ONCE against a real database before the branch merges; a run
+// where it skips is not evidence.
+func TestBackfillPostgresIntegration(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("POSTGRES_URL not set; skipping Postgres integration test")
+	}
+
+	ctx := t.Context()
+	pool, err := OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("OpenPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := CreateSchema(ctx, pool); err != nil {
+		t.Fatalf("CreateSchema: %v", err)
+	}
+
+	// Isolate this run from anything already in the table.
+	serialA := "ST-ITEST-A"
+	serialB := "ST-ITEST-B"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB)
+	})
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB); err != nil {
+		t.Fatalf("pre-clean: %v", err)
+	}
+
+	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC) // far from real data
+
+	// The same interleaved fixture the SQLite suite uses: ST-A has a one-hour
+	// hole; ST-B reports throughout, offset, and would mask it if the query
+	// were not partitioned.
+	var seed []weather.Observation
+	for _, off := range []time.Duration{0, time.Hour, 90 * time.Minute} {
+		seed = append(seed, weather.Observation{
+			SerialNumber: serialA,
+			Timestamp:    base.Add(off),
+			TempAir:      f(20),
+			// These four map to INTEGER columns (schema.go:55 and siblings)
+			// while the bind is a *float64 — the exact hazard named at the
+			// top of this task. Seeding them is what makes the integration
+			// test exercise the risk it was written for; pgx truncates a
+			// float into int4 silently, so only a real round-trip catches it.
+			PrecipType:           f(1),
+			WindSampleInterval:   f(3),
+			LightningStrikeCount: f(0),
+			ReportInterval:       f(1),
+		})
+	}
+	for off := 30 * time.Second; off <= 95*time.Minute; off += 10 * time.Minute {
+		seed = append(seed, weather.Observation{SerialNumber: serialB, Timestamp: base.Add(off), TempAir: f(21)})
+	}
+
+	n, err := InsertObservations(ctx, pool, seed)
+	if err != nil {
+		t.Fatalf("InsertObservations: %v", err)
+	}
+	if n != len(seed) {
+		t.Errorf("inserted %d rows, want %d", n, len(seed))
+	}
+
+	// Idempotency: the same batch again must insert nothing.
+	again, err := InsertObservations(ctx, pool, seed)
+	if err != nil {
+		t.Fatalf("second InsertObservations: %v", err)
+	}
+	if again != 0 {
+		t.Errorf("re-insert added %d rows, want 0", again)
+	}
+
+	from, to := base.Add(-time.Hour), base.Add(3*time.Hour)
+
+	serials, err := DistinctSerials(ctx, pool)
+	if err != nil {
+		t.Fatalf("DistinctSerials: %v", err)
+	}
+	if !slices.Contains(serials, serialA) || !slices.Contains(serials, serialB) {
+		t.Errorf("DistinctSerials = %v, want it to contain %s and %s", serials, serialA, serialB)
+	}
+
+	bounds, err := SeriesBounds(ctx, pool, from, to)
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	var gotA bool
+	for _, b := range bounds {
+		if b.SerialNumber == serialA {
+			gotA = true
+			if !b.First.Equal(base) {
+				t.Errorf("%s First = %v, want %v", serialA, b.First, base)
+			}
+		}
+	}
+	if !gotA {
+		t.Errorf("SeriesBounds missing %s: %+v", serialA, bounds)
+	}
+
+	// Round-trip the INTEGER-typed columns: this is the named hazard.
+	var precip, interval, strikes, report *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT precip_type, wind_sample_interval, lightning_strike_count, report_interval
+		 FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serialA, base).Scan(&precip, &interval, &strikes, &report); err != nil {
+		t.Fatalf("read back INTEGER columns: %v", err)
+	}
+	for _, c := range []struct {
+		name string
+		got  *int64
+		want int64
+	}{
+		{"precip_type", precip, 1},
+		{"wind_sample_interval", interval, 3},
+		{"lightning_strike_count", strikes, 0},
+		{"report_interval", report, 1},
+	} {
+		if c.got == nil {
+			t.Errorf("%s is NULL, want %d", c.name, c.want)
+			continue
+		}
+		if *c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, *c.got, c.want)
+		}
+	}
+
+	gaps, err := FindObservationGaps(ctx, pool, from, to, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	var found bool
+	for _, g := range gaps {
+		if g.SerialNumber == serialA && g.From.Equal(base) && g.To.Equal(base.Add(time.Hour)) {
+			found = true
+		}
+		if g.SerialNumber == serialB {
+			t.Errorf("unexpected gap for %s: %+v", serialB, g)
+		}
+	}
+	if !found {
+		t.Errorf("did not find the %s hole [%v, %v]; got %+v", serialA, base, base.Add(time.Hour), gaps)
+	}
+}

--- a/internal/postgres/backfill_test.go
+++ b/internal/postgres/backfill_test.go
@@ -105,12 +105,13 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	serialA := "ST-ITEST-A"
 	serialB := "ST-ITEST-B"
 	serialC := "ST-ITEST-C" // isolated: exercises the full derive-and-store wetbulb path only
+	serialD := "ST-ITEST-D" // isolated: exercises the full 18-column bind order, one distinct value per field
 	t.Cleanup(func() {
 		_, _ = pool.Exec(context.Background(),
-			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3)`, serialA, serialB, serialC)
+			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3, $4)`, serialA, serialB, serialC, serialD)
 	})
 	if _, err := pool.Exec(ctx,
-		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3)`, serialA, serialB, serialC); err != nil {
+		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3, $4)`, serialA, serialB, serialC, serialD); err != nil {
 		t.Fatalf("pre-clean: %v", err)
 	}
 
@@ -152,6 +153,35 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 		TempAir:      f(20.5),
 		Humidity:     f(55),
 		Pressure:     f(1013),
+	})
+	// serialD carries a DISTINCT, unambiguous value in every one of the 18
+	// bound columns (17 direct fields + the derived temp_wetbulb), so a
+	// transposition of any two adjacent binds in InsertObservations (e.g.
+	// WindAvg <-> WindGust) changes an observable column value and fails the
+	// round-trip assertion below by name, instead of leaving every other
+	// assertion in this test green. This mirrors the SQLite twin's
+	// TestInsertObservationsRoundTripsAllColumns, which the Postgres side
+	// lacked until now (only 7 of 18 columns were ever read back).
+	seed = append(seed, weather.Observation{
+		SerialNumber:         serialD,
+		Timestamp:            base,
+		WindLull:             f(21.1),
+		WindAvg:              f(22.2),
+		WindGust:             f(23.3),
+		WindDirection:        f(24.4),
+		WindSampleInterval:   f(25),
+		Pressure:             f(26.6),
+		TempAir:              f(27.7),
+		Humidity:             f(28.8),
+		Illuminance:          f(29.9),
+		UVIndex:              f(30.1),
+		Irradiance:           f(31.1),
+		RainRate:             f(32.2),
+		PrecipType:           f(33), // the sole INTEGER column (schema.go:55)
+		LightningDistance:    f(34.4),
+		LightningStrikeCount: f(35),
+		Battery:              f(36.6),
+		ReportInterval:       f(37),
 	})
 
 	// Partial-conflict coverage (the real repair-run shape): insert a prefix
@@ -276,6 +306,94 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	}
 	if *wetbulbC <= 0 || *wetbulbC >= 20.5 {
 		t.Errorf("%s temp_wetbulb = %v, want a plausible value below dry-bulb 20.5", serialC, *wetbulbC)
+	}
+
+	// Full 18-column round-trip: serialD carries a distinct value in every
+	// bound field, selected here by name — never positionally — to pin the
+	// complete bind order in InsertObservations. A transposition of ANY two
+	// binds (not just the 7 previously checked) fails this by name.
+	var (
+		windLull, windAvg, windGust, windDirection *float64
+		windSampleInterval                         *int64
+		pressureD, tempAirD                        *float64
+		tempWetbulbD                               *float64
+		humidityD                                  *float64
+		illuminance, uvIndex, irradiance, rainRate *float64
+		precipTypeD                                *int64
+		lightningDistance                          *float64
+		lightningStrikeCount                       *int64
+		batteryD                                   *float64
+		reportIntervalD                            *int64
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
+		        pressure, temp_air, temp_wetbulb, humidity,
+		        illuminance, uv_index, irradiance, rain_rate, precip_type,
+		        lightning_distance, lightning_strike_count, battery, report_interval
+		 FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serialD, base).Scan(
+		&windLull, &windAvg, &windGust, &windDirection, &windSampleInterval,
+		&pressureD, &tempAirD, &tempWetbulbD, &humidityD,
+		&illuminance, &uvIndex, &irradiance, &rainRate, &precipTypeD,
+		&lightningDistance, &lightningStrikeCount, &batteryD, &reportIntervalD,
+	); err != nil {
+		t.Fatalf("read back %s observation columns: %v", serialD, err)
+	}
+
+	floatCases := []struct {
+		column string
+		got    *float64
+		want   float64
+	}{
+		{"wind_lull", windLull, 21.1},
+		{"wind_avg", windAvg, 22.2},
+		{"wind_gust", windGust, 23.3},
+		{"wind_direction", windDirection, 24.4},
+		{"pressure", pressureD, 26.6},
+		{"temp_air", tempAirD, 27.7},
+		{"humidity", humidityD, 28.8},
+		{"illuminance", illuminance, 29.9},
+		{"uv_index", uvIndex, 30.1},
+		{"irradiance", irradiance, 31.1},
+		{"rain_rate", rainRate, 32.2},
+		{"lightning_distance", lightningDistance, 34.4},
+		{"battery", batteryD, 36.6},
+	}
+	for _, c := range floatCases {
+		if c.got == nil {
+			t.Errorf("%s (%s) is NULL, want %v", c.column, serialD, c.want)
+			continue
+		}
+		if *c.got != c.want {
+			t.Errorf("%s (%s) = %v, want %v", c.column, serialD, *c.got, c.want)
+		}
+	}
+
+	intCases := []struct {
+		column string
+		got    *int64
+		want   int64
+	}{
+		{"wind_sample_interval", windSampleInterval, 25},
+		{"precip_type", precipTypeD, 33},
+		{"lightning_strike_count", lightningStrikeCount, 35},
+		{"report_interval", reportIntervalD, 37},
+	}
+	for _, c := range intCases {
+		if c.got == nil {
+			t.Errorf("%s (%s) is NULL, want %d", c.column, serialD, c.want)
+			continue
+		}
+		if *c.got != c.want {
+			t.Errorf("%s (%s) = %d, want %d", c.column, serialD, *c.got, c.want)
+		}
+	}
+
+	if tempWetbulbD == nil {
+		t.Fatalf("%s temp_wetbulb is NULL, want a derived value (temp/humidity/pressure all present)", serialD)
+	}
+	if *tempWetbulbD <= 0 || *tempWetbulbD >= 27.7 {
+		t.Errorf("%s temp_wetbulb = %v, want a plausible value below dry-bulb 27.7", serialD, *tempWetbulbD)
 	}
 
 	gaps, err := FindObservationGaps(ctx, pool, from, to, 30*time.Minute)

--- a/internal/postgres/backfill_test.go
+++ b/internal/postgres/backfill_test.go
@@ -56,6 +56,20 @@ func TestBackfillWetBulbDerivation(t *testing.T) {
 	}
 }
 
+// TestInsertObservationsEmptyInput pins the len(obs) == 0 early return in
+// InsertObservations: it must report (0, nil) without ever touching pool, so
+// this needs no live database and must not sit behind the POSTGRES_URL skip
+// guard below.
+func TestInsertObservationsEmptyInput(t *testing.T) {
+	n, err := InsertObservations(t.Context(), nil, nil)
+	if err != nil {
+		t.Fatalf("InsertObservations(nil pool, nil obs) = _, %v, want nil error", err)
+	}
+	if n != 0 {
+		t.Errorf("InsertObservations(nil pool, nil obs) = %d, want 0", n)
+	}
+}
+
 // --- integration: requires a live Postgres ---
 //
 // Everything above is a pure unit test. The SQL below is the ONLY thing that
@@ -90,12 +104,13 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	// Isolate this run from anything already in the table.
 	serialA := "ST-ITEST-A"
 	serialB := "ST-ITEST-B"
+	serialC := "ST-ITEST-C" // isolated: exercises the full derive-and-store wetbulb path only
 	t.Cleanup(func() {
 		_, _ = pool.Exec(context.Background(),
-			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB)
+			`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3)`, serialA, serialB, serialC)
 	})
 	if _, err := pool.Exec(ctx,
-		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2)`, serialA, serialB); err != nil {
+		`DELETE FROM tempest_observations WHERE serial_number IN ($1, $2, $3)`, serialA, serialB, serialC); err != nil {
 		t.Fatalf("pre-clean: %v", err)
 	}
 
@@ -110,11 +125,15 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 			SerialNumber: serialA,
 			Timestamp:    base.Add(off),
 			TempAir:      f(20),
-			// These four map to INTEGER columns (schema.go:55 and siblings)
-			// while the bind is a *float64 — the exact hazard named at the
-			// top of this task. Seeding them is what makes the integration
-			// test exercise the risk it was written for; pgx truncates a
-			// float into int4 silently, so only a real round-trip catches it.
+			// precip_type is the sole INTEGER column among these four
+			// (schema.go:55) while the bind is a *float64 — the exact
+			// truncation hazard named at the top of this file's comment
+			// block; pgx truncates a float into int4 silently, so only a
+			// real round-trip catches it. wind_sample_interval,
+			// lightning_strike_count, and report_interval are DOUBLE
+			// PRECISION (schema.go:43,58,61); seeding them here is a
+			// float8 round-trip fidelity check, not an INTEGER hazard
+			// check.
 			PrecipType:           f(1),
 			WindSampleInterval:   f(3),
 			LightningStrikeCount: f(0),
@@ -124,13 +143,39 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 	for off := 30 * time.Second; off <= 95*time.Minute; off += 10 * time.Minute {
 		seed = append(seed, weather.Observation{SerialNumber: serialB, Timestamp: base.Add(off), TempAir: f(21)})
 	}
+	// serialC has all three wetBulb inputs present, closing the
+	// derive-and-store path end to end: nothing else in this fixture proves
+	// temp_wetbulb is ever non-NULL.
+	seed = append(seed, weather.Observation{
+		SerialNumber: serialC,
+		Timestamp:    base,
+		TempAir:      f(20.5),
+		Humidity:     f(55),
+		Pressure:     f(1013),
+	})
+
+	// Partial-conflict coverage (the real repair-run shape): insert a prefix
+	// of the seed first, then the full seed, and confirm the second call
+	// reports exactly the rows that were genuinely new. prefix spans all of
+	// ST-A plus the first two ST-B rows, so the overlap crosses both series,
+	// not just one.
+	prefix := seed[:5]
+	prefixInserted, err := InsertObservations(ctx, pool, prefix)
+	if err != nil {
+		t.Fatalf("InsertObservations(prefix): %v", err)
+	}
+	if prefixInserted != len(prefix) {
+		t.Errorf("inserted %d prefix rows, want %d", prefixInserted, len(prefix))
+	}
 
 	n, err := InsertObservations(ctx, pool, seed)
 	if err != nil {
 		t.Fatalf("InsertObservations: %v", err)
 	}
-	if n != len(seed) {
-		t.Errorf("inserted %d rows, want %d", n, len(seed))
+	wantNew := len(seed) - len(prefix)
+	if n != wantNew {
+		t.Errorf("inserted %d rows on partial-conflict batch, want %d (len(seed)=%d, prefix already present=%d)",
+			n, wantNew, len(seed), len(prefix))
 	}
 
 	// Idempotency: the same batch again must insert nothing.
@@ -169,13 +214,22 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 		t.Errorf("SeriesBounds missing %s: %+v", serialA, bounds)
 	}
 
-	// Round-trip the INTEGER-typed columns: this is the named hazard.
+	// Round-trip precip_type (the sole INTEGER column here — schema.go:55)
+	// alongside the three DOUBLE PRECISION columns (wind_sample_interval,
+	// lightning_strike_count, report_interval) for float8 fidelity, plus
+	// temp_air/pressure/temp_wetbulb — selected by name, never positionally
+	// — to pin the full 21-argument bind order in InsertObservations. A
+	// transposition of two adjacent binds (e.g. Pressure <-> TempAir) would
+	// otherwise pass every other assertion in this test while writing the
+	// wrong value into the wrong column.
 	var precip, interval, strikes, report *int64
+	var tempAir, pressure, tempWetbulb *float64
 	if err := pool.QueryRow(ctx,
-		`SELECT precip_type, wind_sample_interval, lightning_strike_count, report_interval
+		`SELECT precip_type, wind_sample_interval, lightning_strike_count, report_interval,
+		        temp_air, pressure, temp_wetbulb
 		 FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
-		serialA, base).Scan(&precip, &interval, &strikes, &report); err != nil {
-		t.Fatalf("read back INTEGER columns: %v", err)
+		serialA, base).Scan(&precip, &interval, &strikes, &report, &tempAir, &pressure, &tempWetbulb); err != nil {
+		t.Fatalf("read back observation columns: %v", err)
 	}
 	for _, c := range []struct {
 		name string
@@ -194,6 +248,34 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 		if *c.got != c.want {
 			t.Errorf("%s = %d, want %d", c.name, *c.got, c.want)
 		}
+	}
+	if tempAir == nil {
+		t.Errorf("%s temp_air is NULL, want the seeded value 20", serialA)
+	} else if *tempAir != 20 {
+		t.Errorf("%s temp_air = %v, want 20 (the seeded value)", serialA, *tempAir)
+	}
+	if pressure != nil {
+		t.Errorf("%s pressure = %v, want NULL (the ST-A fixture sets no pressure)", serialA, *pressure)
+	}
+	if tempWetbulb != nil {
+		t.Errorf("%s temp_wetbulb = %v, want NULL (pressure and humidity are both absent, so wetBulb must return nil)",
+			serialA, *tempWetbulb)
+	}
+
+	// serialC has all three wetBulb inputs, so this closes the
+	// derive-and-store path end to end: nothing else in this fixture proves
+	// InsertObservations ever writes a non-NULL temp_wetbulb.
+	var wetbulbC *float64
+	if err := pool.QueryRow(ctx,
+		`SELECT temp_wetbulb FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serialC, base).Scan(&wetbulbC); err != nil {
+		t.Fatalf("read back %s temp_wetbulb: %v", serialC, err)
+	}
+	if wetbulbC == nil {
+		t.Fatalf("%s temp_wetbulb is NULL, want a derived value (temp/humidity/pressure all present)", serialC)
+	}
+	if *wetbulbC <= 0 || *wetbulbC >= 20.5 {
+		t.Errorf("%s temp_wetbulb = %v, want a plausible value below dry-bulb 20.5", serialC, *wetbulbC)
 	}
 
 	gaps, err := FindObservationGaps(ctx, pool, from, to, 30*time.Minute)

--- a/internal/postgres/pool.go
+++ b/internal/postgres/pool.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// poolConfig is the single authoritative representation of this application's
+// pgx pool tuning. Both NewPostgresWriter (the long-running daemon writer) and
+// OpenPool (one-shot tools such as backfill) build from it, so a change to any
+// value applies to both — which is exactly the shared-knowledge test that
+// justifies extracting it rather than copying five lines.
+func poolConfig(databaseURL string) (*pgxpool.Config, error) {
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse database url: %w", err)
+	}
+	config.MaxConns = 10
+	config.MinConns = 2
+	config.MaxConnLifetime = time.Hour
+	config.MaxConnIdleTime = 10 * time.Minute
+	config.HealthCheckPeriod = 30 * time.Second
+	return config, nil
+}
+
+// OpenPool opens and verifies a connection pool.
+//
+// It starts no goroutines and does NOT create the schema — unlike
+// NewPostgresWriter, which additionally runs CreateSchema and launches four
+// background batch workers. A one-shot tool needs the pool without any of
+// that, and calls CreateSchema explicitly so schema creation stays an
+// observable step of the caller rather than a side effect of opening a pool.
+//
+// The caller owns the returned pool and must Close it.
+func OpenPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
+	config, err := poolConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("create connection pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+	return pool, nil
+}

--- a/internal/postgres/pool.go
+++ b/internal/postgres/pool.go
@@ -28,11 +28,15 @@ func poolConfig(databaseURL string) (*pgxpool.Config, error) {
 
 // OpenPool opens and verifies a connection pool.
 //
-// It starts no goroutines and does NOT create the schema — unlike
-// NewPostgresWriter, which additionally runs CreateSchema and launches four
-// background batch workers. A one-shot tool needs the pool without any of
-// that, and calls CreateSchema explicitly so schema creation stays an
-// observable step of the caller rather than a side effect of opening a pool.
+// It does NOT create the schema and starts no batch-worker goroutines —
+// unlike NewPostgresWriter, which additionally runs CreateSchema and launches
+// four background batch workers. (pgxpool.NewWithConfig itself starts its own
+// internal goroutine for idle-connection maintenance and health checks,
+// regardless of caller; that is pgx's concern, not this function's, and is
+// not the goroutine count this comment is contrasting.) A one-shot tool needs
+// the pool without CreateSchema or the batch workers, and calls CreateSchema
+// explicitly so schema creation stays an observable step of the caller rather
+// than a side effect of opening a pool.
 //
 // The caller owns the returned pool and must Close it.
 func OpenPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {

--- a/internal/postgres/pool_test.go
+++ b/internal/postgres/pool_test.go
@@ -1,0 +1,44 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// OpenPool must reject a malformed URL before it attempts any connection, so
+// a bad POSTGRES_URL fails fast with a useful message rather than hanging.
+func TestOpenPoolRejectsBadURL(t *testing.T) {
+	pool, err := OpenPool(t.Context(), "://not-a-url")
+	if err == nil {
+		pool.Close()
+		t.Fatal("OpenPool accepted a malformed URL")
+	}
+	if !strings.Contains(err.Error(), "parse database url") {
+		t.Errorf("error = %q, want it to mention parse database url", err)
+	}
+}
+
+// The pool tuning is a shared contract between OpenPool and
+// NewPostgresWriter. This pins the values so a change has to be deliberate.
+func TestPoolConfigValues(t *testing.T) {
+	cfg, err := poolConfig("postgres://u:p@localhost:5432/db")
+	if err != nil {
+		t.Fatalf("poolConfig: %v", err)
+	}
+	if cfg.MaxConns != 10 {
+		t.Errorf("MaxConns = %d, want 10", cfg.MaxConns)
+	}
+	if cfg.MinConns != 2 {
+		t.Errorf("MinConns = %d, want 2", cfg.MinConns)
+	}
+	if cfg.MaxConnLifetime != time.Hour {
+		t.Errorf("MaxConnLifetime = %v, want 1h", cfg.MaxConnLifetime)
+	}
+	if cfg.MaxConnIdleTime != 10*time.Minute {
+		t.Errorf("MaxConnIdleTime = %v, want 10m", cfg.MaxConnIdleTime)
+	}
+	if cfg.HealthCheckPeriod != 30*time.Second {
+		t.Errorf("HealthCheckPeriod = %v, want 30s", cfg.HealthCheckPeriod)
+	}
+}

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -214,6 +214,25 @@ func (w *PostgresWriter) flushObservations(ctx context.Context, batch []observat
 	}, "tempest_observations", len(batch))
 }
 
+// insertObservationSQL is the single source of truth for the
+// tempest_observations INSERT shape — the live daemon write path
+// (insertObservations below) and the backfill path
+// (InsertObservations in backfill.go) both bind against this constant.
+// Add a column here and both write paths pick it up together; a second,
+// independently-maintained copy is exactly how backfilled and live rows
+// would silently diverge.
+const insertObservationSQL = `
+	INSERT INTO tempest_observations (
+		id, serial_number, timestamp,
+		wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
+		pressure, temp_air, temp_wetbulb, humidity,
+		illuminance, uv_index, irradiance, rain_rate, precip_type,
+		lightning_distance, lightning_strike_count,
+		battery, report_interval
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	ON CONFLICT (serial_number, timestamp) DO NOTHING
+`
+
 func (w *PostgresWriter) insertObservations(ctx context.Context, batch []observationRow) error {
 	if len(batch) == 0 {
 		return nil
@@ -225,17 +244,7 @@ func (w *PostgresWriter) insertObservations(ctx context.Context, batch []observa
 	b := &pgx.Batch{}
 
 	for _, row := range batch {
-		b.Queue(`
-			INSERT INTO tempest_observations (
-				id, serial_number, timestamp,
-				wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
-				pressure, temp_air, temp_wetbulb, humidity,
-				illuminance, uv_index, irradiance, rain_rate, precip_type,
-				lightning_distance, lightning_strike_count,
-				battery, report_interval
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
-			ON CONFLICT (serial_number, timestamp) DO NOTHING
-		`, row.id, row.serialNumber, row.timestamp,
+		b.Queue(insertObservationSQL, row.id, row.serialNumber, row.timestamp,
 			row.windLull, row.windAvg, row.windGust, row.windDirection, row.windSampleInterval,
 			row.pressure, row.tempAir, row.tempWetbulb, row.humidity,
 			row.illuminance, row.uvIndex, row.irradiance, row.rainRate, row.precipType,

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -142,27 +142,9 @@ type PostgresWriter struct {
 
 // NewPostgresWriter creates a new PostgreSQL writer with connection pooling.
 func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter, error) {
-	config, err := pgxpool.ParseConfig(databaseURL)
+	pool, err := OpenPool(ctx, databaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("parse database url: %w", err)
-	}
-
-	// Connection pool configuration
-	config.MaxConns = 10
-	config.MinConns = 2
-	config.MaxConnLifetime = time.Hour
-	config.MaxConnIdleTime = 10 * time.Minute
-	config.HealthCheckPeriod = 30 * time.Second
-
-	pool, err := pgxpool.NewWithConfig(ctx, config)
-	if err != nil {
-		return nil, fmt.Errorf("create connection pool: %w", err)
-	}
-
-	// Verify connection
-	if err := pool.Ping(ctx); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("ping database: %w", err)
+		return nil, err
 	}
 
 	// Auto-create schema

--- a/internal/sqlite/backfill.go
+++ b/internal/sqlite/backfill.go
@@ -1,0 +1,212 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"time"
+
+	"tempestwx-utilities/internal/tempestudp"
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+)
+
+// This file holds the backfill tool's read/write path. Everything here is a
+// package-level function taking *sql.DB, never a method on Writer:
+// Writer.run is documented as "the only goroutine that ever touches db"
+// (writer.go:161,236), so an insert method on that type would breach the
+// single-writer invariant and be callable from the daemon. Nothing here
+// starts a goroutine.
+//
+// IMPORTANT: sqlite.Open sets db.SetMaxOpenConns(1) (db.go:74). Every query
+// below fully materializes its result slice and closes its *sql.Rows before
+// returning. A streaming iterator that yielded rows while the caller inserted
+// would deadlock on the single connection with no error and no timeout. Do
+// not refactor these into iterators.
+
+// findObservationGapsSQL locates interior holes in each station's series.
+//
+// PARTITION BY serial_number is NOT optional. The series is identified by
+// (serial_number, timestamp) — the same uniqueness contract idempotency
+// relies on. Without partitioning, two stations phase-offset by ~30s produce
+// a merged sequence in which no consecutive interval ever exceeds minGap, so
+// a multi-hour outage on one station becomes undetectable and the tool
+// reports "no gaps" and exits 0. The same failure hides a hardware swap
+// (a new serial) behind an apparently continuous sequence.
+const findObservationGapsSQL = `
+	SELECT serial_number, prev, timestamp FROM (
+	  SELECT serial_number,
+	         LAG(timestamp) OVER (PARTITION BY serial_number ORDER BY timestamp) AS prev,
+	         timestamp
+	  FROM tempest_observations
+	  WHERE timestamp BETWEEN ? AND ?
+	) WHERE prev IS NOT NULL AND timestamp - prev > ?
+	ORDER BY serial_number, prev
+`
+
+// FindObservationGaps returns the interior gaps in [from, to] wider than
+// minGap, one per (serial, hole).
+//
+// LAG yields NULL for the first row of each partition, so this finds interior
+// gaps ONLY. Head and tail gaps — and the empty-table case — are assembled by
+// the caller from SeriesBounds; see internal/backfill.
+func FindObservationGaps(ctx context.Context, db *sql.DB, from, to time.Time, minGap time.Duration) ([]weather.Gap, error) {
+	rows, err := db.QueryContext(ctx, findObservationGapsSQL, from.Unix(), to.Unix(), int64(minGap.Seconds()))
+	if err != nil {
+		return nil, fmt.Errorf("query observation gaps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var gaps []weather.Gap
+	for rows.Next() {
+		var serial string
+		var prev, next int64
+		if err := rows.Scan(&serial, &prev, &next); err != nil {
+			return nil, fmt.Errorf("scan observation gap: %w", err)
+		}
+		gaps = append(gaps, weather.Gap{
+			SerialNumber: serial,
+			From:         time.Unix(prev, 0).UTC(),
+			To:           time.Unix(next, 0).UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate observation gaps: %w", err)
+	}
+	return gaps, nil
+}
+
+const seriesBoundsSQL = `
+	SELECT serial_number, MIN(timestamp), MAX(timestamp)
+	FROM tempest_observations
+	WHERE timestamp BETWEEN ? AND ?
+	GROUP BY serial_number
+	ORDER BY serial_number
+`
+
+// SeriesBounds returns the first and last observation timestamp held for each
+// serial within [from, to]. An empty result means the store holds nothing in
+// that window — the first-run case, where the whole range is one gap.
+func SeriesBounds(ctx context.Context, db *sql.DB, from, to time.Time) ([]weather.Bounds, error) {
+	rows, err := db.QueryContext(ctx, seriesBoundsSQL, from.Unix(), to.Unix())
+	if err != nil {
+		return nil, fmt.Errorf("query series bounds: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []weather.Bounds
+	for rows.Next() {
+		var serial string
+		var first, last int64
+		if err := rows.Scan(&serial, &first, &last); err != nil {
+			return nil, fmt.Errorf("scan series bounds: %w", err)
+		}
+		out = append(out, weather.Bounds{
+			SerialNumber: serial,
+			First:        time.Unix(first, 0).UTC(),
+			Last:         time.Unix(last, 0).UTC(),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate series bounds: %w", err)
+	}
+	return out, nil
+}
+
+// DistinctSerials returns every serial the table has ever held.
+//
+// UNWINDOWED, deliberately. This is the pre-flight check's input, and it must
+// NOT be replaced by SeriesBounds' key set: SeriesBounds is windowed, so a
+// station that was simply quiet during the queried window would look absent
+// from the store entirely and trip a false serial mismatch — breaking
+// `backfill --from X --to Y`, which is the tool's main repair path.
+func DistinctSerials(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT DISTINCT serial_number FROM tempest_observations ORDER BY serial_number`)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct serials: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []string
+	for rows.Next() {
+		var serial string
+		if err := rows.Scan(&serial); err != nil {
+			return nil, fmt.Errorf("scan distinct serial: %w", err)
+		}
+		out = append(out, serial)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate distinct serials: %w", err)
+	}
+	return out, nil
+}
+
+// InsertObservations writes obs idempotently and reports how many rows were
+// actually new.
+//
+// The count is what makes the permanent-hole tradeoff visible: if the station
+// was genuinely offline, the API has no data either, and inserted stays 0
+// across runs. ON CONFLICT (serial_number, timestamp) DO NOTHING is backed by
+// a real UNIQUE constraint (migrations/0001_init.sql:13), and per-row
+// RowsAffected returns 0 for a skipped conflict and 1 for an insert.
+//
+// The count is returned only after a successful Commit — execBatch rolls the
+// whole transaction back on any row error.
+//
+// The caller bounds len(obs) to keep the transaction short; see the design's
+// "Concurrency with a running daemon".
+//
+// Binding is direct from weather.Observation rather than through the private
+// observationRow used by the UDP path: that type's leading fields are
+// non-pointer float64, so routing through it would coerce a JSON null to 0.0.
+func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observation) (int, error) {
+	if len(obs) == 0 {
+		return 0, nil
+	}
+
+	inserted := 0
+	err := execBatch(ctx, db, insertObservationSQL, obs, func(stmt *sql.Stmt, o weather.Observation) error {
+		res, err := stmt.ExecContext(ctx,
+			uuid.Must(uuid.NewV7()).String(), o.SerialNumber, o.Timestamp.Unix(),
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		inserted += int(n)
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return inserted, nil
+}
+
+// wetBulb derives temp_wetbulb, which the REST API does not return.
+//
+// It uses the same tempestudp.WetBulbTemperatureC + math.IsNaN guard the UDP
+// ingest path uses (writer.go:410,432-434), single-sourced, so backfilled and
+// live rows are indistinguishable. Change the formula and both paths change
+// together: shared knowledge, not shared shape.
+//
+// Any missing input yields NULL rather than a value computed from a zero —
+// the same reason the decode preserves nulls in the first place.
+func wetBulb(o weather.Observation) *float64 {
+	if o.TempAir == nil || o.Humidity == nil || o.Pressure == nil {
+		return nil
+	}
+	v := tempestudp.WetBulbTemperatureC(*o.TempAir, *o.Humidity, *o.Pressure)
+	if math.IsNaN(v) {
+		return nil
+	}
+	return &v
+}

--- a/internal/sqlite/backfill.go
+++ b/internal/sqlite/backfill.go
@@ -170,11 +170,11 @@ func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observati
 	err := execBatch(ctx, db, insertObservationSQL, obs, func(stmt *sql.Stmt, o weather.Observation) error {
 		res, err := stmt.ExecContext(ctx,
 			uuid.Must(uuid.NewV7()).String(), o.SerialNumber, o.Timestamp.Unix(),
-			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, asInt64(o.WindSampleInterval),
 			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
-			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
-			o.LightningDistance, o.LightningStrikeCount,
-			o.Battery, o.ReportInterval)
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asInt64(o.PrecipType),
+			o.LightningDistance, asInt64(o.LightningStrikeCount),
+			o.Battery, asInt64(o.ReportInterval))
 		if err != nil {
 			return err
 		}
@@ -189,6 +189,22 @@ func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observati
 		return 0, err
 	}
 	return inserted, nil
+}
+
+// asInt64 converts a possibly-nil *float64 into a possibly-nil *int64,
+// matching how the UDP path stores wind_sample_interval, precip_type,
+// lightning_strike_count, and report_interval (writer.go:436-457, fix
+// B-LOW): the SQLite DDL declares these columns INTEGER, and the read model
+// scans them into *int64. Binding one of these fields as *float64 with a
+// fractional value stores it with REAL affinity, which then fails a *int64
+// scan for the whole row. int64(...) truncation, not rounding, mirrors the
+// UDP path exactly. Nil maps to SQL NULL.
+func asInt64(p *float64) *int64 {
+	if p == nil {
+		return nil
+	}
+	v := int64(*p)
+	return &v
 }
 
 // wetBulb derives temp_wetbulb, which the REST API does not return.

--- a/internal/sqlite/backfill_test.go
+++ b/internal/sqlite/backfill_test.go
@@ -237,3 +237,140 @@ func TestInsertObservationsEmptyIsNoop(t *testing.T) {
 		t.Errorf("n = %d, want 0", n)
 	}
 }
+
+// TestInsertObservationsRoundTripsAllColumns pins the 21-argument bind order
+// in InsertObservations against insertObservationSQL (writer.go). Every
+// measurement field carries a distinct, unambiguous value so a transposition
+// of any two bind arguments (e.g. WindAvg <-> WindGust) changes an observable
+// column value and fails this test by name, rather than leaving the whole
+// suite green.
+//
+// wind_sample_interval, precip_type, lightning_strike_count, and
+// report_interval are declared INTEGER in migrations/0001_init.sql, so this
+// test keeps those four fields integral. That is a deliberate accommodation
+// of the deferred *float64-into-INTEGER-column finding, not a claim that the
+// finding is resolved — SQLite's column affinity converts an integral REAL
+// bind to INTEGER storage losslessly, so using integral values here avoids
+// dragging that out-of-scope issue into this test.
+func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
+	db := newTestDB(t)
+	o := weather.Observation{
+		SerialNumber:         "ST-A",
+		Timestamp:            ts(1000),
+		WindLull:             f(1.5),
+		WindAvg:              f(3.5),
+		WindGust:             f(6.5),
+		WindDirection:        f(180),
+		WindSampleInterval:   f(3), // INTEGER column: kept integral
+		Pressure:             f(1013.25),
+		TempAir:              f(22.5),
+		Humidity:             f(65),
+		Illuminance:          f(15000),
+		UVIndex:              f(4.5),
+		Irradiance:           f(600),
+		RainRate:             f(0.5),
+		PrecipType:           f(1), // INTEGER column: kept integral
+		LightningDistance:    f(12.5),
+		LightningStrikeCount: f(2), // INTEGER column: kept integral
+		Battery:              f(2.85),
+		ReportInterval:       f(5), // INTEGER column: kept integral
+	}
+
+	if _, err := InsertObservations(t.Context(), db, []weather.Observation{o}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var (
+		windLull, windAvg, windGust, windDirection, windSampleInterval sql.NullFloat64
+		pressure, tempAir, tempWetbulb, humidity                       sql.NullFloat64
+		illuminance, uvIndex, irradiance, rainRate, precipType         sql.NullFloat64
+		lightningDistance, lightningStrikeCount, battery               sql.NullFloat64
+		reportInterval                                                 sql.NullFloat64
+	)
+	row := db.QueryRowContext(t.Context(), `
+		SELECT wind_lull, wind_avg, wind_gust, wind_direction, wind_sample_interval,
+		       pressure, temp_air, temp_wetbulb, humidity,
+		       illuminance, uv_index, irradiance, rain_rate, precip_type,
+		       lightning_distance, lightning_strike_count,
+		       battery, report_interval
+		FROM tempest_observations WHERE serial_number = ? AND timestamp = ?`,
+		o.SerialNumber, o.Timestamp.Unix())
+	if err := row.Scan(
+		&windLull, &windAvg, &windGust, &windDirection, &windSampleInterval,
+		&pressure, &tempAir, &tempWetbulb, &humidity,
+		&illuminance, &uvIndex, &irradiance, &rainRate, &precipType,
+		&lightningDistance, &lightningStrikeCount,
+		&battery, &reportInterval,
+	); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	cases := []struct {
+		column string
+		got    sql.NullFloat64
+		want   float64
+	}{
+		{"wind_lull", windLull, 1.5},
+		{"wind_avg", windAvg, 3.5},
+		{"wind_gust", windGust, 6.5},
+		{"wind_direction", windDirection, 180},
+		{"wind_sample_interval", windSampleInterval, 3},
+		{"pressure", pressure, 1013.25},
+		{"temp_air", tempAir, 22.5},
+		{"humidity", humidity, 65},
+		{"illuminance", illuminance, 15000},
+		{"uv_index", uvIndex, 4.5},
+		{"irradiance", irradiance, 600},
+		{"rain_rate", rainRate, 0.5},
+		{"precip_type", precipType, 1},
+		{"lightning_distance", lightningDistance, 12.5},
+		{"lightning_strike_count", lightningStrikeCount, 2},
+		{"battery", battery, 2.85},
+		{"report_interval", reportInterval, 5},
+	}
+	for _, c := range cases {
+		if !c.got.Valid {
+			t.Errorf("%s = NULL, want %v", c.column, c.want)
+			continue
+		}
+		if c.got.Float64 != c.want {
+			t.Errorf("%s = %v, want %v", c.column, c.got.Float64, c.want)
+		}
+	}
+
+	// temp_wetbulb is derived, not bound from the struct, so assert
+	// plausibility rather than equality with an input.
+	if !tempWetbulb.Valid {
+		t.Fatal("temp_wetbulb is NULL; it must be derived at the store boundary")
+	}
+	if tempWetbulb.Float64 <= 0 || tempWetbulb.Float64 > 22.5 {
+		t.Errorf("temp_wetbulb = %v, want a plausible value in (0, 22.5] for dry-bulb 22.5", tempWetbulb.Float64)
+	}
+}
+
+// TestFindObservationGapsRespectsWindow pins the WHERE timestamp BETWEEN ? AND ?
+// predicate in findObservationGapsSQL. ST-C's rows sit well outside the
+// queried window with a hole wide enough to qualify as a gap if the window
+// predicate did not exclude them; ST-D has a genuine in-window hole. If the
+// window predicate were removed, ST-C's rows would participate in the query
+// (and, if the argument list still matched, would surface an extra gap
+// outside the requested range) rather than being excluded entirely.
+func TestFindObservationGapsRespectsWindow(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-D", 1000, 5000)   // in-window hole: 4000s > 30min
+	seedObs(t, db, "ST-C", 50000, 90000) // out-of-window hole: 40000s > 30min
+
+	gaps, err := FindObservationGaps(t.Context(), db, ts(0), ts(10000), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	if len(gaps) != 1 {
+		t.Fatalf("got %d gaps, want 1 (ST-C's out-of-window hole must not appear): %+v", len(gaps), gaps)
+	}
+	if gaps[0].SerialNumber != "ST-D" {
+		t.Errorf("SerialNumber = %q, want ST-D", gaps[0].SerialNumber)
+	}
+	if !gaps[0].From.Equal(ts(1000)) || !gaps[0].To.Equal(ts(5000)) {
+		t.Errorf("gap = [%v, %v], want [%v, %v]", gaps[0].From, gaps[0].To, ts(1000), ts(5000))
+	}
+}

--- a/internal/sqlite/backfill_test.go
+++ b/internal/sqlite/backfill_test.go
@@ -1,0 +1,239 @@
+package sqlite
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+
+	"github.com/google/uuid"
+)
+
+// seedObs inserts bare observation rows (serial + timestamp only; every other
+// column is nullable) so gap tests can express a series compactly.
+func seedObs(t *testing.T, db *sql.DB, serial string, epochs ...int64) {
+	t.Helper()
+	for _, e := range epochs {
+		_, err := db.ExecContext(t.Context(),
+			`INSERT INTO tempest_observations (id, serial_number, timestamp) VALUES (?, ?, ?)`,
+			uuid.Must(uuid.NewV7()).String(), serial, e)
+		if err != nil {
+			t.Fatalf("seed %s@%d: %v", serial, e, err)
+		}
+	}
+}
+
+func ts(epoch int64) time.Time { return time.Unix(epoch, 0).UTC() }
+
+// The regression test for the partitioning bug: two serials whose interleaved
+// timestamps mask each other. ST-A has a one-hour hole from 1000 to 4600.
+// ST-B reports throughout, offset by 30s. Merged and unpartitioned, no
+// consecutive interval exceeds minGap and the hole is invisible.
+func TestFindObservationGapsPartitionsBySerial(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 4600, 5200)
+	for e := int64(1030); e <= 5230; e += 600 {
+		seedObs(t, db, "ST-B", e)
+	}
+
+	gaps, err := FindObservationGaps(t.Context(), db, ts(0), ts(10000), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	if len(gaps) != 1 {
+		t.Fatalf("got %d gaps, want 1: %+v", len(gaps), gaps)
+	}
+	if gaps[0].SerialNumber != "ST-A" {
+		t.Errorf("SerialNumber = %q, want ST-A", gaps[0].SerialNumber)
+	}
+	if !gaps[0].From.Equal(ts(1000)) || !gaps[0].To.Equal(ts(4600)) {
+		t.Errorf("gap = [%v, %v], want [%v, %v]", gaps[0].From, gaps[0].To, ts(1000), ts(4600))
+	}
+}
+
+func TestFindObservationGapsIgnoresJitterBelowMinGap(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 1060, 1125, 1180) // ~1min apart
+	gaps, err := FindObservationGaps(t.Context(), db, ts(0), ts(10000), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FindObservationGaps: %v", err)
+	}
+	if len(gaps) != 0 {
+		t.Errorf("got %d gaps, want 0: %+v", len(gaps), gaps)
+	}
+}
+
+func TestSeriesBoundsPerSerial(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 2000, 3000)
+	seedObs(t, db, "ST-B", 5000, 6000)
+
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	got := map[string]weather.Bounds{}
+	for _, b := range bounds {
+		got[b.SerialNumber] = b
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d serials, want 2: %+v", len(got), bounds)
+	}
+	if !got["ST-A"].First.Equal(ts(1000)) || !got["ST-A"].Last.Equal(ts(3000)) {
+		t.Errorf("ST-A bounds = [%v, %v], want [1000, 3000]", got["ST-A"].First, got["ST-A"].Last)
+	}
+	if !got["ST-B"].First.Equal(ts(5000)) || !got["ST-B"].Last.Equal(ts(6000)) {
+		t.Errorf("ST-B bounds = [%v, %v], want [5000, 6000]", got["ST-B"].First, got["ST-B"].Last)
+	}
+}
+
+// DistinctSerials must ignore the window entirely. This is the regression
+// guard for the false-mismatch bug: ST-B's only rows sit outside any window a
+// caller is likely to ask about, but it is still very much in the store.
+func TestDistinctSerialsIsUnwindowed(t *testing.T) {
+	db := newTestDB(t)
+	seedObs(t, db, "ST-A", 1000, 2000)
+	seedObs(t, db, "ST-B", 900000) // far outside a [0, 10000] window
+
+	serials, err := DistinctSerials(t.Context(), db)
+	if err != nil {
+		t.Fatalf("DistinctSerials: %v", err)
+	}
+	if len(serials) != 2 || serials[0] != "ST-A" || serials[1] != "ST-B" {
+		t.Errorf("got %v, want [ST-A ST-B] — the query must not be windowed", serials)
+	}
+
+	// Contrast: the windowed query legitimately does not see ST-B.
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds: %v", err)
+	}
+	if len(bounds) != 1 {
+		t.Errorf("SeriesBounds returned %d serials, want 1 — this is why the two queries cannot be merged", len(bounds))
+	}
+}
+
+func TestDistinctSerialsEmptyTable(t *testing.T) {
+	db := newTestDB(t)
+	serials, err := DistinctSerials(t.Context(), db)
+	if err != nil {
+		t.Fatalf("DistinctSerials on empty table must not error: %v", err)
+	}
+	if len(serials) != 0 {
+		t.Errorf("got %d serials, want 0", len(serials))
+	}
+}
+
+func TestSeriesBoundsEmptyTable(t *testing.T) {
+	db := newTestDB(t)
+	bounds, err := SeriesBounds(t.Context(), db, ts(0), ts(10000))
+	if err != nil {
+		t.Fatalf("SeriesBounds on empty table must not error: %v", err)
+	}
+	if len(bounds) != 0 {
+		t.Errorf("got %d bounds, want 0", len(bounds))
+	}
+}
+
+func f(v float64) *float64 { return &v }
+
+func TestInsertObservationsIsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+		{SerialNumber: "ST-A", Timestamp: ts(1060), TempAir: f(20.6), Humidity: f(56), Pressure: f(1013)},
+	}
+
+	n, err := InsertObservations(t.Context(), db, obs)
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("first insert = %d, want 2", n)
+	}
+
+	n, err = InsertObservations(t.Context(), db, obs)
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second insert = %d, want 0 (ON CONFLICT DO NOTHING)", n)
+	}
+
+	var count int
+	if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM tempest_observations`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("row count = %d, want 2", count)
+	}
+}
+
+func TestInsertObservationsPreservesNull(t *testing.T) {
+	db := newTestDB(t)
+	// Pressure is nil — it must land as SQL NULL, not 0.0.
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var pressure sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT pressure FROM tempest_observations`).Scan(&pressure); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if pressure.Valid {
+		t.Errorf("pressure = %v, want NULL", pressure.Float64)
+	}
+}
+
+func TestInsertObservationsDerivesWetBulb(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Humidity: f(55), Pressure: f(1013)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var wb sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT temp_wetbulb FROM tempest_observations`).Scan(&wb); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !wb.Valid {
+		t.Fatal("temp_wetbulb is NULL; it must be derived at the store boundary")
+	}
+	if wb.Float64 <= 0 || wb.Float64 >= 20.5 {
+		t.Errorf("temp_wetbulb = %v, want a plausible value below dry-bulb 20.5", wb.Float64)
+	}
+}
+
+func TestInsertObservationsWetBulbNullWhenInputsMissing(t *testing.T) {
+	db := newTestDB(t)
+	// No humidity: wet bulb is not derivable and must stay NULL rather than
+	// being computed from a zero value.
+	obs := []weather.Observation{
+		{SerialNumber: "ST-A", Timestamp: ts(1000), TempAir: f(20.5), Pressure: f(1013)},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var wb sql.NullFloat64
+	if err := db.QueryRowContext(t.Context(), `SELECT temp_wetbulb FROM tempest_observations`).Scan(&wb); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if wb.Valid {
+		t.Errorf("temp_wetbulb = %v, want NULL when humidity is absent", wb.Float64)
+	}
+}
+
+func TestInsertObservationsEmptyIsNoop(t *testing.T) {
+	db := newTestDB(t)
+	n, err := InsertObservations(t.Context(), db, nil)
+	if err != nil {
+		t.Fatalf("empty insert: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0", n)
+	}
+}

--- a/internal/sqlite/backfill_test.go
+++ b/internal/sqlite/backfill_test.go
@@ -247,11 +247,10 @@ func TestInsertObservationsEmptyIsNoop(t *testing.T) {
 //
 // wind_sample_interval, precip_type, lightning_strike_count, and
 // report_interval are declared INTEGER in migrations/0001_init.sql, so this
-// test keeps those four fields integral. That is a deliberate accommodation
-// of the deferred *float64-into-INTEGER-column finding, not a claim that the
-// finding is resolved — SQLite's column affinity converts an integral REAL
-// bind to INTEGER storage losslessly, so using integral values here avoids
-// dragging that out-of-scope issue into this test.
+// test keeps those four fields integral — this test's job is pinning bind
+// ORDER, not the *float64-into-INTEGER-column conversion, which is asInt64's
+// job and TestInsertObservationsStoresIntegerColumnsAsIntegers's coverage
+// (a FRACTIONAL value for these four, round-tripped through a *int64 scan).
 func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 	db := newTestDB(t)
 	o := weather.Observation{
@@ -345,6 +344,68 @@ func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 	}
 	if tempWetbulb.Float64 <= 0 || tempWetbulb.Float64 > 22.5 {
 		t.Errorf("temp_wetbulb = %v, want a plausible value in (0, 22.5] for dry-bulb 22.5", tempWetbulb.Float64)
+	}
+}
+
+// TestInsertObservationsStoresIntegerColumnsAsIntegers pins the fix for the
+// *float64-into-INTEGER-column hazard: wind_sample_interval, precip_type,
+// lightning_strike_count, and report_interval are declared INTEGER in
+// migrations/0001_init.sql, and the UDP read model (writer.go, fix B-LOW)
+// scans them into *int64. Binding a *float64 with a FRACTIONAL value stores
+// it with SQLite REAL affinity, which then fails a *int64 scan for the WHOLE
+// ROW it is part of — not just that column. InsertObservations must convert
+// these four fields to an integral bind exactly the way the UDP path does
+// (writer.go handleObservationReport, fix B-LOW: int64(...) truncation)
+// before binding, so a fractional API value is stored — and reads back — as
+// an integer, indistinguishable from a live UDP-ingested row.
+func TestInsertObservationsStoresIntegerColumnsAsIntegers(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{
+			SerialNumber:         "ST-A",
+			Timestamp:            ts(1000),
+			WindSampleInterval:   f(1.5),
+			PrecipType:           f(1.9),
+			LightningStrikeCount: f(2.5),
+			ReportInterval:       f(5.9),
+		},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Scan into *int64 — the read model's declared type for these columns.
+	// This is the exact scan that fails with "converting driver.Value type
+	// float64 (...) to a int64: invalid syntax" when a fractional value was
+	// bound as *float64 instead of converted to *int64 first.
+	var windSampleInterval, precipType, lightningStrikeCount, reportInterval sql.NullInt64
+	row := db.QueryRowContext(t.Context(), `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = ? AND timestamp = ?`,
+		"ST-A", ts(1000).Unix())
+	if err := row.Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval); err != nil {
+		t.Fatalf("scan into *int64 (the read model's declared type): %v", err)
+	}
+
+	cases := []struct {
+		column string
+		got    sql.NullInt64
+		want   int64
+	}{
+		{"wind_sample_interval", windSampleInterval, 1},
+		{"precip_type", precipType, 1},
+		{"lightning_strike_count", lightningStrikeCount, 2},
+		{"report_interval", reportInterval, 5},
+	}
+	for _, c := range cases {
+		if !c.got.Valid {
+			t.Errorf("%s = NULL, want %d", c.column, c.want)
+			continue
+		}
+		if c.got.Int64 != c.want {
+			t.Errorf("%s = %d, want %d (truncated from the fractional API value, matching "+
+				"the UDP path's int64(...) conversion)", c.column, c.got.Int64, c.want)
+		}
 	}
 }
 

--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -50,6 +51,34 @@ func NewClient(token string, opts ...ClientOption) *Client {
 	return c
 }
 
+// get performs an authenticated GET against url and returns the response
+// body. It is the single source for the HTTP transport contract shared by
+// fetchStations, GetObservations, and Observations: set the Bearer auth
+// header, cap the body at 10 MiB, and classify a non-200 response as a
+// *StatusError. Those three call sites used to duplicate this block, and the
+// duplication had already produced an untested copy of the auth header — an
+// edit that deleted it from Observations left the entire suite green. Response
+// decoding stays with each caller; no response type enters this signature.
+func (c *Client) get(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{HTTPStatus: resp.StatusCode}
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+}
+
 type Station struct {
 	Name         string
 	StationID    int
@@ -80,23 +109,7 @@ type stationsResponse struct {
 // fetchStations performs the GET /stations call and validates the status
 // envelope. Behavior is byte-identical to what ListStations did inline.
 func (c *Client) fetchStations(ctx context.Context) (*stationsResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stations", nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, &StatusError{HTTPStatus: resp.StatusCode}
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	body, err := c.get(ctx, c.baseURL+"/stations")
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +147,18 @@ func (c *Client) ListDevices(ctx context.Context) ([]Station, error) {
 		for _, dev := range station.Devices {
 			if dev.DeviceType != "ST" {
 				continue
+			}
+			// A phantom device (zero ID or no serial) is deliberately still
+			// RETURNED, never skipped: the API can answer 200/status_code=0
+			// with an empty obs window for such a device, which is
+			// byte-identical to the permanent-hole signal a real gap
+			// produces. Dropping it here would silently swap "this sensor
+			// doesn't exist" for "this sensor has no gaps" -- so the
+			// assumption is made self-verifying with a WARN instead.
+			if dev.DeviceID == 0 || dev.SerialNumber == "" {
+				slog.Warn("tempestapi: ST device has a malformed identifier",
+					"station", station.Name, "station_id", station.StationID,
+					"device_id", dev.DeviceID, "serial_number", dev.SerialNumber)
 			}
 			out = append(out, Station{
 				Name:         station.Name,
@@ -183,23 +208,12 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 
 func (c *Client) GetObservations(ctx context.Context, station Station, startAt time.Time, endAt time.Time) ([]prometheus.Metric, error) {
 	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d", c.baseURL, station.DeviceID, startAt.Unix(), endAt.Unix())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("weatherflow API status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	// A non-200 response now surfaces as *StatusError rather than a plain
+	// fmt.Errorf. StatusError.Error()'s HTTP branch renders the byte-identical
+	// "weatherflow API status %d" string, so this is not an observable
+	// behavior change for ModeAPIExport, which only formats the error with
+	// %v and never type-asserts on it (main.go's export loop).
+	body, err := c.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -53,12 +53,33 @@ func NewClient(token string, opts ...ClientOption) *Client {
 type Station struct {
 	Name         string
 	StationID    int
-	deviceID     int
-	serialNumber string
+	DeviceID     int
+	SerialNumber string
 	CreatedAt    time.Time
 }
 
-func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
+// stationsResponse is the /stations payload. ListStations and ListDevices
+// both decode into it, so the JSON contract lives in exactly one place.
+type stationsResponse struct {
+	Stations []struct {
+		CreatedEpoch int64 `json:"created_epoch"`
+		Devices      []struct {
+			DeviceID     int    `json:"device_id"`
+			DeviceType   string `json:"device_type"`
+			SerialNumber string `json:"serial_number"`
+		} `json:"devices"`
+		Name      string `json:"name"`
+		StationID int    `json:"station_id"`
+	} `json:"stations"`
+	Status struct {
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
+	} `json:"status"`
+}
+
+// fetchStations performs the GET /stations call and validates the status
+// envelope. Behavior is byte-identical to what ListStations did inline.
+func (c *Client) fetchStations(ctx context.Context) (*stationsResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stations", nil)
 	if err != nil {
 		return nil, err
@@ -72,7 +93,7 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("weatherflow API status %d", resp.StatusCode)
+		return nil, &StatusError{HTTPStatus: resp.StatusCode}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
@@ -80,27 +101,60 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 		return nil, err
 	}
 
-	var data struct {
-		Stations []struct {
-			CreatedEpoch int64 `json:"created_epoch"`
-			Devices      []struct {
-				DeviceID     int    `json:"device_id"`
-				DeviceType   string `json:"device_type"`
-				SerialNumber string `json:"serial_number"`
-			} `json:"devices"`
-			Name      string `json:"name"`
-			StationID int    `json:"station_id"`
-		} `json:"stations"`
-		Status struct {
-			StatusCode    int    `json:"status_code"`
-			StatusMessage string `json:"status_message"`
-		} `json:"status"`
-	}
+	var data stationsResponse
 	if err := json.Unmarshal(body, &data); err != nil {
 		return nil, err
 	}
 	if data.Status.StatusCode != 0 {
-		return nil, fmt.Errorf("weatherflow status_code %d: %s", data.Status.StatusCode, data.Status.StatusMessage)
+		return nil, &StatusError{
+			StatusCode: data.Status.StatusCode,
+			Message:    data.Status.StatusMessage,
+		}
+	}
+	return &data, nil
+}
+
+// ListDevices returns one Station per ST device across all stations.
+//
+// It exists because ListStations collapses each station to a SINGLE ST device
+// (its loop has no break, so the last one wins). With two Tempest units on one
+// station that silently loses a sensor — the UDP listener records both serials,
+// but a caller driven by ListStations would only ever learn one, and the other
+// unit's gaps would never close, unlogged.
+//
+// ListStations is deliberately left with its collapsing behavior: ModeAPIExport
+// depends on it, and changing it is an explicit non-goal.
+func (c *Client) ListDevices(ctx context.Context) ([]Station, error) {
+	data, err := c.fetchStations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []Station
+	for _, station := range data.Stations {
+		for _, dev := range station.Devices {
+			if dev.DeviceType != "ST" {
+				continue
+			}
+			out = append(out, Station{
+				Name:         station.Name,
+				StationID:    station.StationID,
+				DeviceID:     dev.DeviceID,
+				SerialNumber: dev.SerialNumber,
+				CreatedAt:    time.Unix(station.CreatedEpoch, 0),
+			})
+		}
+	}
+	return out, nil
+}
+
+// ListStations returns one Station per station, collapsing each station's
+// devices to a SINGLE ST device — the last one seen, because the loop below
+// has no break. That behavior is load-bearing for ModeAPIExport and is
+// deliberately preserved; backfill uses ListDevices instead.
+func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
+	data, err := c.fetchStations(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var out []Station
@@ -117,8 +171,8 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 		if deviceId != 0 && instance != "" {
 			out = append(out, Station{
 				Name:         station.Name,
-				deviceID:     deviceId,
-				serialNumber: instance,
+				DeviceID:     deviceId,
+				SerialNumber: instance,
 				StationID:    station.StationID,
 				CreatedAt:    time.Unix(station.CreatedEpoch, 0),
 			})
@@ -128,7 +182,7 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 }
 
 func (c *Client) GetObservations(ctx context.Context, station Station, startAt time.Time, endAt time.Time) ([]prometheus.Metric, error) {
-	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d", c.baseURL, station.deviceID, startAt.Unix(), endAt.Unix())
+	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d", c.baseURL, station.DeviceID, startAt.Unix(), endAt.Unix())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -157,7 +211,7 @@ func (c *Client) GetObservations(ctx context.Context, station Station, startAt t
 
 	switch r := report.(type) {
 	case *tempestudp.TempestObservationReport:
-		r.SerialNumber = station.serialNumber
+		r.SerialNumber = station.SerialNumber
 	default:
 		return nil, fmt.Errorf("unhandled report type %T", report)
 	}

--- a/internal/tempestapi/client_test.go
+++ b/internal/tempestapi/client_test.go
@@ -872,3 +872,52 @@ func TestListStationsStillCollapsesToOneDevicePerStation(t *testing.T) {
 		t.Errorf("SerialNumber = %q, want ST-00000033 (last ST wins — unchanged behavior)", stations[0].SerialNumber)
 	}
 }
+
+// ListStations' HTTP-level failure (non-200 response) must be classifiable
+// via errors.As, not just matched by message text — the retry layer decides
+// whether to retry by extracting *StatusError, and a message-only assertion
+// would keep passing even if fetchStations reverted to a plain fmt.Errorf.
+func TestListStations_HTTPFailure_ClassifiesAsStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	_, err := c.ListStations(t.Context())
+	if err == nil {
+		t.Fatal("ListStations() error = nil, want a *StatusError for HTTP 429")
+	}
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("ListStations() error = %v (%T), want errors.As to find a *StatusError", err, err)
+	}
+	if se.HTTPStatus != http.StatusTooManyRequests {
+		t.Errorf("StatusError.HTTPStatus = %d, want %d", se.HTTPStatus, http.StatusTooManyRequests)
+	}
+}
+
+// ListStations' API-status-level failure (HTTP 200 with a non-zero
+// status.status_code envelope) must also be classifiable via errors.As.
+func TestListStations_APIStatusFailure_ClassifiesAsStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"stations":[],"status":{"status_code":2,"status_message":"BAD TOKEN"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	_, err := c.ListStations(t.Context())
+	if err == nil {
+		t.Fatal("ListStations() error = nil, want a *StatusError for non-zero status_code")
+	}
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("ListStations() error = %v (%T), want errors.As to find a *StatusError", err, err)
+	}
+	if se.StatusCode != 2 {
+		t.Errorf("StatusError.StatusCode = %d, want 2", se.StatusCode)
+	}
+	if se.Message != "BAD TOKEN" {
+		t.Errorf("StatusError.Message = %q, want %q", se.Message, "BAD TOKEN")
+	}
+}

--- a/internal/tempestapi/client_test.go
+++ b/internal/tempestapi/client_test.go
@@ -1,9 +1,11 @@
 package tempestapi
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -841,6 +843,60 @@ func TestListDevicesReturnsEverySTDevice(t *testing.T) {
 	}
 	if got["ST-00000022"] != 22 || got["ST-00000033"] != 33 {
 		t.Errorf("device map = %v, want ST-00000022→22 and ST-00000033→33", got)
+	}
+}
+
+// ListDevices must not silently accept a malformed ST entry. The API can
+// legitimately answer 200/status_code=0 with an empty obs window for a
+// phantom device, which is byte-identical to the permanent-hole signal a real
+// gap produces — so a dropped/malformed sensor must self-report via a WARN,
+// not vanish quietly.
+func TestListDevicesWarnsOnMalformedEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "empty serial number",
+			body: `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+				"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+				"devices": [{"device_id": 22, "device_type": "ST", "serial_number": ""}]
+			}]}`,
+		},
+		{
+			name: "zero device id",
+			body: `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+				"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+				"devices": [{"device_id": 0, "device_type": "ST", "serial_number": "ST-00000022"}]
+			}]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(srv.Close)
+			c := NewClient("test-token", WithBaseURL(srv.URL))
+
+			devices, err := c.ListDevices(t.Context())
+			if err != nil {
+				t.Fatalf("ListDevices: %v", err)
+			}
+			// The device is still returned — dropping it is the failure this
+			// guard exists to prevent.
+			if len(devices) != 1 {
+				t.Fatalf("got %d devices, want 1 (malformed device must still be returned)", len(devices))
+			}
+			if !strings.Contains(buf.String(), "Home") {
+				t.Errorf("malformed ST device must log a WARN naming the station; got:\n%s", buf.String())
+			}
+		})
 	}
 }
 

--- a/internal/tempestapi/client_test.go
+++ b/internal/tempestapi/client_test.go
@@ -91,11 +91,11 @@ func TestListStations_Success_SingleStation(t *testing.T) {
 	if station.StationID != 12345 {
 		t.Errorf("Expected station ID 12345, got %d", station.StationID)
 	}
-	if station.deviceID != 67890 {
-		t.Errorf("Expected device ID 67890, got %d", station.deviceID)
+	if station.DeviceID != 67890 {
+		t.Errorf("Expected device ID 67890, got %d", station.DeviceID)
 	}
-	if station.serialNumber != "ST-00012345" {
-		t.Errorf("Expected serial number 'ST-00012345', got %s", station.serialNumber)
+	if station.SerialNumber != "ST-00012345" {
+		t.Errorf("Expected serial number 'ST-00012345', got %s", station.SerialNumber)
 	}
 
 	expectedTime := time.Unix(1609459200, 0)
@@ -219,11 +219,11 @@ func TestListStations_Success_MultipleDevicesPerStation(t *testing.T) {
 
 	// Should pick the ST device, not HB or AR
 	station := stations[0]
-	if station.deviceID != 67890 {
-		t.Errorf("Expected device ID 67890 (ST device), got %d", station.deviceID)
+	if station.DeviceID != 67890 {
+		t.Errorf("Expected device ID 67890 (ST device), got %d", station.DeviceID)
 	}
-	if station.serialNumber != "ST-00012345" {
-		t.Errorf("Expected serial number 'ST-00012345', got %s", station.serialNumber)
+	if station.SerialNumber != "ST-00012345" {
+		t.Errorf("Expected serial number 'ST-00012345', got %s", station.SerialNumber)
 	}
 }
 
@@ -418,8 +418,8 @@ func TestGetObservations_Success(t *testing.T) {
 	station := Station{
 		Name:         "Test Station",
 		StationID:    12345,
-		deviceID:     67890,
-		serialNumber: "ST-00012345",
+		DeviceID:     67890,
+		SerialNumber: "ST-00012345",
 		CreatedAt:    time.Now(),
 	}
 
@@ -461,8 +461,8 @@ func TestGetObservations_MultipleObservations(t *testing.T) {
 	}
 
 	station := Station{
-		deviceID:     67890,
-		serialNumber: "ST-00012345",
+		DeviceID:     67890,
+		SerialNumber: "ST-00012345",
 	}
 
 	metrics, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
@@ -482,7 +482,7 @@ func TestGetObservations_HTTPError(t *testing.T) {
 		err: errors.New("network error"),
 	}
 
-	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
+	station := Station{DeviceID: 67890, SerialNumber: "ST-00012345"}
 
 	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
 
@@ -497,7 +497,7 @@ func TestGetObservations_InvalidJSON(t *testing.T) {
 		response: mockResponse(http.StatusOK, "not valid json"),
 	}
 
-	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
+	station := Station{DeviceID: 67890, SerialNumber: "ST-00012345"}
 
 	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
 
@@ -512,7 +512,7 @@ func TestGetObservations_ContextCancellation(t *testing.T) {
 		err: context.Canceled,
 	}
 
-	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
+	station := Station{DeviceID: 67890, SerialNumber: "ST-00012345"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
@@ -539,7 +539,7 @@ func TestGetObservations_EmptyObservations(t *testing.T) {
 		response: mockResponse(http.StatusOK, mockBody),
 	}
 
-	station := Station{deviceID: 67890, serialNumber: "ST-00012345"}
+	station := Station{DeviceID: 67890, SerialNumber: "ST-00012345"}
 
 	metrics, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
 
@@ -657,8 +657,8 @@ func TestGetObservations_URLParameters(t *testing.T) {
 	})
 
 	station := Station{
-		deviceID:     98765,
-		serialNumber: "ST-00098765",
+		DeviceID:     98765,
+		SerialNumber: "ST-00098765",
 	}
 
 	startTime := time.Unix(1609459000, 0)
@@ -761,7 +761,7 @@ func TestClient_ReturnsErrorOn401(t *testing.T) {
 		t.Errorf("ListStations() error = %v, want it to mention status 401", err)
 	}
 
-	station := Station{deviceID: 1, serialNumber: "ST-1"}
+	station := Station{DeviceID: 1, SerialNumber: "ST-1"}
 	if _, err := client.GetObservations(context.Background(), station, time.Now(), time.Now()); err == nil {
 		t.Error("GetObservations() error = nil, want error mentioning status 401")
 	} else if !strings.Contains(err.Error(), "401") {
@@ -784,7 +784,7 @@ func TestClient_UnhandledReportType_ReturnsError(t *testing.T) {
 	defer server.Close()
 
 	client := newRedirectingClient("secret-token", server)
-	station := Station{deviceID: 1, serialNumber: "ST-1"}
+	station := Station{DeviceID: 1, SerialNumber: "ST-1"}
 
 	_, err := client.GetObservations(context.Background(), station, time.Now(), time.Now())
 	if err == nil {
@@ -806,5 +806,69 @@ func TestClient_ChecksStatusCode(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "2") {
 		t.Errorf("ListStations() error = %v, want it to mention status_code 2", err)
+	}
+}
+
+func TestListDevicesReturnsEverySTDevice(t *testing.T) {
+	// One station, TWO Tempest sensors, plus a hub that must be ignored.
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+		"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+		"devices": [
+			{"device_id": 11, "device_type": "HB", "serial_number": "HB-00000001"},
+			{"device_id": 22, "device_type": "ST", "serial_number": "ST-00000022"},
+			{"device_id": 33, "device_type": "ST", "serial_number": "ST-00000033"}
+		]
+	}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	devices, err := c.ListDevices(t.Context())
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("got %d devices, want 2 (both ST sensors, hub excluded)", len(devices))
+	}
+	got := map[string]int{}
+	for _, d := range devices {
+		got[d.SerialNumber] = d.DeviceID
+		if !d.CreatedAt.Equal(time.Unix(1600000000, 0)) {
+			t.Errorf("%s CreatedAt = %v, want the owning station's created_epoch", d.SerialNumber, d.CreatedAt)
+		}
+	}
+	if got["ST-00000022"] != 22 || got["ST-00000033"] != 33 {
+		t.Errorf("device map = %v, want ST-00000022→22 and ST-00000033→33", got)
+	}
+}
+
+// ListStations must keep its existing one-per-station collapse — ModeAPIExport
+// depends on it. This pins the divergence so the shared decode refactor cannot
+// silently change it.
+func TestListStationsStillCollapsesToOneDevicePerStation(t *testing.T) {
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{
+		"station_id": 1, "name": "Home", "created_epoch": 1600000000,
+		"devices": [
+			{"device_id": 22, "device_type": "ST", "serial_number": "ST-00000022"},
+			{"device_id": 33, "device_type": "ST", "serial_number": "ST-00000033"}
+		]
+	}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+
+	stations, err := c.ListStations(t.Context())
+	if err != nil {
+		t.Fatalf("ListStations: %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("got %d stations, want 1", len(stations))
+	}
+	if stations[0].SerialNumber != "ST-00000033" {
+		t.Errorf("SerialNumber = %q, want ST-00000033 (last ST wins — unchanged behavior)", stations[0].SerialNumber)
 	}
 }

--- a/internal/tempestapi/errors.go
+++ b/internal/tempestapi/errors.go
@@ -1,0 +1,30 @@
+package tempestapi
+
+import "fmt"
+
+// StatusError is a failed Tempest REST call, carrying enough structure for a
+// caller to decide whether retrying could help. It exists because three
+// behaviors branch on the KIND of failure — retry on 429/5xx/network, treat a
+// non-zero API status_code as a real failure, and exit non-zero if any gap
+// failed — and string-matching an opaque error is not a classification.
+//
+// Exactly one of the two codes is meaningful per instance:
+//
+//   - HTTPStatus != 0: the transport-level response was not 200. Transient
+//     for 429 and 5xx.
+//   - StatusCode != 0: the response was HTTP 200 but WeatherFlow reported an
+//     application-level failure in its status envelope. Never transient.
+//
+// Classify with errors.As, NOT errors.AsType (Go 1.26; go.mod declares 1.25.0).
+type StatusError struct {
+	HTTPStatus int    // HTTP response status, 0 when the failure is API-level
+	StatusCode int    // WeatherFlow status.status_code, 0 when purely HTTP
+	Message    string // WeatherFlow status.status_message, if any
+}
+
+func (e *StatusError) Error() string {
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("weatherflow status_code %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("weatherflow API status %d", e.HTTPStatus)
+}

--- a/internal/tempestapi/errors_test.go
+++ b/internal/tempestapi/errors_test.go
@@ -1,0 +1,54 @@
+package tempestapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestStatusErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *StatusError
+		want string
+	}{
+		{
+			name: "api level status code",
+			err:  &StatusError{StatusCode: 404, Message: "NOT FOUND"},
+			want: "weatherflow status_code 404: NOT FOUND",
+		},
+		{
+			name: "http level status",
+			err:  &StatusError{HTTPStatus: 503},
+			want: "weatherflow API status 503",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The retry layer classifies with errors.As, so StatusError must survive
+// wrapping. NOTE: errors.As, never errors.AsType — that is Go 1.26 and
+// go.mod declares go 1.25.0.
+func TestStatusErrorUnwrapsThroughFmtErrorf(t *testing.T) {
+	wrapped := fmt.Errorf("fetch window: %w", &StatusError{HTTPStatus: 429})
+	var se *StatusError
+	if !errors.As(wrapped, &se) {
+		t.Fatal("errors.As failed to extract *StatusError from a wrapped error")
+	}
+	if se.HTTPStatus != 429 {
+		t.Errorf("HTTPStatus = %d, want 429", se.HTTPStatus)
+	}
+}
+
+func TestStationFieldsAreExported(t *testing.T) {
+	s := Station{SerialNumber: "ST-00000001", DeviceID: 42}
+	if s.SerialNumber != "ST-00000001" || s.DeviceID != 42 {
+		t.Error("Station.SerialNumber and Station.DeviceID must be settable from outside the package")
+	}
+}

--- a/internal/tempestapi/observations.go
+++ b/internal/tempestapi/observations.go
@@ -67,6 +67,14 @@ const (
 // pressure and wind — a real divergence from the ingest path the design
 // forbids. Because every weather.Observation measurement is a *float64,
 // honoring the graduated rule is free: absent indices simply stay nil.
+//
+// The floor mirrors the UDP path exactly, but the tail does not: at() fills
+// obsLightningDistance (14) and obsLightningStrikeCount (15) independently,
+// where sqlite/writer.go's handleObservationReport gates that pair together
+// on len(ob) >= 16. A 15-element tuple therefore keeps a lightning distance
+// here that the UDP path would discard (it would keep neither). This is a
+// deliberate, accepted divergence — not a bug to fix by changing behavior —
+// because the graduated rule this file follows is "preserve what is present."
 const obsMinFields = 13
 
 // Observations fetches raw historical observations for one device over
@@ -172,7 +180,7 @@ func (c *Client) Observations(ctx context.Context, station Station, start, end t
 		// signal the reporting design rests on.
 		slog.Warn("tempestapi: dropped malformed observation tuples",
 			"serial", station.SerialNumber, "dropped", dropped, "total", len(set.Obs),
-			"start", start, "end", end)
+			"start", start.UTC(), "end", end.UTC())
 	}
 	return out, nil
 }

--- a/internal/tempestapi/observations.go
+++ b/internal/tempestapi/observations.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"time"
 
 	"tempestwx-utilities/internal/weather"
@@ -29,8 +27,7 @@ type observationSet struct {
 		StatusCode    int    `json:"status_code"`
 		StatusMessage string `json:"status_message"`
 	} `json:"status"`
-	Type string       `json:"type"`
-	Obs  [][]*float64 `json:"obs"`
+	Obs [][]*float64 `json:"obs"`
 }
 
 // obs_st tuple indices. Indices 0-17 match the UDP layout exactly, so the
@@ -93,23 +90,7 @@ func (c *Client) Observations(ctx context.Context, station Station, start, end t
 	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d",
 		c.baseURL, station.DeviceID, start.Unix(), end.Unix())
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, &StatusError{HTTPStatus: resp.StatusCode}
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	body, err := c.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tempestapi/observations.go
+++ b/internal/tempestapi/observations.go
@@ -1,0 +1,178 @@
+package tempestapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"tempestwx-utilities/internal/weather"
+)
+
+// observationSet mirrors the Tempest ObservationSet response schema.
+//
+// Obs is [][]*float64, not [][]float64: unmarshalling a JSON null into a
+// non-pointer numeric is a silent no-op that yields 0.0, which would write a
+// physically meaningful "pressure = 0.0 mb" where the API said "unknown".
+// Backfill operates precisely on marginal windows, where nulls are most
+// likely. Do not "simplify" this to [][]float64 and do not reuse
+// tempestudp.TempestObservationReport, whose Obs is [][]float64.
+//
+// Every field is optional. The published OpenAPI schema declares no `required`
+// array for ObservationSet, so a response may legitimately omit both `type`
+// and `obs` — that is an empty window, not an error.
+type observationSet struct {
+	Status struct {
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
+	} `json:"status"`
+	Type string       `json:"type"`
+	Obs  [][]*float64 `json:"obs"`
+}
+
+// obs_st tuple indices. Indices 0-17 match the UDP layout exactly, so the
+// same field semantics apply. The REST array carries 22 elements; 18-21
+// (local-day rain accumulation, Nearcast accumulations, precip analysis type)
+// map to no column in tempest_observations and are ignored deliberately.
+const (
+	obsTimestamp = iota
+	obsWindLull
+	obsWindAvg
+	obsWindGust
+	obsWindDirection
+	obsWindSampleInterval
+	obsPressure
+	obsTempAir
+	obsHumidity
+	obsIlluminance
+	obsUVIndex
+	obsIrradiance
+	obsRainRate
+	obsPrecipType
+	obsLightningDistance
+	obsLightningStrikeCount
+	obsBattery
+	obsReportInterval
+)
+
+// obsMinFields is the floor below which a tuple carries no usable core
+// measurements. It mirrors the UDP ingest path, which accepts a report at
+// len(ob) >= 13 and fills the tail conditionally (sqlite/writer.go:406-457).
+//
+// The guards here are GRADUATED, not all-or-nothing. A hard
+// "len(ob) < 18 -> drop" would silently discard a short tuple's temperature,
+// pressure and wind — a real divergence from the ingest path the design
+// forbids. Because every weather.Observation measurement is a *float64,
+// honoring the graduated rule is free: absent indices simply stay nil.
+const obsMinFields = 13
+
+// Observations fetches raw historical observations for one device over
+// [start, end] and returns them in store-neutral form.
+//
+// It is deliberately separate from GetObservations, which returns
+// []prometheus.Metric for ModeAPIExport and routes through
+// tempestudp.ParseReport. ParseReport dispatches on the top-level `type` and
+// fails with `unhandled message type: ""` on a status-only envelope, which
+// would turn a legitimate empty window into a hard error.
+//
+// Derived columns are NOT computed here — this returns raw API fields only.
+// temp_wetbulb is derived at the store boundary so backfilled and live rows
+// stay indistinguishable.
+func (c *Client) Observations(ctx context.Context, station Station, start, end time.Time) ([]weather.Observation, error) {
+	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d",
+		c.baseURL, station.DeviceID, start.Unix(), end.Unix())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &StatusError{HTTPStatus: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	var set observationSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("decode observation set: %w", err)
+	}
+
+	// A non-zero status_code is a real, non-transient API failure. A zero
+	// status_code with an absent/null/empty obs is an empty window: zero
+	// rows, no error.
+	if set.Status.StatusCode != 0 {
+		return nil, &StatusError{
+			StatusCode: set.Status.StatusCode,
+			Message:    set.Status.StatusMessage,
+		}
+	}
+
+	// at returns ob[i] when the tuple is long enough, nil otherwise. This is
+	// the graduated guard: a short tuple keeps its core measurements and gets
+	// NULL for the indices it does not carry.
+	at := func(ob []*float64, i int) *float64 {
+		if i < len(ob) {
+			return ob[i]
+		}
+		return nil
+	}
+
+	out := make([]weather.Observation, 0, len(set.Obs))
+	dropped := 0
+	for _, ob := range set.Obs {
+		if len(ob) < obsMinFields || ob[obsTimestamp] == nil {
+			// Below the floor, or no timestamp: the row cannot be keyed by
+			// (serial_number, timestamp), so writing it would create an
+			// un-dedupable row at some arbitrary instant. Drop it — and count
+			// it, so an all-malformed window is distinguishable from a
+			// permanent hole.
+			dropped++
+			continue
+		}
+		out = append(out, weather.Observation{
+			SerialNumber:         station.SerialNumber,
+			Timestamp:            time.Unix(int64(*ob[obsTimestamp]), 0).UTC(),
+			WindLull:             at(ob, obsWindLull),
+			WindAvg:              at(ob, obsWindAvg),
+			WindGust:             at(ob, obsWindGust),
+			WindDirection:        at(ob, obsWindDirection),
+			WindSampleInterval:   at(ob, obsWindSampleInterval),
+			Pressure:             at(ob, obsPressure),
+			TempAir:              at(ob, obsTempAir),
+			Humidity:             at(ob, obsHumidity),
+			Illuminance:          at(ob, obsIlluminance),
+			UVIndex:              at(ob, obsUVIndex),
+			Irradiance:           at(ob, obsIrradiance),
+			RainRate:             at(ob, obsRainRate),
+			PrecipType:           at(ob, obsPrecipType),
+			LightningDistance:    at(ob, obsLightningDistance),
+			LightningStrikeCount: at(ob, obsLightningStrikeCount),
+			Battery:              at(ob, obsBattery),
+			ReportInterval:       at(ob, obsReportInterval),
+		})
+	}
+
+	if dropped > 0 {
+		// WARN, not silence: without this, a window whose tuples were all
+		// malformed reports zero rows — byte-identical to the permanent-hole
+		// signal the reporting design rests on.
+		slog.Warn("tempestapi: dropped malformed observation tuples",
+			"serial", station.SerialNumber, "dropped", dropped, "total", len(set.Obs),
+			"start", start, "end", end)
+	}
+	return out, nil
+}

--- a/internal/tempestapi/observations_test.go
+++ b/internal/tempestapi/observations_test.go
@@ -1,0 +1,228 @@
+package tempestapi
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestClient points a Client at an httptest.Server via the existing
+// WithBaseURL seam (client.go:35-39).
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient("test-token", WithBaseURL(srv.URL))
+}
+
+func TestObservationsMapsNullToNilNotZero(t *testing.T) {
+	// obs[6] (pressure) and obs[16] (battery) are null. They must decode to
+	// nil pointers, NOT 0.0 — a 0.0 mb pressure reads as real to
+	// SummarizeObservations' MIN(pressure) and to every chart.
+	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":[
+		[1700000000,0.1,0.2,0.3,180,3,null,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,null,1]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1", len(obs))
+	}
+	if obs[0].Pressure != nil {
+		t.Errorf("Pressure = %v, want nil (JSON null must not become 0.0)", *obs[0].Pressure)
+	}
+	if obs[0].Battery != nil {
+		t.Errorf("Battery = %v, want nil", *obs[0].Battery)
+	}
+	if obs[0].TempAir == nil || *obs[0].TempAir != 20.5 {
+		t.Errorf("TempAir = %v, want 20.5", obs[0].TempAir)
+	}
+	if obs[0].SerialNumber != "ST-1" {
+		t.Errorf("SerialNumber = %q, want %q", obs[0].SerialNumber, "ST-1")
+	}
+	if !obs[0].Timestamp.Equal(time.Unix(1700000000, 0).UTC()) {
+		t.Errorf("Timestamp = %v, want %v", obs[0].Timestamp, time.Unix(1700000000, 0).UTC())
+	}
+}
+
+func TestObservationsEmptyWindowIsNotAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"obs empty", `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":[]}`},
+		{"obs null", `{"status":{"status_code":0,"status_message":"SUCCESS"},"type":"obs_st","obs":null}`},
+		{"status only, no type, no obs", `{"status":{"status_code":0,"status_message":"SUCCESS - Either no capabilities or no recent observations"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			})
+			obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+			if err != nil {
+				t.Fatalf("empty window must not be an error, got %v", err)
+			}
+			if len(obs) != 0 {
+				t.Errorf("got %d observations, want 0", len(obs))
+			}
+		})
+	}
+}
+
+func TestObservationsNonZeroStatusCodeIsStatusError(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":{"status_code":404,"status_message":"NOT FOUND"}}`))
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 1}, time.Unix(0, 0), time.Unix(1, 0))
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("want *StatusError, got %T: %v", err, err)
+	}
+	if se.StatusCode != 404 || se.Message != "NOT FOUND" {
+		t.Errorf("got %+v, want StatusCode 404 / NOT FOUND", se)
+	}
+}
+
+func TestObservationsHTTPErrorIsStatusError(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 1}, time.Unix(0, 0), time.Unix(1, 0))
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("want *StatusError, got %T: %v", err, err)
+	}
+	if se.HTTPStatus != http.StatusServiceUnavailable {
+		t.Errorf("HTTPStatus = %d, want 503", se.HTTPStatus)
+	}
+}
+
+func TestObservationsSkipsRowWithNullTimestamp(t *testing.T) {
+	// A row with no timestamp cannot be keyed by (serial, timestamp) and
+	// must be dropped rather than written at the epoch.
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[
+		[null,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1],
+		[1700000000,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1 (the null-timestamp row must be dropped)", len(obs))
+	}
+}
+
+// The guards are GRADUATED, matching the UDP ingest path (>= 13 floor, tail
+// filled conditionally). A 13-element tuple must be KEPT with its core
+// measurements and NULL for the indices it does not carry — not dropped.
+func TestObservationsKeepsShortTupleWithNullTail(t *testing.T) {
+	// Exactly 13 elements: timestamp through rain_rate, nothing after.
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[
+		[1700000000,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0]
+	]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("got %d observations, want 1 — a 13-element tuple must not be dropped", len(obs))
+	}
+	if obs[0].TempAir == nil || *obs[0].TempAir != 20.5 {
+		t.Errorf("TempAir = %v, want 20.5 (core measurements must survive)", obs[0].TempAir)
+	}
+	if obs[0].Battery != nil {
+		t.Errorf("Battery = %v, want nil (index 16 absent from a 13-element tuple)", *obs[0].Battery)
+	}
+	if obs[0].ReportInterval != nil {
+		t.Errorf("ReportInterval = %v, want nil (index 17 absent)", *obs[0].ReportInterval)
+	}
+}
+
+// Below the floor there is nothing usable, so the tuple is dropped — and the
+// drop MUST be logged.
+//
+// Asserting only len(obs)==0 would be insufficient: that outcome is identical
+// to an empty window, which is exactly the confusion the WARN exists to
+// prevent. A window whose tuples were all malformed would otherwise report
+// zero rows and read as a permanent hole — the one machine-readable
+// diagnostic the reporting design rests on.
+func TestObservationsDropsTupleBelowFloorAndLogsIt(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	body := `{"status":{"status_code":0},"type":"obs_st","obs":[[1700000000,0.1,0.2]]}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	obs, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Errorf("got %d observations, want 0 — a 3-element tuple is below the 13 floor", len(obs))
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "dropped=1") {
+		t.Errorf("the drop must be logged with a count; got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "ST-1") {
+		t.Errorf("the drop log must name the serial; got:\n%s", logged)
+	}
+}
+
+// The contrast case: a genuinely empty window must NOT log a drop warning,
+// or the signal is worthless.
+func TestObservationsEmptyWindowLogsNoDropWarning(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
+	})
+	if _, err := c.Observations(t.Context(), Station{DeviceID: 1, SerialNumber: "ST-1"}, time.Unix(0, 0), time.Unix(1, 0)); err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if strings.Contains(buf.String(), "dropped") {
+		t.Errorf("an empty window must not log a drop warning; got:\n%s", buf.String())
+	}
+}
+
+func TestObservationsRequestsCorrectWindow(t *testing.T) {
+	var gotQuery string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
+	})
+	_, err := c.Observations(t.Context(), Station{DeviceID: 77}, time.Unix(1700000000, 0), time.Unix(1700086400, 0))
+	if err != nil {
+		t.Fatalf("Observations: %v", err)
+	}
+	if want := "time_start=1700000000&time_end=1700086400"; gotQuery != want {
+		t.Errorf("query = %q, want %q", gotQuery, want)
+	}
+}

--- a/internal/tempestapi/observations_test.go
+++ b/internal/tempestapi/observations_test.go
@@ -110,7 +110,14 @@ func TestObservationsHTTPErrorIsStatusError(t *testing.T) {
 
 func TestObservationsSkipsRowWithNullTimestamp(t *testing.T) {
 	// A row with no timestamp cannot be keyed by (serial, timestamp) and
-	// must be dropped rather than written at the epoch.
+	// must be dropped rather than written at the epoch. This exercises the
+	// same drop path as the logging tests below, so it needs the same
+	// buffer handler to keep the WARN out of real stderr.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	body := `{"status":{"status_code":0},"type":"obs_st","obs":[
 		[null,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1],
 		[1700000000,0.1,0.2,0.3,180,3,1013.0,20.5,55.0,1000,1.5,300,0.0,0,10.0,2,2.6,1]
@@ -124,6 +131,12 @@ func TestObservationsSkipsRowWithNullTimestamp(t *testing.T) {
 	}
 	if len(obs) != 1 {
 		t.Fatalf("got %d observations, want 1 (the null-timestamp row must be dropped)", len(obs))
+	}
+	if !obs[0].Timestamp.Equal(time.Unix(1700000000, 0).UTC()) {
+		t.Errorf("Timestamp = %v, want %v (the surviving row, not the dropped one)", obs[0].Timestamp, time.Unix(1700000000, 0).UTC())
+	}
+	if logged := buf.String(); !strings.Contains(logged, "dropped=1") {
+		t.Errorf("the drop must be logged with a count; got:\n%s", logged)
 	}
 }
 
@@ -213,14 +226,18 @@ func TestObservationsEmptyWindowLogsNoDropWarning(t *testing.T) {
 }
 
 func TestObservationsRequestsCorrectWindow(t *testing.T) {
-	var gotQuery string
+	var gotPath, gotQuery string
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
 		gotQuery = r.URL.RawQuery
 		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
 	})
 	_, err := c.Observations(t.Context(), Station{DeviceID: 77}, time.Unix(1700000000, 0), time.Unix(1700086400, 0))
 	if err != nil {
 		t.Fatalf("Observations: %v", err)
+	}
+	if want := "/observations/device/77"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
 	}
 	if want := "time_start=1700000000&time_end=1700086400"; gotQuery != want {
 		t.Errorf("query = %q, want %q", gotQuery, want)

--- a/internal/tempestapi/observations_test.go
+++ b/internal/tempestapi/observations_test.go
@@ -226,10 +226,11 @@ func TestObservationsEmptyWindowLogsNoDropWarning(t *testing.T) {
 }
 
 func TestObservationsRequestsCorrectWindow(t *testing.T) {
-	var gotPath, gotQuery string
+	var gotPath, gotQuery, gotAuth string
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
 		_, _ = w.Write([]byte(`{"status":{"status_code":0},"obs":[]}`))
 	})
 	_, err := c.Observations(t.Context(), Station{DeviceID: 77}, time.Unix(1700000000, 0), time.Unix(1700086400, 0))
@@ -241,5 +242,13 @@ func TestObservationsRequestsCorrectWindow(t *testing.T) {
 	}
 	if want := "time_start=1700000000&time_end=1700086400"; gotQuery != want {
 		t.Errorf("query = %q, want %q", gotQuery, want)
+	}
+	// This is the ONLY test that directly asserts Observations sends the
+	// Bearer header — deleting the header line from Observations left the
+	// entire suite green before this assertion existed, because every other
+	// test on this path either doesn't inspect the header or exercises a
+	// different method (fetchStations, via ListStations).
+	if want := "Bearer test-token"; gotAuth != want {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, want)
 	}
 }

--- a/internal/weather/observation.go
+++ b/internal/weather/observation.go
@@ -1,0 +1,86 @@
+// Package weather holds the store-neutral representation of a weather
+// observation and of a hole in an observation series.
+//
+// It deliberately imports nothing else in this repository. Both store
+// packages (internal/sqlite, internal/postgres) and the REST client
+// (internal/tempestapi) name these types, so any home that imported one of
+// them would create a cycle. It is not the UDP wire protocol — that is
+// internal/tempestudp — and these types must not be added there.
+package weather
+
+import "time"
+
+// Observation is one tempest_observations row in store-neutral form.
+//
+// Every measurement is a *float64 because the SQLite and Postgres DDL declare
+// every column except id/serial_number/timestamp as nullable, and the Tempest
+// REST API may return JSON null for any element of an obs tuple. A nil here
+// means SQL NULL; database/sql and pgx both bind it that way directly.
+//
+// This is deliberately NOT the stores' private observationRow types, whose
+// leading fields are non-pointer float64: unmarshalling a JSON null into a
+// non-pointer numeric is a silent no-op that yields 0.0, which would write
+// "pressure = 0.0 mb" where the API said "unknown". See the design's
+// "Nullability — mandatory" section.
+type Observation struct {
+	// SerialNumber and Timestamp are the series key and are never NULL.
+	// An observation whose ob[0] is null cannot be keyed and is dropped
+	// at decode time rather than represented here.
+	SerialNumber string
+	Timestamp    time.Time
+
+	WindLull             *float64 // obs_st[1]
+	WindAvg              *float64 // obs_st[2]
+	WindGust             *float64 // obs_st[3]
+	WindDirection        *float64 // obs_st[4]
+	WindSampleInterval   *float64 // obs_st[5]
+	Pressure             *float64 // obs_st[6], raw mb (no conversion)
+	TempAir              *float64 // obs_st[7]
+	Humidity             *float64 // obs_st[8]
+	Illuminance          *float64 // obs_st[9]
+	UVIndex              *float64 // obs_st[10]
+	Irradiance           *float64 // obs_st[11]
+	RainRate             *float64 // obs_st[12]
+	PrecipType           *float64 // obs_st[13]
+	LightningDistance    *float64 // obs_st[14]
+	LightningStrikeCount *float64 // obs_st[15]
+	Battery              *float64 // obs_st[16]
+	ReportInterval       *float64 // obs_st[17]
+}
+
+// NOTE: there is deliberately no TempWetbulb field. The API does not return
+// wet bulb; each store derives it at its own insert boundary from
+// TempAir/Humidity/Pressure using tempestudp.WetBulbTemperatureC. A field
+// here would never be read by any code path, and setting it would silently
+// do nothing — dead code that looks load-bearing.
+
+// Gap is a CLOSED hole [From, To] in one station's observation series.
+//
+// Closed, not half-open: every producer emits endpoints that are rows which
+// already exist (prev/next from LAG, First/Last from SeriesBounds), so both
+// ends get re-fetched and re-offered to the store. ON CONFLICT DO NOTHING
+// absorbs the duplicates, so this costs nothing but a slightly inflated
+// Returned count — but the doc must not claim a half-open interval it does
+// not have.
+//
+// The series is keyed by (SerialNumber, Timestamp) — the same uniqueness
+// contract idempotent inserts rely on — so a Gap is meaningless without its
+// serial.
+type Gap struct {
+	SerialNumber string
+	From         time.Time
+	To           time.Time
+}
+
+// Duration is the width of the gap.
+func (g Gap) Duration() time.Duration { return g.To.Sub(g.From) }
+
+// Bounds is the first and last observation timestamp held for one serial
+// within a queried window. It is what lets the caller find head and tail
+// gaps, which a SQL LAG window function cannot see: LAG yields NULL for the
+// first row of each partition, so it finds interior gaps only.
+type Bounds struct {
+	SerialNumber string
+	First        time.Time
+	Last         time.Time
+}

--- a/internal/weather/observation_test.go
+++ b/internal/weather/observation_test.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -16,15 +17,23 @@ func TestGapDuration(t *testing.T) {
 	}
 }
 
-// The invariant this pins is that the measurement fields are POINTER-typed,
-// so a JSON null can round-trip to SQL NULL. It asserts through the type
-// system rather than through behavior — the behavioral proof is in Task 3's
-// decode test and Task 5's insert test.
+// The invariant this pins is that every measurement field is POINTER-typed,
+// so a JSON null can round-trip to SQL NULL. It walks the struct via
+// reflection and asserts, at runtime, that every field other than the
+// SerialNumber/Timestamp series key is *float64 — this is a real runtime
+// assertion covering every field (including any added later), not just the
+// handful a compile-time nil-assignment would happen to cover. The
+// behavioral proof that a JSON null actually decodes to a nil pointer lives
+// in Task 3's decode test and Task 5's insert test.
 func TestObservationMeasurementFieldsArePointers(t *testing.T) {
-	var o Observation
-	// Assigning nil compiles only if these are pointers.
-	o.Pressure, o.TempAir, o.Battery = nil, nil, nil
-	if o.Pressure != nil || o.TempAir != nil || o.Battery != nil {
-		t.Error("measurement fields must be *float64 so JSON null maps to SQL NULL")
+	typ := reflect.TypeFor[Observation]()
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		if f.Name == "SerialNumber" || f.Name == "Timestamp" {
+			continue
+		}
+		if f.Type.Kind() != reflect.Pointer || f.Type.Elem().Kind() != reflect.Float64 {
+			t.Errorf("%s is %s, want *float64 so JSON null maps to SQL NULL", f.Name, f.Type)
+		}
 	}
 }

--- a/internal/weather/observation_test.go
+++ b/internal/weather/observation_test.go
@@ -1,0 +1,30 @@
+package weather
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGapDuration(t *testing.T) {
+	g := Gap{
+		SerialNumber: "ST-00000001",
+		From:         time.Unix(1000, 0).UTC(),
+		To:           time.Unix(4600, 0).UTC(),
+	}
+	if got, want := g.Duration(), time.Hour; got != want {
+		t.Errorf("Duration() = %v, want %v", got, want)
+	}
+}
+
+// The invariant this pins is that the measurement fields are POINTER-typed,
+// so a JSON null can round-trip to SQL NULL. It asserts through the type
+// system rather than through behavior — the behavioral proof is in Task 3's
+// decode test and Task 5's insert test.
+func TestObservationMeasurementFieldsArePointers(t *testing.T) {
+	var o Observation
+	// Assigning nil compiles only if these are pointers.
+	o.Pressure, o.TempAir, o.Battery = nil, nil, nil
+	if o.Pressure != nil || o.TempAir != nil || o.Battery != nil {
+		t.Error("measurement fields must be *float64 so JSON null maps to SQL NULL")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -185,9 +186,56 @@ func runHealthcheck() int {
 	return 0
 }
 
+// isKnownSubcommand reports whether name is a subcommand this binary
+// dispatches. It exists so an unrecognized argument becomes a usage error
+// instead of silently falling through to daemon mode — a typo such as
+// `tempestwx-utilities backfil` previously started a UDP listener.
+func isKnownSubcommand(name string) bool {
+	switch name {
+	case "healthcheck", "backfill":
+		return true
+	default:
+		return false
+	}
+}
+
+const usageText = `tempestwx-utilities — Tempest weather station data utilities
+
+usage:
+  tempestwx-utilities                 run the UDP listener / API export daemon (configured by env)
+  tempestwx-utilities backfill [...]  fill gaps in the observation history from the Tempest REST API
+  tempestwx-utilities healthcheck     probe the running server's /healthz endpoint
+
+run "tempestwx-utilities backfill --help" for the backfill flags
+`
+
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
-		os.Exit(runHealthcheck())
+	// A non-flag first argument is a subcommand. An unknown one is a usage
+	// error, never a silent fallthrough to daemon mode.
+	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], "-") {
+		if !isKnownSubcommand(os.Args[1]) {
+			fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n%s", os.Args[1], usageText)
+			os.Exit(2)
+		}
+		switch os.Args[1] {
+		case "healthcheck":
+			os.Exit(runHealthcheck())
+		case "backfill":
+			// runBackfill owns all of its cleanup via internal defers and
+			// wires its own signal context.
+			os.Exit(runBackfill(context.Background(), os.Args[2:]))
+		default:
+			// Unreachable while this switch and isKnownSubcommand agree — but
+			// the subcommand name is duplicated across the two, so they CAN
+			// desync. Without this arm a desync falls through to daemon mode
+			// and silently starts the UDP listener, which is precisely the
+			// bug the isKnownSubcommand check above exists to prevent.
+			// Fail loudly instead.
+			fmt.Fprintf(os.Stderr,
+				"internal error: %q passed isKnownSubcommand but has no dispatch case\n\n%s",
+				os.Args[1], usageText)
+			os.Exit(2)
+		}
 	}
 
 	ctx, done := signalContext(context.Background(), signal.NotifyContext)


### PR DESCRIPTION
## What this does

Adds a `backfill` subcommand that finds holes in the local observation history and fills them from the Tempest REST API — idempotently, and safe to re-run.

The service persists observations received over UDP. Anything missed while the process was down is simply absent, and nothing recovers it. The REST API retains that history.

```bash
TOKEN=… tempestwx-utilities backfill
TOKEN=… tempestwx-utilities backfill --dry-run
TOKEN=… tempestwx-utilities backfill --from 2026-07-01T00:00:00Z --to 2026-07-05T00:00:00Z
```

Implements `docs/designs/2026-07-28-api-backfill-tool-design.md` via `docs/plans/2026-07-29-api-backfill-tool-implementation.md`.

## Also fixes a live bug

`main()` previously matched only `healthcheck` and **fell through to daemon mode for anything else** — so `tempestwx-utilities backfil` (typo) silently started a UDP listener that never exits. Unknown non-flag arguments now print usage and exit 2.

## Shape

| | |
|---|---|
| New packages | `internal/weather` (store-neutral `Observation`/`Gap`/`Bounds`), `internal/backfill` (chunking, retry classification, gap assembly, the `Run` core) |
| Modified | `internal/tempestapi`, `internal/sqlite`, `internal/postgres`, `main.go` |
| Scope | 28 files, +9907/−106 — of which **26 files, +4772/−106 is code**; the other 2 files (+5135) are the design and plan documents, which landed on this branch |
| Dependencies | **none added** — `go.mod`/`go.sum` byte-identical |

## Design points worth knowing at review time

- **`PARTITION BY serial_number`** in both gap queries is not optional. Without it, two stations phase-offset by ~30s mask each other and a multi-hour outage is undetectable — the tool reports "no gaps" and exits 0.
- **The serial pre-flight is disjoint-sets**, not "some API serial missing". It stops only when the API's serials and a *non-empty* store's serials have no overlap at all — the signature of a serial-format mismatch that would create a parallel series that never dedupes. A newly added station, or one this host never hears over UDP, is explicitly **not** a mismatch.
- **`DistinctSerials` is unwindowed; `SeriesBounds` is windowed.** Feeding the pre-flight the windowed key set would false-positive on any station quiet during the requested window, breaking `--from/--to`.
- **Window vs insert errors are asymmetric.** A failed *window* logs and continues; a failed *insert* aborts the gap. Reversing either loses windows permanently across runs, or hammers a dying store.
- **Insert batches bounded to 200 rows** — a long transaction contends with live ingest, whose error path only logs, so an unbounded transaction could lose live observations while repairing historical ones.
- **Nulls never become zeros.** Every measurement is `*float64` end to end, so a JSON null lands as SQL NULL rather than a physically meaningful `0.0`.
- **`ListDevices`, not `ListStations`** — the latter collapses each station to a single ST device, so a two-Tempest station would leave one sensor permanently unrepaired and unlogged.
- **One store per run.** With both stores configured the daemon fans out to each; backfill refuses without `--store` rather than guessing, since repairing Postgres while leaving the Litestream-replicated SQLite database holed and then exiting 0 is the worst available outcome.

## Verification

Gate: `CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./... -race` — **365 tests across 16 packages, golangci-lint 0 issues, `gofmt -l .` silent.**

Beyond the gate:

- **The Postgres integration test was run against a real PostgreSQL 16**, not skipped — it is `POSTGRES_URL`-gated, and a skipped run is not evidence.
- **CLI behavior verified against the built binary**: `backfil` → exit 2 with usage, no hang; `--help` → exit 0; both stores configured without `--store` → exit 2, nothing written.
- **Mutation-tested.** Every task was reviewed adversarially, and reviewers used `go test -overlay` to demonstrate surviving mutants rather than assert them. Gaps found and closed this way included `chunkWindow` tests that a 720-hour-window mutant passed, an interior-serial filter whose deletion left the suite green, `Stats.Returned` being deletable with 47 tests passing, a cancellation test that passed while the run did every API call first, and an RFC3339-rejection test that passed via a different error branch.

## Deliberate non-goals

- `tempest_rapid_wind`, `tempest_hub_status`, `tempest_events` are **not** backfilled — no historical REST endpoint exists for any of them.
- `ModeAPIExport` and `sqlite.WriteMetrics` are unchanged. `ListStations` keeps its collapsing behavior (a test pins it) because `ModeAPIExport` depends on it.
- No `--json` output; `slog` attributes are the machine-readable surface.

## Known follow-ups (filed, not blockers)

#107 · #108 · #109 · #110 · #111 — schema divergence between the two stores, `detectFrom` flooring and progress logging, an untested convergence log, an unpinned `ListDevices` choice, and a pre-existing drain-on-close bug this branch surfaced but did not cause.

## Note on sequencing

Intended to absorb the P1 fixes into 3.1.0 rather than shipping a separate patch. **PR #106 has zero file overlap with this branch**, so ordering between them is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D
