### PR TITLE
fix(sqlite): conform three measurement columns to float across both stores

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -2,6 +2,15 @@
 name: Tests
 description: Runs the full Go quality gate — format, build, vet, lint, and race-enabled tests
 
+inputs:
+  postgres-url:
+    description: >-
+      Connection string for a Postgres instance the test suite can use. When
+      empty, internal/postgres's integration tests skip themselves, which is
+      the correct behaviour for a local run without a database.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -83,6 +92,8 @@ runs:
     - name: Run all Tests
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        POSTGRES_URL: ${{ inputs.postgres-url }}
       run: |
         go version
         START_TIME=$(date +%s)

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -14,12 +14,36 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      # The Postgres-backed tests in internal/postgres are guarded on
+      # POSTGRES_URL and skip without it, so before this they never ran in CI
+      # and the Postgres half of the store was asserted by nothing. Only the
+      # standard untagged suite runs -- `-tags integration` is deliberately not
+      # enabled, because it holds the known-failing drain-on-close test (#111).
+      postgres:
+        # Floating tag, deliberately: every action in this repo is SHA-pinned,
+        # but a test-only service container is not a supply-chain surface the
+        # way an action that runs with repo credentials is, and Renovate keeps
+        # the three copies of this block in step by matching the tag string.
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: weather
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
+        with:
+          postgres-url: "postgres://postgres:postgres@localhost:5432/weather?sslmode=disable"
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -20,12 +20,36 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      # The Postgres-backed tests in internal/postgres are guarded on
+      # POSTGRES_URL and skip without it, so before this they never ran in CI
+      # and the Postgres half of the store was asserted by nothing. Only the
+      # standard untagged suite runs -- `-tags integration` is deliberately not
+      # enabled, because it holds the known-failing drain-on-close test (#111).
+      postgres:
+        # Floating tag, deliberately: every action in this repo is SHA-pinned,
+        # but a test-only service container is not a supply-chain surface the
+        # way an action that runs with repo credentials is, and Renovate keeps
+        # the three copies of this block in step by matching the tag string.
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: weather
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
+        with:
+          postgres-url: "postgres://postgres:postgres@localhost:5432/weather?sslmode=disable"
 
   release-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,12 +12,36 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      # The Postgres-backed tests in internal/postgres are guarded on
+      # POSTGRES_URL and skip without it, so before this they never ran in CI
+      # and the Postgres half of the store was asserted by nothing. Only the
+      # standard untagged suite runs -- `-tags integration` is deliberately not
+      # enabled, because it holds the known-failing drain-on-close test (#111).
+      postgres:
+        # Floating tag, deliberately: every action in this repo is SHA-pinned,
+        # but a test-only service container is not a supply-chain surface the
+        # way an action that runs with repo credentials is, and Renovate keeps
+        # the three copies of this block in step by matching the tag string.
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: weather
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Tests
         uses: ./.github/actions/tests
+        with:
+          postgres-url: "postgres://postgres:postgres@localhost:5432/weather?sslmode=disable"
 
   release-image:
     runs-on: ubuntu-latest

--- a/docs/designs/2026-08-02-sqlite-float-conformance-design.md
+++ b/docs/designs/2026-08-02-sqlite-float-conformance-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#107](https://github.com/jacaudi/tempestwx-utilities/issues/107)
 **Date:** 2026-08-02
-**Status:** proposed
+**Status:** proposed (revised after Gate 1 review)
 **Branch point:** `a1b07f1`
 
 ## Goal
@@ -11,15 +11,15 @@ Stop three measurement columns from being silently truncated to integers on the
 SQLite write path, so the SQLite and Postgres stores hold the same value for the
 same observation, and make the SQLite DDL declare the type it actually stores.
 
-## The defect, correctly stated
+## What #107 gets wrong, and what it gets right
 
-Issue #107 describes the problem as a *read* failure: a fractional value is
-stored with `REAL` affinity and the `*int64` read model then fails for the whole
-query. **That framing is wrong, and the correction matters because it changes
-what the fix is.**
+#107 describes the problem as a *read* failure: a fractional value is stored with
+`REAL` affinity and the `*int64` read model then fails for the whole query, so
+"the current-observation endpoint breaks for that station."
 
-No fractional value can reach these columns from either write path, because both
-truncate in Go before binding:
+**The mechanism is real; the reachability claim is not.** No fractional value can
+reach these columns from either production write path, because both truncate in
+Go before binding:
 
 | Path | Site | Conversion |
 |---|---|---|
@@ -27,41 +27,57 @@ truncate in Go before binding:
 | REST backfill | `internal/sqlite/backfill.go:173,176,177` | `asInt64(...)` (`:202`) |
 
 `asInt64`'s own doc comment names the exact crash #107 describes and exists to
-prevent it.
+prevent it. Those are the only two writers to `tempest_observations` — the sole
+callers of `insertObservationSQL` are `writer.go:635` and `backfill.go:170`.
 
-### Verified by probe, not assumed
-
-Run against `modernc.org/sqlite` (the driver this project uses), in-memory,
-declaring one table `INTEGER` and one `REAL`:
-
-```
-INTEGER-declared, bound float 1.5 -> stored typeof=real    value=1.5   (NOT truncated)
-INTEGER-declared, bound float 5.0 -> stored typeof=integer value=5
-REAL-declared,    bound float 5.0 -> stored typeof=real    value=5
-
-sql.NullInt64   scan of 5.0 -> 5       (succeeds in BOTH declared types)
-sql.NullInt64   scan of 1.5 -> ERROR   (fails    in BOTH declared types)
-sql.NullFloat64 scan        -> 1.5 / 5 / 2.6 correct in BOTH declared types
-```
-
-Two conclusions follow:
-
-1. **SQLite's `INTEGER` declaration was never lossy.** Affinity stores `1.5` as
-   `REAL` rather than truncating it. The DDL is not where data was being lost.
-2. **The declared type is nearly irrelevant to the crash.** An integral value
-   scans into `NullInt64` fine even in a `REAL` column; a fractional one fails
-   even there. Changing the DDL alone fixes nothing.
+**This does not change the fix.** #107's Scope items 2 and 3 are the Go changes
+below, near-identically. What the reframing changes is the *severity story* (an
+unreachable crash versus a live cross-store divergence) and, separately, the
+migration strategy — and that changed for an unrelated reason, the scope decision
+below, not because of the diagnosis.
 
 ### What is actually broken
 
 Silent truncation in Go. The same observation is persisted as `1.5` in Postgres
 (`DOUBLE PRECISION`, `*float64` end to end) and as `1` in SQLite. That is a
-cross-store data divergence, and it is reachable today through the normal
-backfill path.
+cross-store data divergence, reachable today through the normal backfill path.
 
-Postgres needs no change: `internal/postgres/schema.go:43,58,61` already declares
-all three `DOUBLE PRECISION`, and `internal/postgres/writer.go`'s `observationRow`
-carries them as `*float64`.
+## SQLite affinity — measured, with the correction
+
+Probed against `modernc.org/sqlite`, in-memory, one table declared `INTEGER`
+(`ti`) and one `REAL` (`tr`):
+
+```
+ti bind 1.5          -> typeof=real     value=1.5      (NOT truncated)
+ti bind 5            -> typeof=integer  NullInt64=5
+tr bind 5            -> typeof=real     NullInt64=5
+ti bind 999999       -> typeof=integer  NullInt64=999999
+tr bind 999999       -> typeof=real     NullInt64=999999
+ti bind 1e+06        -> typeof=integer  NullInt64=1000000
+tr bind 1e+06        -> typeof=real     NullInt64 ERROR ("1e+06": invalid syntax)
+tr bind 8.388608e+06 -> typeof=real     NullInt64 ERROR ("8.388608e+06": invalid syntax)
+```
+
+1. **`INTEGER` affinity was never lossy.** It stores `1.5` as `REAL` rather than
+   truncating. The DDL is not where data was being lost — Go is.
+2. **The declared type matters, and it favours `INTEGER` for `NullInt64` reads.**
+   `INTEGER` affinity converts a lossless integral float to integer storage, so a
+   `NullInt64` scan works at any magnitude. `REAL` affinity keeps it a float, and
+   `database/sql` converts float64→int64 via
+   `strconv.FormatFloat(v, 'g', -1, 64)`, which switches to scientific notation at
+   exponent ≥ 6 — so a `NullInt64` scan from a `REAL` column **fails at ≥ 1e6**.
+
+> **Correction.** An earlier revision of this design stated conclusion 2 as "the
+> declared type is nearly irrelevant to the crash; an integral value scans into
+> `NullInt64` fine even in a `REAL` column." That was generalised from a probe of
+> three small values (`1.5`, `5.0`, `2.6`) and is false at scale, in the opposite
+> direction. Caught by Gate 1 review and re-verified.
+
+**Practical reach for these three columns: nil.** A lightning strike count per
+minute, a wind sample interval in seconds, and a report interval in minutes do
+not approach 1e6. The magnitude hazard is why the *claim* had to be corrected,
+not a live risk — but it does mean every `NullInt64` read of a now-`REAL` column
+must be changed, because "it still passes today" is not evidence of correctness.
 
 ## Scope decision
 
@@ -70,9 +86,17 @@ compatible with. The schema is therefore rewritten to what it should be, rather
 than patched forward with a rebuild migration. `0002` is folded into `0001` and
 deleted; no `0003` is created.
 
-This is only sound because there are no databases to migrate. It is recorded
-here so a future reader does not mistake it for a general licence to edit applied
+This is only sound because there are no databases to migrate. It is recorded here
+so a future reader does not mistake it for a general licence to edit applied
 migrations.
+
+**The premise is load-bearing and unverifiable from here.** `0001_init.sql` and
+`0002_add_timestamp_index.sql` both shipped in v3.0.0 and v3.1.0 (`git ls-tree`
+confirms), so a database at `schema_version = 2` *could* exist. If one did, the
+consequence is worse than keeping stale column types: `Migrate` skips any file
+whose `version <= current` (`internal/sqlite/schema.go:39`), so the folded `0001`
+is skipped **and so is every future migration numbered `0002`** — silently, with
+no error and no log. See "Fail loud on a future database" below.
 
 ## Changes
 
@@ -83,15 +107,32 @@ migrations.
 - `report_interval` `INTEGER` → `REAL`
 - `precip_type` stays `INTEGER` — a categorical enum, not a measurement, and it
   already agrees with Postgres. Conformance means the two backends agree *per
-  column*, not that all four columns share one type.
+  column*, not that all four share one type.
 - Drop the now-false `-- INTEGER not float (fix B-LOW)` comment.
 - Fold in `CREATE INDEX IF NOT EXISTS idx_obs_time ON tempest_observations(timestamp)`
-  from `0002`, **carrying its rationale comment verbatim**. That comment is the
-  only record of why the index exists (`idx_obs_serial_time` leads with
+  from `0002`, placed with `idx_obs_serial_time` after the `CREATE TABLE`
+  statements (`:29`). Carry its rationale comment — that comment is the only
+  record of why the index exists (`idx_obs_serial_time` leads with
   `serial_number`, so `LatestObservationAny` and `HistoryPoints` cannot use it);
-  losing it invites a later reader to delete the index as redundant.
+  losing it invites a later reader to delete the index as redundant. **Drop the
+  `(0001_init.sql)` parenthetical**, which becomes self-referential once folded.
 
 ### Delete `internal/sqlite/migrations/0002_add_timestamp_index.sql`
+
+### Fail loud on a future database — `internal/sqlite/schema.go`
+
+Add to `Migrate`: if `current` exceeds the highest version present in
+`migrationsFS`, return an error naming both numbers instead of silently applying
+nothing.
+
+This does not reopen the fold decision — it converts the fold's one silent
+failure mode into a startup failure, matching the project's existing posture
+("If the SQLite database cannot be opened, the process exits on startup",
+`CLAUDE.md`). It also covers the general case of a downgraded binary meeting a
+newer database. Roughly two lines plus a test.
+
+*This is an addition beyond #107's scope, included because the stated goal is a
+production-ready schema. Drop it if unwanted.*
 
 ### `internal/sqlite/writer.go`
 
@@ -101,81 +142,161 @@ migrations.
 | `:113` | `precipType` stays `*int64` |
 | `:437,446,455` | drop the `int64(...)` conversions |
 | `:441` | `precipType` keeps `int64(ob[13])` |
-| `:760-761` | three columns `sql.NullInt64` → `sql.NullFloat64`; `precipType` stays `NullInt64` |
+| `:760-761` | three columns `sql.NullInt64` → `sql.NullFloat64`; `precipType` stays `NullInt64`. Note `:760` declares `windSampleInterval, precipType` on one line — the split is required, not optional |
 | `:720,731,733` | public `Observation` three fields `*int64` → `*float64` |
 | `:948` | `Summary.LightningTotal` `sql.NullInt64` → `sql.NullFloat64` |
+| `:87-95` | `observationRow` doc comment — states the `*int64` divergence from Postgres as deliberate |
+| `:399-403` | `handleObservationReport` doc comment — "INTEGER-typed columns are converted to int64 (fix B-LOW)" |
 
-`Summary.LightningTotal` is load-bearing and easy to miss: it scans
-`SUM(lightning_strike_count)` (`:960`). Once that column holds `REAL`, the sum
-returns `REAL` and a `NullInt64` scan fails — the summary endpoint breaks at
-runtime while every compile-time check passes.
-
-Also update the `observationRow` doc comment at `:87-95`, which currently states
-the `*int64` divergence from Postgres as deliberate.
+**`Summary.LightningTotal` is the one site that fails silently.** It scans
+`SUM(lightning_strike_count)` (`:960`). The failure is *not* "the sum returns
+REAL and the scan fails" — measured, `SUM(2,3)` over a `REAL` column returns
+`typeof=real` and scans into `NullInt64` as `5` **successfully**. It fails only
+on a fractional sum (`SUM(2.5,3)` → `5.5` → scan error) or at ≥ 1e6. So leaving
+it as `NullInt64` compiles, passes every existing test, and breaks in production
+the first time a fractional strike count is summed.
 
 ### `internal/sqlite/backfill.go`
 
 - Delete `asInt64` (`:202`) and bind `WindSampleInterval`, `LightningStrikeCount`,
   and `ReportInterval` directly from `weather.Observation` (already `*float64`).
 - `precip_type` still needs a `*float64` → `*int64` conversion. Keep a helper for
-  that one column, named for what it does rather than the general shape it used
-  to have.
-- Update the `InsertObservations` doc comment (`:161-163`).
+  that one column; the plan names it.
+- **Do not** edit the `InsertObservations` doc comment at `:161-163`. Its
+  rationale — that `observationRow`'s leading fields are non-pointer `float64`,
+  so routing through it would coerce a JSON null to `0.0` — remains true and
+  correct after the change (`writer.go:100-103` are unchanged). The comment that
+  goes stale is `asInt64`'s at `:194-201`, and it is deleted with the function.
 
 ### `internal/httpserver/observations.go`
 
+Exactly three edits:
+
 - `:70,80,82` `int64` → `float64`
 - `:130` `LightningTotal *int64` → `*float64`
-- the `deref` / `i64` helpers follow
+- `:280` `i64(s.LightningTotal)` → `f64(s.LightningTotal)`. **`f64` already exists**
+  and is used for `TempMax`, `RainTotal`, and the rest — no new helper is needed
 
-This is the public JSON contract the TypeScript UI consumes, so it is called out
-explicitly rather than treated as an internal ripple. The change is nearly
+**`deref` (`:342`) needs no change** — it is generic, `func deref[T any](p *T) T`.
+**`i64` (`:154`) must be kept**, not converted or deleted: it serves
+`CoveredFrom`/`CoveredTo` at `:272,273`, which are `MIN/MAX(timestamp)` over an
+`INTEGER` column and stay `NullInt64`. Changing them would silently alter two
+wire fields this design does not intend to touch.
+
+This is the public JSON contract the TypeScript UI consumes. The change is nearly
 invisible on the wire: Go marshals `float64(5)` as `5`, not `5.0`, so every
-integral value serialises byte-identically. Only a genuinely fractional value
-looks different — which is the point of the change.
+integral value serialises byte-identically (verified for `0` through `2^53`;
+divergence begins at ≥ 1e21, unreachable here). Only a genuinely fractional value
+looks different — which is the point. `web/src/types/weather.ts:21,31,33,150`
+already types these as `number`, so no TypeScript change is needed. Note CI has
+no web/TypeScript step, so that claim is not machine-checked.
+
+### `internal/postgres/backfill.go`
+
+`:159` binds `o.PrecipType` — a `*float64` — into `precip_type INTEGER`
+(`schema.go:55`). pgx truncates it silently (`pgtype/builtin_wrappers.go:358-364`,
+`int64(w)` with no error). The stored value is correct and agrees with SQLite, so
+this is not a correctness defect, but it is the same implicit truncation this
+design is removing elsewhere, and Postgres's *daemon* path already converts
+explicitly (`writer.go:45,541`). Make the backfill path convert explicitly too,
+for symmetry with the SQLite helper.
+
+This is #107's Scope item 4, which an earlier revision dropped without saying so.
 
 ### Not touched
 
-- `internal/postgres/**` — already correct.
+- `internal/postgres/schema.go` and `writer.go` — the three columns are already
+  `DOUBLE PRECISION` / `*float64`.
 - `internal/weather/observation.go` — already `*float64`.
-- The `schema_version` machinery itself.
+- The `schema_version` mechanism itself, beyond the fail-loud guard above.
+
+## Test and comment sites the change list must cover
+
+These compile-break or, worse, keep passing while asserting nothing:
+
+| Site | Nature |
+|---|---|
+| `internal/sqlite/writer_test.go:76,81,83,95,98,99` | **silent survivor** — declares the three as plain `int64` and raw-scans them; seeded `3,4,5` still scan fine from a `REAL` column, so the test stays green while proving nothing. Must move to `float64` |
+| `internal/sqlite/litestream_test.go:48,49,63,75,81` | `sql.NullInt64` scans, `&x.Int64` assignment. Live, not skipped — `litestream` is on PATH and CI installs it |
+| `internal/sqlite/summary_test.go:22,31,32,33,51,52` | compile break on `.Int64` / `%d` |
+| `internal/httpserver/observations_test.go:70,72,82,92,94,325` | `int64(...)` locals assigned into `sqlite.Observation`; `sql.NullInt64{}` literal |
+| `internal/sqlite/backfill_test.go:381,392` | compile break |
+| `internal/sqlite/schema_test.go:37-41` | comment references the deleted `0002_add_timestamp_index.sql` |
+| `internal/sqlite/backfill_test.go:241-253,263,271,273,275` | comments asserting the INTEGER-column rationale |
 
 ## Testing
 
-TDD has a real red state available without inventing one.
-`internal/sqlite/backfill_test.go:358-406` currently **asserts the truncation**:
-`want %d (truncated from the fractional API value...)`. Inverting it to assert
-the fractional value round-trips fails against today's code and passes after.
-
 | Test | Purpose |
 |---|---|
-| invert `backfill_test.go:358-406` | fractional value survives the REST path |
+| rework `backfill_test.go:350-410` | fractional value survives the REST path. **`precip_type` must NOT be inverted** — it is one of the four columns this test covers (`PrecipType: f(1.9)` at `:369`, asserting `1` at `:397`) and it must still truncate. Only the other three flip |
 | new: UDP path round-trip | fractional value survives `handleObservationReport` |
+| new: fractional `SUM` | seed a fractional `lightning_strike_count`, assert the summed total. This is the only thing that catches a missed `LightningTotal` — the existing summary tests seed `2` and `3` and pass either way |
 | new: `pragma_table_info` assertion | the three columns declare `REAL` |
+| new: `Migrate` fail-loud | a database at a version higher than any bundled migration errors rather than no-opping |
 | `schema_test.go:43,50` | `assertSchemaVersion` 2 → 1 |
 | existing `idx_obs_time` assertion | unchanged — proves the fold did not drop the index |
-| existing summary tests | cover the `LightningTotal` type change |
+
+**Known gap:** #107 asks for a fractional round-trip "through both stores." The
+Postgres round-trip is not covered here — `internal/postgres/backfill_test.go`
+seeds only integral values, and those tests skip without `POSTGRES_URL`, so CI
+proves nothing there either. Stated rather than silently omitted.
+
+**TDD note.** The genuine red state is the reworked `backfill_test.go` assertion
+and the new fractional-`SUM` test. Compile errors do not count as a failing test
+(per this project's own standard, `docs/designs/2026-07-28-api-backfill-tool-design.md:449`),
+so the many compile breaks above are mechanical fixes, not evidence.
 
 ## Consequences
 
 - SQLite and Postgres agree on stored values for these three columns.
 - The SQLite DDL declares what it stores.
-- `precip_type` remains the one integer measurement-adjacent column, in both
-  stores, by intent.
-- Fresh installs apply `0001` and land at `schema_version = 1`. The next
-  migration is `0002`, in normal sequence.
+- `precip_type` remains an integer in both stores **and still truncates silently**
+  — in Go on the SQLite path, in pgx on the Postgres path. That is intended
+  coercion of a categorical value, not an oversight.
+- Fresh installs apply `0001` and land at `schema_version = 1`; the next migration
+  is `0002`, in normal sequence. **If the "nothing is deployed" premise is wrong,
+  a `schema_version = 2` database silently skips both this schema and any future
+  `0002`** — which the fail-loud guard converts into a startup error.
 - The JSON API can now return a fractional `windSampleInterval`,
   `lightningStrikeCount`, `reportInterval`, or `lightningTotal`. No consumer
-  breaks on this — JSON has no integer type — but it is a contract widening.
+  breaks — JSON has no integer type — but the UI renders these raw
+  (`web/src/components/LightningCard.tsx:25`,
+  `RecordsCard.tsx:111-112`), so a fractional value would display as
+  "2.5 strikes". Cosmetic, and only if the API ever returns one.
+- Widening `lightningTotal` on the wire is a *choice*, not forced —
+  `CAST(SUM(...) AS INTEGER)` would have avoided it. A fractional column implies a
+  fractional sum, so widening is the honest option.
+- **New unstated-assumption made explicit:** these fields can now carry non-finite
+  floats into `json.Encoder`, which errors *after* the 200 status line — the
+  failure `sanitize()` exists to prevent (`internal/httpserver/observations.go:350-357`).
+  Unreachable today because both ingest paths decode via `encoding/json` and JSON
+  has no `NaN`/`Infinity` literal. That is now load-bearing.
 
 ## Could not verify
 
-- **Whether WeatherFlow ever actually returns a fractional value** for these
-  three fields in practice. The REST API's `obs` arrays are JSON numbers, so it
-  *can*; whether it *does* was not established. The fix is therefore correctness
-  insurance against a divergence that may currently be latent, not a repair of
-  observed bad data.
-- **Whether any database anywhere is at `schema_version = 2`.** This rests on
-  the stated fact that nothing is deployed. `0001` and `0002` did ship in v3.0.0
-  and v3.1.0, so such a database *could* exist; the scope decision above assumes
-  none does.
+- **Whether WeatherFlow ever returns a fractional value** for these three fields.
+  No token, no live call. The fix is correctness insurance against a possibly
+  latent divergence, not a repair of observed bad data.
+
+  This repo already contains a conflicting claim:
+  `docs/designs/2026-07-28-api-backfill-tool-design.md:458` asserts under a
+  "verified by execution" heading that "the Tempest API supplies integral values
+  there." That claim is unsourced for the API-behaviour half (the measured part
+  was pgx truncation) and conflates the stores — three of those four columns are
+  `DOUBLE PRECISION` in Postgres, not `INTEGER`. This design's hedge supersedes
+  it; the older document should be annotated rather than left to disagree.
+- **Whether any database is at `schema_version = 2`.** A binary producing one
+  shipped twice. This rests on the owner's stated fact.
+- **pgx's `*float64` → `INTEGER` behaviour against a live PostgreSQL** — verified
+  by reading `pgtype/builtin_wrappers.go:358-364`, not by execution.
+- **Whether the Litestream round-trip passes post-change** — not run, since the
+  change is not applied.
+
+## Disposition of #107's acceptance criteria
+
+- "`asInt64` is gone" — satisfied in name; a renamed single-column helper remains
+  for `precip_type`, by design.
+- "The SQLite rebuild migration preserves existing rows" — moot under the scope
+  decision; there is no rebuild migration.
+- "A fractional API value round-trips losslessly through both stores" — SQLite
+  covered, Postgres gap stated above.

--- a/docs/designs/2026-08-02-sqlite-float-conformance-design.md
+++ b/docs/designs/2026-08-02-sqlite-float-conformance-design.md
@@ -203,6 +203,42 @@ for symmetry with the SQLite helper.
 
 This is #107's Scope item 4, which an earlier revision dropped without saying so.
 
+### Postgres smoke coverage in CI
+
+Today every Postgres-dependent test skips in CI, so the Postgres half of this
+change is asserted by nothing. Add a Postgres service container and set
+`POSTGRES_URL`, so the standard suite exercises it for real.
+
+**Placement is forced.** `services:` is a job-level workflow key; a composite
+action cannot declare one, and `.github/actions/tests` is composite. So the
+service block goes in the three workflows that call it —
+`on-pull-request.yml:22`, `on-push-main.yml:28`, `on-release.yml:20` — and the
+action gains a `POSTGRES_URL` pass-through.
+
+That triplicates the block, which is a DRY cost. It is accepted rather than
+worked around: the alternative (starting Postgres with `docker run` inside the
+composite action, single-sourced) hides the image tag from Renovate, and this
+repo actively relies on Renovate to keep Docker tags current. A `services:`
+image is scanned; a tag buried in a `run:` string is not. Renovate updating all
+three in one PR is what makes the duplication safe.
+
+**Scope: the standard, untagged suite only.** The test this activates is
+`internal/postgres/backfill_test.go:89-91`, which skips on missing
+`POSTGRES_URL`. `internal/postgres/writer_integration_test.go` is behind
+`//go:build integration` and is **not** enabled — it contains the known-failing
+`TestPostgresWriter_DrainOnClose_Integration` from #111, which would turn CI red.
+Enabling the integration tag is deliberately left to #111.
+
+With this in place, the Postgres fractional round-trip test is worth adding —
+`internal/postgres/backfill_test.go` currently seeds only integral values
+(`f(3)`, `f(25)`, `f(35)`), so it would not catch a regression on the Postgres
+side of the conformance this design establishes.
+
+**Check for interference:** `internal/config/database_test.go` reads and writes
+`POSTGRES_URL` via `t.Setenv`, which overrides the ambient value per-test and
+restores it, so a globally-set `POSTGRES_URL` should not disturb it. Verify by
+running the suite with the variable set.
+
 ### Not touched
 
 - `internal/postgres/schema.go` and `writer.go` — the three columns are already
@@ -236,10 +272,14 @@ These compile-break or, worse, keep passing while asserting nothing:
 | `schema_test.go:43,50` | `assertSchemaVersion` 2 → 1 |
 | existing `idx_obs_time` assertion | unchanged — proves the fold did not drop the index |
 
-**Known gap:** #107 asks for a fractional round-trip "through both stores." The
-Postgres round-trip is not covered here — `internal/postgres/backfill_test.go`
-seeds only integral values, and those tests skip without `POSTGRES_URL`, so CI
-proves nothing there either. Stated rather than silently omitted.
+| new: Postgres fractional round-trip | `internal/postgres/backfill_test.go` — closes #107's "through both stores" criterion. Real coverage now that CI sets `POSTGRES_URL` |
+
+**Gap closed.** An earlier revision listed the Postgres round-trip as a known
+omission because those tests skip without `POSTGRES_URL`. The CI service
+container above removes that excuse, so the test is in scope.
+
+**Still not covered:** anything behind `//go:build integration`, by decision —
+see #111.
 
 **TDD note.** The genuine red state is the reworked `backfill_test.go` assertion
 and the new fractional-`SUM` test. Compile errors do not count as a failing test
@@ -298,5 +338,6 @@ so the many compile breaks above are mechanical fixes, not evidence.
   for `precip_type`, by design.
 - "The SQLite rebuild migration preserves existing rows" — moot under the scope
   decision; there is no rebuild migration.
-- "A fractional API value round-trips losslessly through both stores" — SQLite
-  covered, Postgres gap stated above.
+- "A fractional API value round-trips losslessly through both stores" — satisfied
+  for both, and the Postgres half is now genuinely exercised in CI rather than
+  skipped.

--- a/docs/designs/2026-08-02-sqlite-float-conformance-design.md
+++ b/docs/designs/2026-08-02-sqlite-float-conformance-design.md
@@ -253,7 +253,7 @@ These compile-break or, worse, keep passing while asserting nothing:
 | Site | Nature |
 |---|---|
 | `internal/sqlite/writer_test.go:76,81,83,95,98,99` | **silent survivor** — declares the three as plain `int64` and raw-scans them; seeded `3,4,5` still scan fine from a `REAL` column, so the test stays green while proving nothing. Must move to `float64` |
-| `internal/sqlite/litestream_test.go:48,49,63,75,81` | `sql.NullInt64` scans, `&x.Int64` assignment. Live, not skipped — `litestream` is on PATH and CI installs it |
+| `internal/sqlite/litestream_test.go:48,49,63,75,81` | `sql.NullInt64` scans, `&x.Int64` assignment. **Correction:** an earlier revision said "CI installs litestream" — it does not (`grep -rn -i litestream .github/` returns nothing), so this test SKIPS in CI and runs only where litestream is on PATH locally. It still must be fixed; it just is not gated |
 | `internal/sqlite/summary_test.go:22,31,32,33,51,52` | compile break on `.Int64` / `%d` |
 | `internal/httpserver/observations_test.go:70,72,82,92,94,325` | `int64(...)` locals assigned into `sqlite.Observation`; `sql.NullInt64{}` literal |
 | `internal/sqlite/backfill_test.go:381,392` | compile break |

--- a/docs/designs/2026-08-02-sqlite-float-conformance-design.md
+++ b/docs/designs/2026-08-02-sqlite-float-conformance-design.md
@@ -1,0 +1,181 @@
+# SQLite float conformance — design
+
+**Issue:** [#107](https://github.com/jacaudi/tempestwx-utilities/issues/107)
+**Date:** 2026-08-02
+**Status:** proposed
+**Branch point:** `a1b07f1`
+
+## Goal
+
+Stop three measurement columns from being silently truncated to integers on the
+SQLite write path, so the SQLite and Postgres stores hold the same value for the
+same observation, and make the SQLite DDL declare the type it actually stores.
+
+## The defect, correctly stated
+
+Issue #107 describes the problem as a *read* failure: a fractional value is
+stored with `REAL` affinity and the `*int64` read model then fails for the whole
+query. **That framing is wrong, and the correction matters because it changes
+what the fix is.**
+
+No fractional value can reach these columns from either write path, because both
+truncate in Go before binding:
+
+| Path | Site | Conversion |
+|---|---|---|
+| UDP ingest | `internal/sqlite/writer.go:437,446,455` | `int64(ob[5])`, `int64(ob[15])`, `int64(ob[17])` |
+| REST backfill | `internal/sqlite/backfill.go:173,176,177` | `asInt64(...)` (`:202`) |
+
+`asInt64`'s own doc comment names the exact crash #107 describes and exists to
+prevent it.
+
+### Verified by probe, not assumed
+
+Run against `modernc.org/sqlite` (the driver this project uses), in-memory,
+declaring one table `INTEGER` and one `REAL`:
+
+```
+INTEGER-declared, bound float 1.5 -> stored typeof=real    value=1.5   (NOT truncated)
+INTEGER-declared, bound float 5.0 -> stored typeof=integer value=5
+REAL-declared,    bound float 5.0 -> stored typeof=real    value=5
+
+sql.NullInt64   scan of 5.0 -> 5       (succeeds in BOTH declared types)
+sql.NullInt64   scan of 1.5 -> ERROR   (fails    in BOTH declared types)
+sql.NullFloat64 scan        -> 1.5 / 5 / 2.6 correct in BOTH declared types
+```
+
+Two conclusions follow:
+
+1. **SQLite's `INTEGER` declaration was never lossy.** Affinity stores `1.5` as
+   `REAL` rather than truncating it. The DDL is not where data was being lost.
+2. **The declared type is nearly irrelevant to the crash.** An integral value
+   scans into `NullInt64` fine even in a `REAL` column; a fractional one fails
+   even there. Changing the DDL alone fixes nothing.
+
+### What is actually broken
+
+Silent truncation in Go. The same observation is persisted as `1.5` in Postgres
+(`DOUBLE PRECISION`, `*float64` end to end) and as `1` in SQLite. That is a
+cross-store data divergence, and it is reachable today through the normal
+backfill path.
+
+Postgres needs no change: `internal/postgres/schema.go:43,58,61` already declares
+all three `DOUBLE PRECISION`, and `internal/postgres/writer.go`'s `observationRow`
+carries them as `*float64`.
+
+## Scope decision
+
+Nothing is deployed and no database exists anywhere that this must remain
+compatible with. The schema is therefore rewritten to what it should be, rather
+than patched forward with a rebuild migration. `0002` is folded into `0001` and
+deleted; no `0003` is created.
+
+This is only sound because there are no databases to migrate. It is recorded
+here so a future reader does not mistake it for a general licence to edit applied
+migrations.
+
+## Changes
+
+### `internal/sqlite/migrations/0001_init.sql`
+
+- `wind_sample_interval` `INTEGER` → `REAL`
+- `lightning_strike_count` `INTEGER` → `REAL`
+- `report_interval` `INTEGER` → `REAL`
+- `precip_type` stays `INTEGER` — a categorical enum, not a measurement, and it
+  already agrees with Postgres. Conformance means the two backends agree *per
+  column*, not that all four columns share one type.
+- Drop the now-false `-- INTEGER not float (fix B-LOW)` comment.
+- Fold in `CREATE INDEX IF NOT EXISTS idx_obs_time ON tempest_observations(timestamp)`
+  from `0002`, **carrying its rationale comment verbatim**. That comment is the
+  only record of why the index exists (`idx_obs_serial_time` leads with
+  `serial_number`, so `LatestObservationAny` and `HistoryPoints` cannot use it);
+  losing it invites a later reader to delete the index as redundant.
+
+### Delete `internal/sqlite/migrations/0002_add_timestamp_index.sql`
+
+### `internal/sqlite/writer.go`
+
+| Site | Change |
+|---|---|
+| `:104,115,117` | `observationRow` three fields `*int64` → `*float64` |
+| `:113` | `precipType` stays `*int64` |
+| `:437,446,455` | drop the `int64(...)` conversions |
+| `:441` | `precipType` keeps `int64(ob[13])` |
+| `:760-761` | three columns `sql.NullInt64` → `sql.NullFloat64`; `precipType` stays `NullInt64` |
+| `:720,731,733` | public `Observation` three fields `*int64` → `*float64` |
+| `:948` | `Summary.LightningTotal` `sql.NullInt64` → `sql.NullFloat64` |
+
+`Summary.LightningTotal` is load-bearing and easy to miss: it scans
+`SUM(lightning_strike_count)` (`:960`). Once that column holds `REAL`, the sum
+returns `REAL` and a `NullInt64` scan fails — the summary endpoint breaks at
+runtime while every compile-time check passes.
+
+Also update the `observationRow` doc comment at `:87-95`, which currently states
+the `*int64` divergence from Postgres as deliberate.
+
+### `internal/sqlite/backfill.go`
+
+- Delete `asInt64` (`:202`) and bind `WindSampleInterval`, `LightningStrikeCount`,
+  and `ReportInterval` directly from `weather.Observation` (already `*float64`).
+- `precip_type` still needs a `*float64` → `*int64` conversion. Keep a helper for
+  that one column, named for what it does rather than the general shape it used
+  to have.
+- Update the `InsertObservations` doc comment (`:161-163`).
+
+### `internal/httpserver/observations.go`
+
+- `:70,80,82` `int64` → `float64`
+- `:130` `LightningTotal *int64` → `*float64`
+- the `deref` / `i64` helpers follow
+
+This is the public JSON contract the TypeScript UI consumes, so it is called out
+explicitly rather than treated as an internal ripple. The change is nearly
+invisible on the wire: Go marshals `float64(5)` as `5`, not `5.0`, so every
+integral value serialises byte-identically. Only a genuinely fractional value
+looks different — which is the point of the change.
+
+### Not touched
+
+- `internal/postgres/**` — already correct.
+- `internal/weather/observation.go` — already `*float64`.
+- The `schema_version` machinery itself.
+
+## Testing
+
+TDD has a real red state available without inventing one.
+`internal/sqlite/backfill_test.go:358-406` currently **asserts the truncation**:
+`want %d (truncated from the fractional API value...)`. Inverting it to assert
+the fractional value round-trips fails against today's code and passes after.
+
+| Test | Purpose |
+|---|---|
+| invert `backfill_test.go:358-406` | fractional value survives the REST path |
+| new: UDP path round-trip | fractional value survives `handleObservationReport` |
+| new: `pragma_table_info` assertion | the three columns declare `REAL` |
+| `schema_test.go:43,50` | `assertSchemaVersion` 2 → 1 |
+| existing `idx_obs_time` assertion | unchanged — proves the fold did not drop the index |
+| existing summary tests | cover the `LightningTotal` type change |
+
+## Consequences
+
+- SQLite and Postgres agree on stored values for these three columns.
+- The SQLite DDL declares what it stores.
+- `precip_type` remains the one integer measurement-adjacent column, in both
+  stores, by intent.
+- Fresh installs apply `0001` and land at `schema_version = 1`. The next
+  migration is `0002`, in normal sequence.
+- The JSON API can now return a fractional `windSampleInterval`,
+  `lightningStrikeCount`, `reportInterval`, or `lightningTotal`. No consumer
+  breaks on this — JSON has no integer type — but it is a contract widening.
+
+## Could not verify
+
+- **Whether WeatherFlow ever actually returns a fractional value** for these
+  three fields in practice. The REST API's `obs` arrays are JSON numbers, so it
+  *can*; whether it *does* was not established. The fix is therefore correctness
+  insurance against a divergence that may currently be latent, not a repair of
+  observed bad data.
+- **Whether any database anywhere is at `schema_version = 2`.** This rests on
+  the stated fact that nothing is deployed. `0001` and `0002` did ship in v3.0.0
+  and v3.1.0, so such a database *could* exist; the scope decision above assumes
+  none does.

--- a/docs/designs/2026-08-02-sqlite-float-conformance-design.md
+++ b/docs/designs/2026-08-02-sqlite-float-conformance-design.md
@@ -293,10 +293,24 @@ so the many compile breaks above are mechanical fixes, not evidence.
 - `precip_type` remains an integer in both stores **and still truncates silently**
   — in Go on the SQLite path, in pgx on the Postgres path. That is intended
   coercion of a categorical value, not an oversight.
-- Fresh installs apply `0001` and land at `schema_version = 1`; the next migration
-  is `0002`, in normal sequence. **If the "nothing is deployed" premise is wrong,
-  a `schema_version = 2` database silently skips both this schema and any future
-  `0002`** — which the fail-loud guard converts into a startup error.
+- ~~Fresh installs apply `0001` and land at `schema_version = 1`; the next migration
+  is `0002`, in normal sequence.~~
+
+  **Superseded during execution — the whole-branch review found this combination was
+  a blocking defect.** With the folded init numbered `0001`, `highest` is 1, so the
+  fail-loud guard rejects *any* database at version 2 — including one this very build
+  creates, then meets again after a rollback to v3.1.0 (which applies its own `0002`).
+  Reproduced end to end; roll-forward became permanently impossible, and the error
+  text was inverted, telling the operator the binary was older when it was newer.
+
+  **Resolution:** the folded init ships as `0002_init.sql`, so `highest` is 2 —
+  matching the version every released binary already reaches. Verified: fresh installs
+  land at `schema_version = 2` with `REAL` columns; rollback-then-roll-forward
+  succeeds; a legacy v3.x database (INTEGER-declared, version 2) is accepted and
+  round-trips fractional values correctly, because SQLite affinity is lossless and the
+  read path is float-tolerant. The guard still fires on a genuinely newer database
+  (version 99 → error), with corrected wording. **The next migration must be `0003`**,
+  a constraint now recorded in `0002_init.sql` itself rather than only here.
 - The JSON API can now return a fractional `windSampleInterval`,
   `lightningStrikeCount`, `reportInterval`, or `lightningTotal`. No consumer
   breaks — JSON has no integer type — but the UI renders these raw

--- a/docs/plans/2026-08-02-sqlite-float-conformance-implementation.md
+++ b/docs/plans/2026-08-02-sqlite-float-conformance-implementation.md
@@ -1,0 +1,1370 @@
+# SQLite Float Conformance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop three measurement columns being silently truncated to integers on the SQLite write
+path, so SQLite and Postgres hold the same value for the same observation, and make the SQLite DDL
+declare the type it actually stores.
+
+**Architecture:** SQLite's `INTEGER` declaration was never the lossy part — Go was. Both write paths
+convert `*float64` to `*int64` before binding. The fix removes those conversions, widens the read
+model and the JSON contract to `float64`, and changes the three columns to `REAL`. Postgres already
+stores these as `DOUBLE PRECISION` with `*float64` end to end and needs no schema change.
+
+**Tech Stack:** Go 1.25 (toolchain go1.26.1), `modernc.org/sqlite` (pure Go, `CGO_ENABLED=0`),
+`pgx/v5`, GitHub Actions.
+
+**Design:** `docs/designs/2026-08-02-sqlite-float-conformance-design.md`
+
+> **For Claude:** REQUIRED EXECUTION WORKFLOW (follow in order):
+> 1. `superpowers:using-git-worktrees` — **already satisfied.** Work happens in the existing worktree
+>    `/Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance`
+>    on branch `worktree-schema-conformance`. Do **not** create another worktree.
+> 2. `superpowers:subagent-driven-development` — fresh subagent per task
+> 3. `superpowers:test-driven-development` — mandatory for every task
+> 4. `superpowers:verification-before-completion` — verify per task
+> 5. `superpowers:requesting-code-review` — review after each task (built in)
+> 6. After all tasks: whole-diff review with `sr-eng-review`
+> 7. `superpowers:finishing-a-development-branch`
+>
+> Skills carry their own model and effort settings. Do not override them.
+
+## Global Constraints
+
+- **Work only in** `/Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance`.
+  It is a git worktree. Do **not** `cd` to the parent repo at
+  `/Users/acaudill/Projects/github/tempestwx-exporter`. The shell's cwd resets between tool calls —
+  prefix every command with `cd <worktree>` or use absolute paths.
+- Every task brief must confirm `docs/designs/2026-08-02-sqlite-float-conformance-design.md` exists;
+  if it does not, STOP and report `NEEDS_CONTEXT`.
+- **Never bypass commit signing.** 1Password's SSH agent intermittently drops keys, producing
+  `1Password: failed to fill whole buffer` / `fatal: failed to write commit object`. Retry the same
+  `git commit` two or three times. **Never** use `--no-gpg-sign`.
+- **Never use bare `git stash` / `git stash pop`** — the stash stack is shared across worktrees.
+  Use a WIP commit instead.
+- **Do not push, open a PR, or merge.** The human does that. Committing locally is expected.
+- **`CGO_ENABLED=0` is load-bearing.** Never add a cgo dependency.
+- **`precip_type` stays `INTEGER` in both stores and keeps truncating.** It is a categorical enum
+  (`0 none, 1 rain, 2 hail, 3 rain+hail`), not a measurement. Any change that makes `precip_type`
+  a float is wrong.
+- **`rain_rate` is the precipitation amount and is already `REAL`/`DOUBLE PRECISION`.** Do not touch it.
+- The branch point is `a1b07f1`. For branch-wide diffs use `a1b07f1..HEAD`, **never** `main...HEAD` —
+  local `main` is stale at `8990b88` and reports 27 unrelated `.go` files.
+- `timeout` does not exist on macOS (it is `gtimeout`). Use the tool's own timeout.
+- The full gate is `go build ./...` (with `CGO_ENABLED=0`), `go vet ./...`, `gofmt -l .`,
+  `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`, `go test -race ./...`.
+- **Known conflict:** PR #117 (`worktree-release-binaries`) also modifies
+  `.github/workflows/on-push-main.yml` and `on-release.yml`. It removes `latest:` / `tag-strategy:`
+  from the `docker` step; Task 4 adds a `services:` block to the `tests` job. Different jobs, so a
+  clean auto-merge is expected — but if #117 merges first, rebase before Task 4 and do **not**
+  re-add the lines it deleted.
+
+## Background an implementer needs
+
+Measured facts this plan depends on. Do not re-derive them; do not contradict them.
+
+- SQLite `INTEGER` affinity does **not** truncate a fractional bind — it stores `1.5` as `REAL`.
+- `database/sql` converts `float64` → `int64` via `strconv.FormatFloat(v, 'g', -1, 64)`, which
+  switches to scientific notation at exponent ≥ 6. So a `sql.NullInt64` scan of a `REAL`-stored
+  value **succeeds** below 1e6 (`5` → `5`) and **fails** at/above it (`1e+06` → `invalid syntax`).
+- Therefore an integral value still scans into `NullInt64` from a `REAL` column. **Several existing
+  tests keep passing after Task 1 for exactly this reason — that is expected, not a bug.**
+- `SUM(...)` over a `REAL` column returns `REAL`, but `SUM(2,3)` = `5.0` still scans into
+  `NullInt64` as `5`. Only a fractional sum (`5.5`) errors.
+- Go marshals `float64(5)` as `5`, not `5.0`, so widening a JSON field from `int64` to `float64` is
+  byte-identical on the wire for every integral value.
+
+## File Structure
+
+| File | Task | Change |
+|---|---|---|
+| `internal/sqlite/migrations/0001_init.sql` | 1 | three columns → `REAL`; fold in `idx_obs_time` |
+| `internal/sqlite/migrations/0002_add_timestamp_index.sql` | 1 | delete |
+| `internal/sqlite/schema.go` | 1 | fail-loud guard for a database newer than the bundled migrations |
+| `internal/sqlite/schema_test.go` | 1 | version `2` → `1`; new column-type and guard tests |
+| `internal/sqlite/writer.go` | 2, 3 | read model (2), write model (3) |
+| `internal/sqlite/writer_test.go` | 2 | scan types |
+| `internal/sqlite/litestream_test.go` | 2 | scan types |
+| `internal/sqlite/summary_test.go` | 2 | `LightningTotal` type; new fractional-`SUM` test |
+| `internal/httpserver/observations.go` | 2 | JSON contract |
+| `internal/httpserver/observations_test.go` | 2 | fixture types |
+| `internal/sqlite/backfill.go` | 3 | delete `asInt64`; `precip_type`-only helper |
+| `internal/sqlite/backfill_test.go` | 3 | rework the truncation test |
+| `.github/workflows/on-pull-request.yml` | 4 | Postgres service container |
+| `.github/workflows/on-push-main.yml` | 4 | Postgres service container |
+| `.github/workflows/on-release.yml` | 4 | Postgres service container |
+| `.github/actions/tests/action.yml` | 4 | `POSTGRES_URL` pass-through |
+| `internal/postgres/backfill.go` | 5 | explicit `precip_type` conversion |
+| `internal/postgres/backfill_test.go` | 5 | fractional round-trip |
+
+**Task order is load-bearing.** The read path must widen (Task 2) *before* the write path stops
+truncating (Task 3). Reversed, a fractional value lands in the database while the read model is
+still `NullInt64`, and the current-observation endpoint breaks between commits.
+
+---
+
+### Task 1: SQLite schema — fold `0002` into `0001`, widen three columns, fail loud on a newer database
+
+**Files:**
+- Modify: `internal/sqlite/migrations/0001_init.sql`
+- Delete: `internal/sqlite/migrations/0002_add_timestamp_index.sql`
+- Modify: `internal/sqlite/schema.go` (`Migrate`, `:23-54`)
+- Modify: `internal/sqlite/schema_test.go` (`:37-50`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a schema where `wind_sample_interval`, `lightning_strike_count`, and `report_interval`
+  are `REAL`; `schema_version` reaches `1`; `Migrate` returns a non-nil error when the database's
+  version exceeds the highest bundled migration.
+
+**Expected end state of this task:** the whole suite still passes. Existing tests scan integral
+values, which still read back through `sql.NullInt64` from a `REAL` column. Do not "fix" them here.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/sqlite/schema_test.go`:
+
+```go
+func TestMigrateDeclaresMeasurementColumnsAsREAL(t *testing.T) {
+	ctx := t.Context()
+	db := newTestDB(t)
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	// precip_type is deliberately excluded: it is a categorical enum
+	// (0 none, 1 rain, 2 hail, 3 rain+hail), not a measurement, and stays
+	// INTEGER so it matches internal/postgres/schema.go:55.
+	want := map[string]string{
+		"wind_sample_interval":   "REAL",
+		"lightning_strike_count": "REAL",
+		"report_interval":        "REAL",
+		"precip_type":            "INTEGER",
+	}
+	for column, wantType := range want {
+		var got string
+		err := db.QueryRowContext(ctx,
+			`SELECT type FROM pragma_table_info('tempest_observations') WHERE name = ?`,
+			column,
+		).Scan(&got)
+		if err != nil {
+			t.Fatalf("pragma_table_info for %q: %v", column, err)
+		}
+		if got != wantType {
+			t.Errorf("%s declared %s, want %s", column, got, wantType)
+		}
+	}
+}
+
+func TestMigrateRejectsDatabaseNewerThanBundledMigrations(t *testing.T) {
+	ctx := t.Context()
+	db := newTestDB(t)
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("first Migrate() error = %v", err)
+	}
+
+	// Simulate a database written by a NEWER binary. Migrate skips any
+	// migration whose version is <= current, so without a guard this would
+	// silently apply nothing and report success -- and would keep skipping
+	// every future migration numbered at or below 99.
+	if _, err := db.ExecContext(ctx, `INSERT INTO schema_version (version) VALUES (99)`); err != nil {
+		t.Fatalf("seed future schema version: %v", err)
+	}
+
+	err := Migrate(ctx, db)
+	if err == nil {
+		t.Fatal("Migrate() = nil, want an error for a database newer than the bundled migrations")
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error %q does not name the database's version (99)", err)
+	}
+}
+```
+
+Add `"strings"` to that file's imports.
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+go test ./internal/sqlite/ -run 'TestMigrateDeclaresMeasurementColumnsAsREAL|TestMigrateRejectsDatabaseNewerThanBundledMigrations' -v 2>&1 | tail -30
+```
+
+Expected: `TestMigrateDeclaresMeasurementColumnsAsREAL` FAILs with
+`wind_sample_interval declared INTEGER, want REAL` (and the same for the other two).
+`TestMigrateRejectsDatabaseNewerThanBundledMigrations` FAILs with
+`Migrate() = nil, want an error…`.
+
+If either passes at this point, stop and report — the change is already applied.
+
+- [ ] **Step 3: Rewrite `internal/sqlite/migrations/0001_init.sql`**
+
+Replace the file's **complete** contents with:
+
+```sql
+-- All timestamps stored as INTEGER unix-epoch seconds (UTC). UUIDv7 text PKs generated in Go.
+CREATE TABLE IF NOT EXISTS tempest_observations (
+  id TEXT PRIMARY KEY,                 -- UUIDv7
+  serial_number TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,          -- ob[0] epoch
+  wind_lull REAL, wind_avg REAL, wind_gust REAL, wind_direction REAL,
+  wind_sample_interval REAL,
+  pressure REAL, temp_air REAL, temp_wetbulb REAL, humidity REAL,
+  illuminance REAL, uv_index REAL, irradiance REAL, rain_rate REAL,
+  precip_type INTEGER,                 -- categorical enum (0 none, 1 rain, 2 hail, 3 rain+hail), not a measurement
+  lightning_distance REAL, lightning_strike_count REAL,
+  battery REAL, report_interval REAL,
+  UNIQUE(serial_number, timestamp)     -- backs ON CONFLICT DO NOTHING
+);
+CREATE TABLE IF NOT EXISTS tempest_rapid_wind (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  wind_speed REAL, wind_direction REAL, UNIQUE(serial_number, timestamp)
+);
+CREATE TABLE IF NOT EXISTS tempest_hub_status (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  uptime INTEGER, rssi REAL, reboot_count INTEGER, bus_errors INTEGER,
+  UNIQUE(serial_number, timestamp)
+);
+CREATE TABLE IF NOT EXISTS tempest_events (
+  id TEXT PRIMARY KEY, serial_number TEXT NOT NULL, timestamp INTEGER NOT NULL,
+  event_type TEXT NOT NULL, distance_km REAL, energy REAL,
+  UNIQUE(serial_number, timestamp, event_type)
+);
+CREATE INDEX IF NOT EXISTS idx_obs_serial_time ON tempest_observations(serial_number, timestamp);
+-- The read hot-path (LatestObservationAny's ORDER BY timestamp DESC LIMIT 1,
+-- HistoryPoints' WHERE timestamp BETWEEN ?) filters/sorts on timestamp alone.
+-- idx_obs_serial_time leads with serial_number, so neither query can use it and
+-- both fall back to a full table scan + sort, serialized against the single
+-- writer connection (SGE review I1). This index leads with timestamp so both
+-- queries can use it directly.
+CREATE INDEX IF NOT EXISTS idx_obs_time ON tempest_observations(timestamp);
+CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+```
+
+Three changes from the original: `wind_sample_interval`, `lightning_strike_count`, and
+`report_interval` are now `REAL`; the `-- INTEGER not float (fix B-LOW)` comment is gone;
+`idx_obs_time` and its rationale are folded in from `0002`. Everything else is byte-identical.
+
+- [ ] **Step 4: Delete the folded migration**
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+git rm internal/sqlite/migrations/0002_add_timestamp_index.sql
+ls internal/sqlite/migrations/
+```
+
+Expected: `rm 'internal/sqlite/migrations/0002_add_timestamp_index.sql'`, then only
+`0001_init.sql` listed.
+
+- [ ] **Step 5: Add the fail-loud guard to `internal/sqlite/schema.go`**
+
+Replace the body of `Migrate` (`:23-54`) with:
+
+```go
+func Migrate(ctx context.Context, db *sql.DB) error {
+	entries, err := fs.ReadDir(migrationsFS, migrationsDir)
+	if err != nil {
+		return fmt.Errorf("read migrations directory: %w", err)
+	}
+
+	current, err := currentSchemaVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("determine current schema version: %w", err)
+	}
+
+	type migration struct {
+		name    string
+		version int
+	}
+	migrations := make([]migration, 0, len(entries))
+	highest := 0
+	for _, entry := range entries {
+		version, err := migrationVersion(entry.Name())
+		if err != nil {
+			return fmt.Errorf("parse migration version from %q: %w", entry.Name(), err)
+		}
+		migrations = append(migrations, migration{name: entry.Name(), version: version})
+		if version > highest {
+			highest = version
+		}
+	}
+
+	// A database newer than this binary must fail loudly. The loop below
+	// skips any migration whose version is <= current, so an older binary
+	// pointed at a newer database would apply nothing and report success --
+	// and would go on silently skipping every future migration numbered at
+	// or below the version the database already records.
+	if current > highest {
+		return fmt.Errorf(
+			"database schema version %d is newer than the highest bundled migration (%d): "+
+				"this binary is older than the database it was pointed at",
+			current, highest)
+	}
+
+	for _, m := range migrations {
+		if m.version <= current {
+			continue
+		}
+
+		content, err := migrationsFS.ReadFile(migrationsDir + "/" + m.name)
+		if err != nil {
+			return fmt.Errorf("read migration %q: %w", m.name, err)
+		}
+
+		if err := applyMigration(ctx, db, m.version, string(content)); err != nil {
+			return fmt.Errorf("apply migration %q: %w", m.name, err)
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 6: Update the version assertions in `internal/sqlite/schema_test.go`**
+
+Two sites, `:43` and `:50`, both currently `assertSchemaVersion(t, db, 2)`. Change both to:
+
+```go
+	assertSchemaVersion(t, db, 1)
+```
+
+Also update the comment at `:37-41`, which references the deleted file. Replace:
+
+```go
+	// idx_obs_time (0002_add_timestamp_index.sql) leads with timestamp alone
+```
+
+with:
+
+```go
+	// idx_obs_time leads with timestamp alone
+```
+
+Leave the rest of that comment and the `assertIndexExists(t, db, "idx_obs_time")` call untouched —
+that assertion is what proves the fold did not drop the index.
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+```bash
+go test ./internal/sqlite/ -run 'TestMigrate' -v 2>&1 | tail -30
+```
+
+Expected: PASS for both new tests and the existing migration tests.
+
+- [ ] **Step 8: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test -race ./... 2>&1 | tail -20
+```
+
+Expected: `gofmt -l .` prints nothing; everything passes. **Every existing test still passes** —
+integral values scan into `sql.NullInt64` from a `REAL` column without error. That is expected.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/sqlite/migrations internal/sqlite/schema.go internal/sqlite/schema_test.go
+git status --porcelain
+git commit -m "fix(sqlite): declare the three measurement columns REAL; fold 0002 into 0001
+
+wind_sample_interval, lightning_strike_count, and report_interval were
+declared INTEGER in SQLite but DOUBLE PRECISION in Postgres. The DDL was
+never the lossy part -- INTEGER affinity stores 1.5 as REAL rather than
+truncating -- but the declaration should say what the column holds.
+
+precip_type stays INTEGER in both stores: it is a categorical enum, not
+a measurement.
+
+0002_add_timestamp_index.sql folds into 0001 rather than a 0003 rebuild,
+because nothing is deployed and SQLite cannot ALTER COLUMN TYPE. Its
+rationale comment moves with it so idx_obs_time is not later deleted as
+redundant.
+
+Migrate now fails loudly when the database's schema version exceeds the
+highest bundled migration. Without it, an older binary meeting a newer
+database applies nothing and reports success, then silently skips every
+future migration numbered at or below the recorded version.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D"
+```
+
+`git status --porcelain` must show exactly four lines, all with the status code in **column 1**:
+
+```
+M  internal/sqlite/migrations/0001_init.sql
+D  internal/sqlite/migrations/0002_add_timestamp_index.sql
+M  internal/sqlite/schema.go
+M  internal/sqlite/schema_test.go
+```
+
+---
+
+### Task 2: Widen the read path — `Observation`, `scanObservation`, `Summary`, and the JSON contract
+
+**Files:**
+- Modify: `internal/sqlite/writer.go` (`:705-800`, `:930-950`)
+- Modify: `internal/sqlite/writer_test.go` (`:74-100`)
+- Modify: `internal/sqlite/litestream_test.go` (`:46-85`)
+- Modify: `internal/sqlite/summary_test.go`
+- Modify: `internal/httpserver/observations.go` (`:70`, `:80`, `:82`, `:130`, `:280`)
+- Modify: `internal/httpserver/observations_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's `REAL` columns.
+- Produces: `sqlite.Observation.WindSampleInterval`, `.LightningStrikeCount`, `.ReportInterval` are
+  `*float64`; `.PrecipType` stays `*int64`. `sqlite.Summary.LightningTotal` is `sql.NullFloat64`.
+  `currentObservation.WindSampleInterval`, `.LightningStrikeCount`, `.ReportInterval` are `float64`;
+  `.PrecipitationType` stays `int64`. `summaryResponse.LightningTotal` is `*float64`.
+
+**Why this task comes before Task 3:** it makes reads tolerant of fractional values *before* writes
+start producing them. Reversed, the current-observation endpoint breaks between commits.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/sqlite/summary_test.go`. This is the one test that catches a missed
+`LightningTotal` — the existing summary test seeds `2` and `3`, whose `REAL` sum is `5.0` and still
+scans into `sql.NullInt64` as `5`, so it passes either way.
+
+```go
+func TestSummarizeObservationsPreservesFractionalLightningTotal(t *testing.T) {
+	w := newTestWriter(t)
+	ctx := t.Context()
+
+	// A fractional sum is the only thing that distinguishes a NullFloat64
+	// LightningTotal from a NullInt64 one: SUM(2,3) over a REAL column is
+	// 5.0, which a NullInt64 scan still accepts. SUM(2.5,3) is 5.5, which
+	// it rejects with "converting driver.Value type float64 to a int64".
+	for i, v := range []float64{2.5, 3} {
+		_, err := w.db.ExecContext(ctx, `
+			INSERT INTO tempest_observations (id, serial_number, timestamp, lightning_strike_count)
+			VALUES (?, ?, ?, ?)`,
+			uuid.Must(uuid.NewV7()).String(), "ST-A", int64(100+i), v)
+		if err != nil {
+			t.Fatalf("seed row %d: %v", i, err)
+		}
+	}
+
+	s, err := w.SummarizeObservations(ctx, 0, 1000)
+	if err != nil {
+		t.Fatalf("SummarizeObservations: %v", err)
+	}
+	if !s.LightningTotal.Valid {
+		t.Fatal("LightningTotal is NULL, want 5.5")
+	}
+	if s.LightningTotal.Float64 != 5.5 {
+		t.Errorf("LightningTotal = %v, want 5.5", s.LightningTotal.Float64)
+	}
+}
+```
+
+`newTestWriter` is defined in `internal/sqlite/writer_test.go:35` and is available to every test in
+the package; it migrates the database and leaves the flush ticker dormant. `w.db` is the package's
+own field, reachable from an in-package test. If `summary_test.go` does not already import
+`github.com/google/uuid`, add it.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+go test ./internal/sqlite/ -run TestSummarizeObservationsPreservesFractionalLightningTotal -v 2>&1 | tail -20
+```
+
+Expected: FAIL with a compile error on `s.LightningTotal.Float64` (the field is `sql.NullInt64`).
+A compile failure is acceptable as the red state **only for this step**, because the type itself is
+what the test is asserting. Confirm the message names `Float64` / `NullInt64`.
+
+- [ ] **Step 3: Widen the read model in `internal/sqlite/writer.go`**
+
+In `type Observation struct` (`:712-734`), change three fields — leave `PrecipType` alone:
+
+```go
+	WindSampleInterval   *float64
+	...
+	LightningStrikeCount *float64
+	...
+	ReportInterval       *float64
+```
+
+In `scanObservation` (`:757-800`), change the declaration block:
+
+```go
+	var (
+		obs                                                          Observation
+		precipType                                                   sql.NullInt64
+		windSampleInterval, lightningStrikeCount, reportInterval     sql.NullFloat64
+		tempWetbulb, lightningDistance, battery                      sql.NullFloat64
+	)
+```
+
+and the three assignments:
+
+```go
+	if windSampleInterval.Valid {
+		obs.WindSampleInterval = &windSampleInterval.Float64
+	}
+	...
+	if lightningStrikeCount.Valid {
+		obs.LightningStrikeCount = &lightningStrikeCount.Float64
+	}
+	...
+	if reportInterval.Valid {
+		obs.ReportInterval = &reportInterval.Float64
+	}
+```
+
+`precipType` keeps `&precipType.Int64`. Run `gofmt -w internal/sqlite/writer.go` afterwards — the
+`var` block alignment will change.
+
+In `type Summary struct` (`:936-950`):
+
+```go
+	LightningTotal sql.NullFloat64
+```
+
+- [ ] **Step 4: Update the read model's doc comment**
+
+`internal/sqlite/writer.go:87-95` describes `observationRow` as diverging from Postgres because the
+INTEGER-typed columns are `*int64`. That is still true of `observationRow` until Task 3, so **leave
+it alone in this task.** Task 3 owns it.
+
+- [ ] **Step 5: Fix the scanning tests**
+
+`internal/sqlite/writer_test.go:76,81,83` — these are a **silent survivor**: they declare the three
+columns as plain `int64` and raw-scan them, and the seeded values `3,4,5` still scan fine from a
+`REAL` column, so the test stays green while asserting the wrong type. Change:
+
+```go
+			windSampleInterval                         float64
+			...
+			lightningStrikeCount                       float64
+			...
+			reportInterval                             float64
+```
+
+Leave `precipType int64`. Adjust any `%d` verbs for those three to `%v`, and any integer literal
+comparisons remain valid (`3 == 3.0`).
+
+`internal/sqlite/litestream_test.go:46-50` — change the declaration block:
+
+```go
+		var (
+			obs                                                      Observation
+			precipType                                               sql.NullInt64
+			windSampleInterval, lightningStrikeCount, reportInterval sql.NullFloat64
+			tempWetbulb, lightningDistance, battery                  sql.NullFloat64
+		)
+```
+
+and the corresponding `&x.Int64` assignments at `:63,75,81` to `&x.Float64` for those three only.
+
+`internal/sqlite/summary_test.go:22,31,32,33` — the `seed` helper takes a `sql.NullInt64` lightning
+argument. Change its parameter type to `sql.NullFloat64` and the three call sites to
+`sql.NullFloat64{Float64: 2, Valid: true}`, `sql.NullFloat64{}`, and
+`sql.NullFloat64{Float64: 3, Valid: true}`. At `:51-52` change `s.LightningTotal.Int64 != 5` to
+`s.LightningTotal.Float64 != 5` and the `%d` verb to `%v`.
+
+- [ ] **Step 6: Widen the JSON contract in `internal/httpserver/observations.go`**
+
+Exactly four edits. **`deref` at `:342` needs no change — it is generic.** **`i64` at `:154` must be
+kept** — it still serves `CoveredFrom`/`CoveredTo` at `:272-273`, which are `MIN/MAX(timestamp)`
+over an `INTEGER` column.
+
+`:70`, `:80`, `:82` — three fields in `currentObservation`. `PrecipitationType` stays `int64`:
+
+```go
+	WindSampleInterval         float64 `json:"windSampleInterval"`
+	...
+	LightningStrikeCount       float64 `json:"lightningStrikeCount"`
+	...
+	ReportInterval             float64 `json:"reportInterval"`
+```
+
+`:130` in `summaryResponse`:
+
+```go
+	LightningTotal *float64      `json:"lightningTotal"`
+```
+
+`:280` — `f64` already exists at `:145` and serves `TempMax`, `RainTotal`, and the rest. Reuse it:
+
+```go
+		LightningTotal: f64(s.LightningTotal),
+```
+
+`toCurrentObservation` at `:312,322,324` needs no edit — `deref` is generic and infers the new type.
+
+- [ ] **Step 7: Fix the httpserver test fixtures**
+
+`internal/httpserver/observations_test.go:70,72,82,92,94` construct `int64` locals and assign them
+into `sqlite.Observation`. Change those three to `float64` — e.g. `lightningCount := 4.0`,
+`reportInterval := 5.0`. `:325` has a `sql.NullInt64{...}` literal for `LightningTotal`; change it
+to `sql.NullFloat64{Float64: <same value>, Valid: true}`.
+
+Read the surrounding lines before editing: match whatever the existing values are rather than
+assuming, and leave any `precipType` fixture as `int64`.
+
+- [ ] **Step 8: Run the tests and watch them pass**
+
+```bash
+go test ./internal/sqlite/ ./internal/httpserver/ 2>&1 | tail -20
+```
+
+Expected: all pass, including the new fractional-`SUM` test.
+
+- [ ] **Step 9: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
+  go test -race ./... 2>&1 | tail -20
+```
+
+Expected: `gofmt -l .` prints nothing; lint clean; all tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/sqlite internal/httpserver
+git status --porcelain
+git commit -m "fix(sqlite): read the three measurement columns as float64
+
+Widens the read model and the JSON contract ahead of the write-path
+change, so a fractional value can be read back before one can be
+written. Reversed, the current-observation endpoint would break between
+commits.
+
+Summary.LightningTotal is the site that fails silently: SUM over a REAL
+column returns REAL, but SUM(2,3) = 5.0 still scans into NullInt64 as 5,
+so every existing summary test passes either way. Only a fractional sum
+errors -- hence the new test seeding 2.5.
+
+writer_test.go was a silent survivor of the same kind: it declared the
+columns as plain int64 and its integral fixtures kept scanning fine from
+a REAL column, so it stayed green while asserting the wrong type.
+
+The wire change is byte-identical for integral values -- Go marshals
+float64(5) as 5, not 5.0. precip_type stays an integer end to end.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D"
+```
+
+---
+
+### Task 3: Stop truncating on the write path
+
+**Files:**
+- Modify: `internal/sqlite/writer.go` (`:87-95`, `:96-118`, `:399-403`, `:436-457`)
+- Modify: `internal/sqlite/backfill.go` (`:161-208`)
+- Modify: `internal/sqlite/backfill_test.go` (`:350-410`, and the comments at `:241-275`)
+
+**Interfaces:**
+- Consumes: Task 2's float-tolerant read model.
+- Produces: `observationRow.windSampleInterval`, `.lightningStrikeCount`, `.reportInterval` are
+  `*float64`; `.precipType` stays `*int64`. `asInt64` is gone, replaced by a `precip_type`-only
+  helper.
+
+- [ ] **Step 1: Rework the truncation test into a fidelity test**
+
+`internal/sqlite/backfill_test.go:350-410` currently asserts the truncation. Replace the whole
+function **and its doc comment** with:
+
+```go
+// TestInsertObservationsPreservesFractionalMeasurements pins the cross-store
+// conformance fix: wind_sample_interval, lightning_strike_count, and
+// report_interval are REAL in SQLite and DOUBLE PRECISION in Postgres, so a
+// fractional API value must survive the SQLite write path unchanged rather
+// than being truncated in Go. precip_type is the deliberate exception -- a
+// categorical enum (0 none, 1 rain, 2 hail, 3 rain+hail), INTEGER in both
+// stores, where a fractional value is corrupt input and truncation is the
+// intended coercion.
+func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
+	db := newTestDB(t)
+	obs := []weather.Observation{
+		{
+			SerialNumber:         "ST-A",
+			Timestamp:            ts(1000),
+			WindSampleInterval:   f(1.5),
+			PrecipType:           f(1.9),
+			LightningStrikeCount: f(2.5),
+			ReportInterval:       f(5.9),
+		},
+	}
+	if _, err := InsertObservations(t.Context(), db, obs); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var windSampleInterval, lightningStrikeCount, reportInterval sql.NullFloat64
+	var precipType sql.NullInt64
+	row := db.QueryRowContext(t.Context(), `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = ? AND timestamp = ?`,
+		"ST-A", ts(1000).Unix())
+	if err := row.Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	measurements := []struct {
+		column string
+		got    sql.NullFloat64
+		want   float64
+	}{
+		{"wind_sample_interval", windSampleInterval, 1.5},
+		{"lightning_strike_count", lightningStrikeCount, 2.5},
+		{"report_interval", reportInterval, 5.9},
+	}
+	for _, c := range measurements {
+		if !c.got.Valid {
+			t.Errorf("%s = NULL, want %v", c.column, c.want)
+			continue
+		}
+		if c.got.Float64 != c.want {
+			t.Errorf("%s = %v, want %v (fractional API value must not be truncated)", c.column, c.got.Float64, c.want)
+		}
+	}
+
+	if !precipType.Valid {
+		t.Fatal("precip_type = NULL, want 1")
+	}
+	if precipType.Int64 != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: still truncated by design)", precipType.Int64)
+	}
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+go test ./internal/sqlite/ -run TestInsertObservationsPreservesFractionalMeasurements -v 2>&1 | tail -20
+```
+
+Expected: FAIL with `wind_sample_interval = 1, want 1.5` (and `2, want 2.5`, `5, want 5.9`) — the
+values `asInt64` truncated. The `precip_type` assertion should already pass.
+
+**This is the genuine red state for this task.** If it passes, stop and report.
+
+- [ ] **Step 3: Widen `observationRow` in `internal/sqlite/writer.go`**
+
+At `:96-118`, change three fields — `precipType` stays `*int64`:
+
+```go
+	windSampleInterval   *float64
+	...
+	precipType           *int64
+	...
+	lightningStrikeCount *float64
+	...
+	reportInterval       *float64
+```
+
+- [ ] **Step 4: Update the two now-false doc comments**
+
+`:87-95` — replace:
+
+```go
+// INTEGER-typed columns here (wind_sample_interval, precip_type,
+// lightning_strike_count, and report_interval) are *int64, not *float64 (fix
+// B-LOW: the SQLite DDL declares these INTEGER), and timestamp is a raw
+// unix-epoch int64 rather than time.Time (design §12: SQLite stores epoch
+// integers, not TIMESTAMPTZ).
+```
+
+with:
+
+```go
+// precip_type here is *int64 rather than *float64 -- it is a categorical
+// enum, INTEGER in both stores -- and timestamp is a raw unix-epoch int64
+// rather than time.Time (design §12: SQLite stores epoch integers, not
+// TIMESTAMPTZ). The three measurement columns match Postgres exactly.
+```
+
+`:399-403` — replace:
+
+```go
+// handleObservationReport for the field-index table), except INTEGER-typed
+// columns are converted to int64 (fix B-LOW) and timestamp is stored as a
+// raw unix-epoch int64 (design §12).
+```
+
+with:
+
+```go
+// handleObservationReport for the field-index table), except precip_type is
+// converted to int64 (categorical enum, INTEGER in both stores) and timestamp
+// is stored as a raw unix-epoch int64 (design §12).
+```
+
+- [ ] **Step 5: Drop the three `int64(...)` conversions in `handleObservationReport`**
+
+At `:436-457`, three of the four blocks change. **`precipType` at `:441` is unchanged:**
+
+```go
+		if len(ob) >= 6 {
+			interval := ob[5]
+			row.windSampleInterval = &interval
+		}
+		if len(ob) >= 14 {
+			precipType := int64(ob[13])
+			row.precipType = &precipType
+		}
+		if len(ob) >= 16 {
+			distance := ob[14]
+			count := ob[15]
+			row.lightningDistance = &distance
+			row.lightningStrikeCount = &count
+		}
+		if len(ob) >= 17 {
+			battery := ob[16]
+			row.battery = &battery
+		}
+		if len(ob) >= 18 {
+			interval := ob[17]
+			row.reportInterval = &interval
+		}
+```
+
+- [ ] **Step 6: Replace `asInt64` in `internal/sqlite/backfill.go`**
+
+Delete `asInt64` (`:194-208`) and add in its place:
+
+```go
+// asPrecipType converts a possibly-nil *float64 into a possibly-nil *int64
+// for precip_type, which is INTEGER in both stores. Unlike the three
+// measurement columns, precip_type is a categorical enum (0 none, 1 rain,
+// 2 hail, 3 rain + hail), so a fractional value is corrupt input and
+// int64(...) truncation -- matching the UDP path at writer.go's
+// handleObservationReport -- is the intended coercion, not data loss. Nil
+// maps to SQL NULL.
+func asPrecipType(p *float64) *int64 {
+	if p == nil {
+		return nil
+	}
+	v := int64(*p)
+	return &v
+}
+```
+
+Then change the bind at `:171-177` — three `asInt64` calls become direct binds, one becomes
+`asPrecipType`:
+
+```go
+		res, err := stmt.ExecContext(ctx,
+			uuid.Must(uuid.NewV7()).String(), o.SerialNumber, o.Timestamp.Unix(),
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
+			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asPrecipType(o.PrecipType),
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
+```
+
+**Do not touch the `InsertObservations` doc comment at `:161-163`.** Its rationale — that
+`observationRow`'s *leading* fields are non-pointer `float64`, so routing through it would coerce a
+JSON null to `0.0` — is still true and correct (`writer.go:100-103` are unchanged).
+
+- [ ] **Step 7: Update the stale comments in `internal/sqlite/backfill_test.go`**
+
+`:241-253` and the inline notes at `:263,271,273,275` describe these as INTEGER columns. Read them
+and correct the wording: the three measurement columns are `REAL` and preserve fractional values;
+`precip_type` is `INTEGER` and still truncates. Do not change any assertion values in those tests
+unless the change makes one false — if it does, report which and why before editing.
+
+- [ ] **Step 8: Run the tests and watch them pass**
+
+```bash
+go test ./internal/sqlite/ -v 2>&1 | tail -30
+```
+
+Expected: all pass, including `TestInsertObservationsPreservesFractionalMeasurements`.
+
+- [ ] **Step 9: Add a UDP-path round-trip test**
+
+The REST path is now covered; the UDP path is not. Add to `internal/sqlite/writer_test.go`:
+
+```go
+// TestWriter_PreservesFractionalMeasurements is the UDP-path counterpart to
+// internal/sqlite's TestInsertObservationsPreservesFractionalMeasurements.
+// obs_st indices: 0 epoch, 5 wind sample interval, 13 precip type, 15
+// lightning strike count, 17 report interval. The three measurements must
+// survive fractionally; precip_type must still truncate.
+func TestWriter_PreservesFractionalMeasurements(t *testing.T) {
+	w := newTestWriter(t)
+	ctx := t.Context()
+
+	report := &tempestudp.TempestObservationReport{
+		SerialNumber: "ST-FRAC",
+		Obs: [][]float64{
+			//  0           1    2    3    4    5     6        7     8     9      10  11   12   13   14   15   16   17
+			{1700000100, 1.5, 2.0, 2.5, 180, 1.5, 1013.25, 20.5, 55.0, 50000, 3, 500, 0.5, 1.9, 2.1, 2.5, 3.6, 5.9},
+		},
+	}
+
+	if err := w.WriteReport(ctx, report); err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+	if err := w.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	var (
+		windSampleInterval, lightningStrikeCount, reportInterval float64
+		precipType                                               int64
+	)
+	err := w.db.QueryRowContext(ctx, `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = ?`, "ST-FRAC",
+	).Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval)
+	if err != nil {
+		t.Fatalf("scan observation row: %v", err)
+	}
+
+	if windSampleInterval != 1.5 {
+		t.Errorf("wind_sample_interval = %v, want 1.5", windSampleInterval)
+	}
+	if lightningStrikeCount != 2.5 {
+		t.Errorf("lightning_strike_count = %v, want 2.5", lightningStrikeCount)
+	}
+	if reportInterval != 5.9 {
+		t.Errorf("report_interval = %v, want 5.9", reportInterval)
+	}
+	if precipType != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: truncated by design)", precipType)
+	}
+}
+```
+
+The `Obs` row above is the same 18-element shape as the existing
+`TestWriter_InsertsObservation` fixture at `writer_test.go:57-60`, with indices 5, 13, 15, and 17
+changed to fractional values. `tempestudp` and `uuid` are already imported by this file.
+
+Run it and watch it pass:
+
+```bash
+go test ./internal/sqlite/ -run TestWriter_PreservesFractionalMeasurements -v 2>&1 | tail -20
+```
+
+If you run this **before** Steps 3–5, it fails with `wind_sample_interval = 1, want 1.5` — that is
+the same red state Step 2 already demonstrated for the REST path, and running it early is a
+legitimate way to prove this test bites too.
+
+- [ ] **Step 10: Run the full gate**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
+  go test -race ./... 2>&1 | tail -20
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/sqlite
+git status --porcelain
+git commit -m "fix(sqlite): stop truncating measurement columns on the write path
+
+Both write paths converted *float64 to *int64 before binding -- the UDP
+path with int64(ob[5]) and friends, the REST path with asInt64 -- so the
+same observation was stored as 1.5 in Postgres and 1 in SQLite. That
+truncation, not the DDL, was the actual defect in #107: SQLite INTEGER
+affinity stores 1.5 as REAL rather than truncating it.
+
+precip_type keeps its conversion, now in a helper named for that one
+column. It is a categorical enum, INTEGER in both stores, where a
+fractional value is corrupt input.
+
+The reworked test previously asserted the truncation; it now asserts
+fidelity for the three measurements and truncation for precip_type.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D"
+```
+
+---
+
+### Task 4: Run the Postgres suite in CI
+
+**Files:**
+- Modify: `.github/workflows/on-pull-request.yml` (`tests` job, `:15-22`)
+- Modify: `.github/workflows/on-push-main.yml` (`tests` job, `:21-28`)
+- Modify: `.github/workflows/on-release.yml` (`tests` job)
+- Modify: `.github/actions/tests/action.yml`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `POSTGRES_URL` set during `go test`, so `internal/postgres`'s untagged
+  `POSTGRES_URL`-guarded tests run instead of skipping.
+
+**Scope:** the standard, untagged suite only. Do **not** add `-tags integration` — that would
+enable `internal/postgres/writer_integration_test.go`, which contains the known-failing
+`TestPostgresWriter_DrainOnClose_Integration` tracked as issue #111, and CI would go red.
+
+**Why the service block goes in the workflows and not the action:** `services:` is a job-level
+workflow key. `.github/actions/tests` is a *composite* action, and composite actions cannot declare
+services. The block is therefore duplicated three times; that is accepted so the image tag stays
+visible to Renovate, which keeps the three copies in step.
+
+- [ ] **Step 1: Confirm the failing state**
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+go test ./internal/postgres/ -run TestBackfillPostgresIntegration -v 2>&1 | tail -10
+grep -rn 'services:' .github/workflows/; echo "exit=$?"
+```
+
+Expected: the test reports `SKIP` with `POSTGRES_URL not set`; the grep prints nothing and
+`exit=1`. This is the state the task removes.
+
+- [ ] **Step 2: Add the service container to `.github/workflows/on-pull-request.yml`**
+
+Replace the `tests` job (currently `:15-22`) with:
+
+```yaml
+  tests:
+    runs-on: ubuntu-latest
+    services:
+      # The Postgres-backed tests in internal/postgres are guarded on
+      # POSTGRES_URL and skip without it, so before this they never ran in CI
+      # and the Postgres half of the store was asserted by nothing. Only the
+      # standard untagged suite runs -- `-tags integration` is deliberately not
+      # enabled, because it holds the known-failing drain-on-close test (#111).
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: weather
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Tests
+        uses: ./.github/actions/tests
+        with:
+          postgres-url: "postgres://postgres:postgres@localhost:5432/weather?sslmode=disable"
+```
+
+- [ ] **Step 3: Apply the identical change to the other two workflows**
+
+`.github/workflows/on-push-main.yml` — its `tests` job at `:21-28`. `.github/workflows/on-release.yml`
+— its `tests` job. Both get the same `services:` block and the same `with: postgres-url:` argument.
+Copy the block verbatim, including the comment, so Renovate updates all three identically.
+
+Leave every other job in those files untouched. In particular, if PR #117 has already merged, do
+**not** re-add the `latest:` / `tag-strategy:` lines it removed from the `docker` steps.
+
+- [ ] **Step 4: Add the input to `.github/actions/tests/action.yml`**
+
+After the `description:` line at the top, add:
+
+```yaml
+inputs:
+  postgres-url:
+    description: >-
+      Connection string for a Postgres instance the test suite can use. When
+      empty, internal/postgres's integration tests skip themselves, which is
+      the correct behaviour for a local run without a database.
+    required: false
+    default: ""
+```
+
+Then add `env:` to the "Run all Tests" step (currently `:83-94`), leaving the rest of that step
+unchanged:
+
+```yaml
+    - name: Run all Tests
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        POSTGRES_URL: ${{ inputs.postgres-url }}
+      run: |
+```
+
+- [ ] **Step 5: Verify the workflows are valid**
+
+```bash
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12; echo "exit=$?"
+```
+
+Expected: no output, `exit=0`. If it reports `input "postgres-url" is not defined in action "Tests"`,
+Step 4 did not land — actionlint validates the caller→declaration contract for local composite
+actions.
+
+- [ ] **Step 6: Verify the tests actually run with a database**
+
+```bash
+docker run --rm -d --name pg-conformance -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+until docker exec pg-conformance pg_isready -U postgres; do sleep 1; done
+POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
+  go test ./internal/postgres/ ./internal/config/ -count=1 -v 2>&1 | tail -30
+docker rm -f pg-conformance
+```
+
+Expected: `TestBackfillPostgresIntegration` runs and PASSes rather than skipping. `internal/config`
+is included deliberately: its tests read and write `POSTGRES_URL` via `t.Setenv`, and this confirms
+a globally-set value does not disturb them. If any `internal/config` test fails only when
+`POSTGRES_URL` is set, stop and report — that is a real interaction the design flagged as needing
+verification.
+
+- [ ] **Step 7: Run the full gate and commit**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test -race ./... 2>&1 | tail -10
+git add .github
+git status --porcelain
+git commit -m "ci: run the Postgres suite against a real database
+
+internal/postgres's tests are guarded on POSTGRES_URL and skip without
+it, so CI has never exercised the Postgres store at all. Adds a Postgres
+service container to the three workflows that call the tests action, and
+passes the connection string through as an input.
+
+services: is a job-level key and the tests action is composite, so the
+block cannot live in the action and is duplicated across the three
+callers. That is accepted so the image tag stays visible to Renovate,
+which is what keeps the three copies in step.
+
+Standard untagged suite only. -tags integration stays off: it holds
+TestPostgresWriter_DrainOnClose_Integration, which fails against a real
+database on unmodified main (#111).
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D"
+```
+
+---
+
+### Task 5: Postgres — explicit `precip_type` conversion and a fractional round-trip test
+
+**Files:**
+- Modify: `internal/postgres/backfill.go` (`:154-162`)
+- Modify: `internal/postgres/backfill_test.go`
+
+**Interfaces:**
+- Consumes: Task 4's CI database, so the new test is real coverage rather than a skip.
+- Produces: nothing later tasks depend on.
+
+**This task changes no stored value.** pgx already truncates a `*float64` bound into an `INTEGER`
+column (`pgtype/builtin_wrappers.go`, `int64(w)` with no error), so `1.9` is already stored as `1`.
+The change makes that coercion explicit, matching Postgres's own daemon path
+(`internal/postgres/writer.go:541`, `precipType := int(ob[13])`) and SQLite's new `asPrecipType`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/postgres/backfill_test.go`, following the `POSTGRES_URL` skip idiom already used at
+`:89-91`:
+
+```go
+// TestInsertObservationsPreservesFractionalMeasurements is the Postgres half
+// of the cross-store conformance pinned on the SQLite side by
+// TestInsertObservationsPreservesFractionalMeasurements in internal/sqlite.
+// The three measurement columns are DOUBLE PRECISION here and REAL there, so
+// a fractional API value must survive both. precip_type is INTEGER in both
+// and truncates in both.
+func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("POSTGRES_URL not set; skipping Postgres integration test")
+	}
+
+	ctx := t.Context()
+	pool, err := OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("OpenPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := CreateSchema(ctx, pool); err != nil {
+		t.Fatalf("CreateSchema: %v", err)
+	}
+
+	serial := "ST-FRAC"
+	stamp := time.Unix(1_900_000_000, 0).UTC()
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM tempest_observations WHERE serial_number = $1`, serial); err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+
+	obs := []weather.Observation{{
+		SerialNumber:         serial,
+		Timestamp:            stamp,
+		WindSampleInterval:   f(1.5),
+		PrecipType:           f(1.9),
+		LightningStrikeCount: f(2.5),
+		ReportInterval:       f(5.9),
+	}}
+	if _, err := InsertObservations(ctx, pool, obs); err != nil {
+		t.Fatalf("InsertObservations: %v", err)
+	}
+
+	var windSampleInterval, lightningStrikeCount, reportInterval float64
+	var precipType int
+	err = pool.QueryRow(ctx, `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serial, stamp,
+	).Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	if windSampleInterval != 1.5 {
+		t.Errorf("wind_sample_interval = %v, want 1.5", windSampleInterval)
+	}
+	if lightningStrikeCount != 2.5 {
+		t.Errorf("lightning_strike_count = %v, want 2.5", lightningStrikeCount)
+	}
+	if reportInterval != 5.9 {
+		t.Errorf("report_interval = %v, want 5.9", reportInterval)
+	}
+	if precipType != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: truncated by design)", precipType)
+	}
+}
+```
+
+Check the file's existing imports and helpers first — `f`, `os`, `time`, and `weather` should
+already be present. Match the existing cleanup idiom if the file has one rather than the `DELETE`
+above.
+
+- [ ] **Step 2: Run it against a real database and watch the result**
+
+```bash
+docker run --rm -d --name pg-conformance -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+until docker exec pg-conformance pg_isready -U postgres; do sleep 1; done
+POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
+  go test ./internal/postgres/ -run TestInsertObservationsPreservesFractionalMeasurements -count=1 -v 2>&1 | tail -20
+```
+
+**Expected: this test PASSES before the Step 3 change.** The three measurement columns are already
+`DOUBLE PRECISION` bound from `*float64`, and pgx already truncates `precip_type`. That is the
+point — this test is a regression pin for behaviour that is already correct, and Step 3 is a
+readability change that must not alter it.
+
+**If it fails, stop and report** — that would mean the design's premise about the Postgres side is
+wrong, and Task 5 needs rethinking rather than patching. A `SKIP` means the database is not
+reachable; fix that before continuing.
+
+- [ ] **Step 3: Make the `precip_type` conversion explicit**
+
+In `internal/postgres/backfill.go`, add above `InsertObservations`:
+
+```go
+// asPrecipType converts a possibly-nil *float64 into a possibly-nil *int for
+// precip_type, which is INTEGER here and in SQLite. pgx already truncates a
+// float bind into an integer column silently; doing it here makes the
+// coercion visible and matches the daemon path (writer.go's
+// handleObservationReport) and internal/sqlite's helper of the same name.
+// Nil maps to SQL NULL.
+func asPrecipType(p *float64) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+```
+
+Then change the bind at `:159`:
+
+```go
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asPrecipType(o.PrecipType),
+```
+
+- [ ] **Step 4: Re-run and confirm the behaviour is unchanged**
+
+```bash
+POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
+  go test ./internal/postgres/ -count=1 2>&1 | tail -20
+docker rm -f pg-conformance
+```
+
+Expected: still PASS, with the same `precip_type = 1`. A behaviour change here is a bug.
+
+- [ ] **Step 5: Run the full gate and commit**
+
+```bash
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
+  go test -race ./... 2>&1 | tail -10
+git add internal/postgres
+git status --porcelain
+git commit -m "refactor(postgres): make the precip_type truncation explicit
+
+The backfill path bound o.PrecipType -- a *float64 -- straight into
+precip_type INTEGER, leaving pgx to truncate it silently. The stored
+value was already correct and already agreed with SQLite, so this
+changes no behaviour; it makes the coercion visible and matches both the
+daemon path and internal/sqlite's asPrecipType.
+
+Also pins the Postgres half of the cross-store fractional round-trip,
+which #107 asks for through both stores and which now runs in CI rather
+than skipping.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D"
+```
+
+---
+
+## Final verification (after all tasks)
+
+Run from the worktree root. All must hold simultaneously.
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+
+# 1. The three columns are REAL; precip_type is not
+go test ./internal/sqlite/ -run TestMigrateDeclaresMeasurementColumnsAsREAL -v 2>&1 | tail -5
+
+# 2. No truncating helper survives under its old name
+git grep -n 'asInt64' -- ':!docs/'; echo "exit=$?"          # expect exit=1, no output
+
+# 3. The folded migration is gone and only 0001 remains
+git ls-files internal/sqlite/migrations/                     # expect only 0001_init.sql
+
+# 4. No stale reference to the deleted migration outside docs
+git grep -n '0002_add_timestamp_index' -- ':!docs/'; echo "exit=$?"   # expect exit=1
+
+# 5. Workflows valid
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12; echo "exit=$?"   # expect exit=0
+
+# 6. Full gate, no database
+CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
+  go test -race ./...
+
+# 7. Full gate, with a database -- the Postgres tests must RUN, not skip
+docker run --rm -d --name pg-final -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16
+until docker exec pg-final pg_isready -U postgres; do sleep 1; done
+POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
+  go test -race ./... -count=1 2>&1 | tail -20
+docker rm -f pg-final
+
+# 8. Nothing outside the intended surface changed
+git diff --name-only a1b07f1..HEAD
+```
+
+Step 8 must list only: `docs/designs/2026-08-02-sqlite-float-conformance-design.md`,
+`docs/plans/2026-08-02-sqlite-float-conformance-implementation.md`, the four `.github` files, and
+files under `internal/sqlite/`, `internal/httpserver/`, `internal/postgres/`.
+
+**Not verifiable before merge:** that a real WeatherFlow response containing a fractional value
+round-trips end to end. No token is available. The tests pin the behaviour with synthetic
+fractional values, which is the strongest available pre-merge evidence.
+
+## Out of scope — do not do these
+
+- **Do not enable `-tags integration` anywhere.** It holds #111's known-failing test.
+- **Do not fix #111.** Separate issue.
+- **Do not change `precip_type` to a float** in either store, or remove its truncation.
+- **Do not touch `rain_rate`** — it is the precipitation amount, already `REAL`/`DOUBLE PRECISION`.
+- **Do not add a `0003` migration** or restore `0002`.
+- **Do not touch `web/`.** `web/src/types/weather.ts` already types these fields as `number`.
+- **Do not touch `internal/postgres/schema.go`** — the three columns are already `DOUBLE PRECISION`.
+- **Do not push, open a PR, or merge.**

--- a/docs/plans/2026-08-02-sqlite-float-conformance-implementation.md
+++ b/docs/plans/2026-08-02-sqlite-float-conformance-implementation.md
@@ -53,13 +53,74 @@ stores these as `DOUBLE PRECISION` with `*float64` end to end and needs no schem
 - The branch point is `a1b07f1`. For branch-wide diffs use `a1b07f1..HEAD`, **never** `main...HEAD` —
   local `main` is stale at `8990b88` and reports 27 unrelated `.go` files.
 - `timeout` does not exist on macOS (it is `gtimeout`). Use the tool's own timeout.
-- The full gate is `go build ./...` (with `CGO_ENABLED=0`), `go vet ./...`, `gofmt -l .`,
-  `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`, `go test -race ./...`.
-- **Known conflict:** PR #117 (`worktree-release-binaries`) also modifies
-  `.github/workflows/on-push-main.yml` and `on-release.yml`. It removes `latest:` / `tag-strategy:`
-  from the `docker` step; Task 4 adds a `services:` block to the `tests` job. Different jobs, so a
-  clean auto-merge is expected — but if #117 merges first, rebase before Task 4 and do **not**
-  re-add the lines it deleted.
+- **THE GATE.** Every task ends with this exact block. Copy it verbatim; do not simplify it.
+
+  ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+  cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+  CGO_ENABLED=0 go build ./... || exit 1
+  go vet ./... || exit 1
+  unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+  GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+    go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+  go test -race ./... 2>&1 | tail -20
+  ```
+
+  Two things in it are load-bearing and were wrong in an earlier revision:
+
+  - **`GOLANGCI_LINT_CACHE` must be set.** golangci-lint's default cache is keyed such that it
+    collides across sibling git worktrees of the same module. Without this, running the linter here
+    reports three issues in `../api-backfill/main.go` — a **different worktree** — on a completely
+    unmodified tree, because `//nolint` directives resolve against the wrong file. Verified: with an
+    isolated cache the same command reports `0 issues`. If you see findings in a path containing
+    `api-backfill`, `p1-fixes`, `records-summary`, `release-binaries`, or `w5-ux-polish`, that is
+    this bug — **do not edit those files**, set the cache variable.
+  - **`gofmt -l .` exits 0 even when it lists files.** Verified. Chaining it with `&&` therefore
+    enforces nothing; the `if [ -n "$unformatted" ]` form is what actually fails, and it mirrors
+    what CI does at `.github/actions/tests/action.yml:43-52`.
+
+  `|| exit 1` per step rather than one `&&` chain, so a failure names the step that failed instead
+  of silently skipping everything after it.
+- **Every shell block in this plan begins with `cd` to the worktree.** The shell's cwd resets
+  between tool calls. A `git add`/`git commit` run from the parent repo commits to the wrong
+  branch. If a block below is missing its `cd`, add it — that is a defect in this document, not a
+  signal that the block is special.
+- **PR #117 overlap — assume it has NOT merged.** PR #117 (`worktree-release-binaries`) also
+  modifies `.github/workflows/on-push-main.yml` and `on-release.yml`, removing `latest:` /
+  `tag-strategy:` from the `docker` step. Task 4 adds a `services:` block to the `tests` job in the
+  same files — a different job, so the two do not overlap textually.
+
+  Execute this plan against the branch as it stands. **Do not attempt a rebase.** Before Task 4,
+  run `cd <worktree> && git log --oneline -1 origin/main` — if it is not `a1b07f1`, `origin/main`
+  has moved, so STOP and report rather than guessing what changed. Merge-order reconciliation is
+  the human's call, not an unattended one.
+
+## If a task fails partway
+
+Each task is one commit. Nothing is pushed, so recovery is always local.
+
+- **Before that task's commit lands:** discard the whole task and start it over.
+  ```bash
+  cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+  git reset -q HEAD && git checkout -- . && git status --porcelain
+  ```
+  `git status --porcelain` must come back empty. This is safe because every task's edits are
+  confined to tracked files, and any new test file you added is discarded with them — re-add it
+  when you retry.
+
+  **Task 1 needs this most.** Step 4 runs `git rm`, so between Steps 4 and 6 the tree is in a state
+  where `assertSchemaVersion(t, db, 2)` is false and the suite cannot pass. A failure in that window
+  leaves a staged deletion; the reset above clears it.
+
+- **After that task's commit lands:** the previous commit is a safe stopping point. Use
+  `git checkout -- .` to drop only the uncommitted work, and report. **Do not `git reset` past a
+  commit this plan created**, and do not improvise a partial commit.
+
+- **Never use bare `git stash` / `git stash pop`.** The stash stack is shared across worktrees. The
+  single sanctioned exception is the tagged, apply-by-SHA probe in Task 3 Step 9.
+
+- **Whatever the failure, report it rather than working around it.** A step that cannot be completed
+  as written is a defect in this document; inventing a substitute hides it.
 
 ## Background an implementer needs
 
@@ -348,6 +409,7 @@ that assertion is what proves the fold did not drop the index.
 - [ ] **Step 7: Run the tests and watch them pass**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ -run 'TestMigrate' -v 2>&1 | tail -30
 ```
 
@@ -356,7 +418,13 @@ Expected: PASS for both new tests and the existing migration tests.
 - [ ] **Step 8: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test -race ./... 2>&1 | tail -20
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 ```
 
 Expected: `gofmt -l .` prints nothing; everything passes. **Every existing test still passes** —
@@ -365,6 +433,7 @@ integral values scan into `sql.NullInt64` from a `REAL` column without error. Th
 - [ ] **Step 9: Commit**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 git add internal/sqlite/migrations internal/sqlite/schema.go internal/sqlite/schema_test.go
 git status --porcelain
 git commit -m "fix(sqlite): declare the three measurement columns REAL; fold 0002 into 0001
@@ -454,26 +523,38 @@ func TestSummarizeObservationsPreservesFractionalLightningTotal(t *testing.T) {
 	if !s.LightningTotal.Valid {
 		t.Fatal("LightningTotal is NULL, want 5.5")
 	}
-	if s.LightningTotal.Float64 != 5.5 {
-		t.Errorf("LightningTotal = %v, want 5.5", s.LightningTotal.Float64)
-	}
 }
 ```
+
+**Note what this test deliberately does NOT do yet: it never reads `.Float64`.** That is what keeps
+it compiling against today's `sql.NullInt64` field, so its red state is a genuine runtime failure
+rather than a compile error. The value assertion is added in Step 8, after the type changes.
 
 `newTestWriter` is defined in `internal/sqlite/writer_test.go:35` and is available to every test in
 the package; it migrates the database and leaves the flush ticker dormant. `w.db` is the package's
 own field, reachable from an in-package test. If `summary_test.go` does not already import
 `github.com/google/uuid`, add it.
 
-- [ ] **Step 2: Run it and watch it fail**
+- [ ] **Step 2: Run it and watch it fail at RUNTIME**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ -run TestSummarizeObservationsPreservesFractionalLightningTotal -v 2>&1 | tail -20
 ```
 
-Expected: FAIL with a compile error on `s.LightningTotal.Float64` (the field is `sql.NullInt64`).
-A compile failure is acceptable as the red state **only for this step**, because the type itself is
-what the test is asserting. Confirm the message names `Float64` / `NullInt64`.
+Expected: FAIL — **not** a compile error — with a message containing:
+
+```
+SummarizeObservations: ... converting driver.Value type float64 ("5.5") to a int64: invalid syntax
+```
+
+`SummarizeObservations` (`internal/sqlite/writer.go:970-981`) wraps the scan error, so the
+fractional `SUM` surfaces as a returned error and `t.Fatalf` fires. That is a real red state.
+
+If instead you get a compile error, the test was written with a `.Float64` reference — remove it and
+re-run. **A compile failure does not count as a TDD red state in this project**
+(`docs/designs/2026-07-28-api-backfill-tool-design.md:449`), which is exactly why this test is
+staged in two parts.
 
 - [ ] **Step 3: Widen the read model in `internal/sqlite/writer.go`**
 
@@ -543,8 +624,47 @@ columns as plain `int64` and raw-scan them, and the seeded values `3,4,5` still 
 			reportInterval                             float64
 ```
 
-Leave `precipType int64`. Adjust any `%d` verbs for those three to `%v`, and any integer literal
-comparisons remain valid (`3 == 3.0`).
+Leave `precipType int64`. Integer literal comparisons remain valid (`3 == 3.0`). The `%d` verbs in
+this subtest are already `%v` at `:131,161,167` — nothing to change there.
+
+**There is a SECOND silent survivor of the same kind in the same file**, in the
+`nullable_fields_absent` subtest. `:198` declares:
+
+```go
+			windSampleInterval                               int64
+```
+
+change it to:
+
+```go
+			windSampleInterval                               float64
+```
+
+and at `:217` replace:
+
+```go
+			t.Errorf("wind_sample_interval = %d, want 1 (present at len=13)", windSampleInterval)
+```
+
+with:
+
+```go
+			t.Errorf("wind_sample_interval = %v, want 1 (present at len=13)", windSampleInterval)
+```
+
+The `precipType, lightningStrikeCount, reportInterval sql.NullInt64` line at `:199` also needs
+splitting — `precipType` stays `sql.NullInt64`, the other two become `sql.NullFloat64`:
+
+```go
+			precipType                               sql.NullInt64
+			lightningStrikeCount, reportInterval     sql.NullFloat64
+```
+
+and their `.Int64` reads later in the subtest become `.Float64`. Run `gofmt -w
+internal/sqlite/writer_test.go` after — the `var` block alignment changes.
+
+This subtest keeps passing either way (value `1` scans fine from a `REAL` column), which is exactly
+why it has to be fixed deliberately rather than waiting for a compiler error.
 
 `internal/sqlite/litestream_test.go:46-50` — change the declaration block:
 
@@ -597,35 +717,65 @@ over an `INTEGER` column.
 
 - [ ] **Step 7: Fix the httpserver test fixtures**
 
-`internal/httpserver/observations_test.go:70,72,82,92,94` construct `int64` locals and assign them
-into `sqlite.Observation`. Change those three to `float64` — e.g. `lightningCount := 4.0`,
-`reportInterval := 5.0`. `:325` has a `sql.NullInt64{...}` literal for `LightningTotal`; change it
-to `sql.NullFloat64{Float64: <same value>, Valid: true}`.
+Four exact find-and-replace edits in `internal/httpserver/observations_test.go`. **`:68` (`precip`)
+and `:318-319` (`CoveredFrom`/`CoveredTo`) are deliberately NOT in this list** — they stay `int64`.
 
-Read the surrounding lines before editing: match whatever the existing values are rather than
-assuming, and leave any `precipType` fixture as `int64`.
+| Line | Replace | With |
+|---|---|---|
+| `:67` | `windSample := int64(3)` | `windSample := 3.0` |
+| `:70` | `lightningCount := int64(4)` | `lightningCount := 4.0` |
+| `:72` | `reportInterval := int64(5)` | `reportInterval := 5.0` |
+| `:325` | `LightningTotal: sql.NullInt64{Int64: 4, Valid: true},` | `LightningTotal: sql.NullFloat64{Float64: 4, Valid: true},` |
 
-- [ ] **Step 8: Run the tests and watch them pass**
+The `&windSample` / `&lightningCount` / `&reportInterval` assignments at `:82,92,94` need **no
+edit** — they take the address of the retyped locals.
+
+An earlier revision listed the declarations as `:70,72,82,92,94` and said to "change those three."
+Wrong twice: it omitted `:67`, whose absence produces
+`cannot use &windSample (variable of type *int64) as *float64`, and three of the five lines it
+named are `&x` assignments where retyping means nothing.
+
+- [ ] **Step 8: Complete the fractional-`SUM` test with its value assertion**
+
+Now that `Summary.LightningTotal` is `sql.NullFloat64`, add the assertion deferred from Step 1. In
+`TestSummarizeObservationsPreservesFractionalLightningTotal`, after the `if !s.LightningTotal.Valid`
+block, add:
+
+```go
+	if s.LightningTotal.Float64 != 5.5 {
+		t.Errorf("LightningTotal = %v, want 5.5", s.LightningTotal.Float64)
+	}
+```
+
+Without this, the test only proves the scan stopped erroring — not that the value is right.
+
+- [ ] **Step 9: Run the tests and watch them pass**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ ./internal/httpserver/ 2>&1 | tail -20
 ```
 
 Expected: all pass, including the new fractional-`SUM` test.
 
-- [ ] **Step 9: Run the full gate**
+- [ ] **Step 10: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
-  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
-  go test -race ./... 2>&1 | tail -20
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 ```
 
 Expected: `gofmt -l .` prints nothing; lint clean; all tests pass.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 git add internal/sqlite internal/httpserver
 git status --porcelain
 git commit -m "fix(sqlite): read the three measurement columns as float64
@@ -737,6 +887,7 @@ func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
 - [ ] **Step 2: Run it and watch it fail**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ -run TestInsertObservationsPreservesFractionalMeasurements -v 2>&1 | tail -20
 ```
 
@@ -865,20 +1016,45 @@ JSON null to `0.0` — is still true and correct (`writer.go:100-103` are unchan
 
 - [ ] **Step 7: Update the stale comments in `internal/sqlite/backfill_test.go`**
 
-`:241-253` and the inline notes at `:263,271,273,275` describe these as INTEGER columns. Read them
-and correct the wording: the three measurement columns are `REAL` and preserve fractional values;
-`precip_type` is `INTEGER` and still truncates. Do not change any assertion values in those tests
-unless the change makes one false — if it does, report which and why before editing.
+**No assertion value changes in this step.** All four `f(...)` seeds stay exactly as they are —
+`TestInsertObservationsRoundTripsAllColumns` scans into `sql.NullFloat64`, and `3 == 3.0`, so every
+existing assertion remains true against `REAL` columns. This step is comment text only.
+
+Replace the doc-comment paragraph at `:248-253` — the whole of it, from `// wind_sample_interval,`
+through `// (a FRACTIONAL value for these four, round-tripped through a *int64 scan).`:
+
+```go
+// wind_sample_interval, lightning_strike_count, and report_interval are REAL
+// in migrations/0001_init.sql and preserve fractional values; precip_type is
+// INTEGER and still truncates. This test keeps all four integral anyway —
+// its job is pinning bind ORDER, not value fidelity, which is
+// TestInsertObservationsPreservesFractionalMeasurements's coverage.
+```
+
+That replacement is also what satisfies Final Verification #2: the old text names `asInt64`, a
+function this task deletes, and `TestInsertObservationsStoresIntegerColumnsAsIntegers`, a test
+Step 1 renamed. Leaving it makes `git grep 'asInt64' -- ':!docs/'` non-empty and leaves a comment
+pointing at a function that no longer exists.
+
+Then the four inline notes. Each currently reads `// INTEGER column: kept integral`:
+
+| Line | Replace with |
+|---|---|
+| `:263` (`WindSampleInterval: f(3),`) | `// REAL column: integral here; fidelity is pinned elsewhere` |
+| `:271` (`PrecipType: f(1),`) | `// INTEGER column: kept integral` — **unchanged** |
+| `:273` (`LightningStrikeCount: f(2),`) | `// REAL column: integral here; fidelity is pinned elsewhere` |
+| `:275` (`ReportInterval: f(5),`) | `// REAL column: integral here; fidelity is pinned elsewhere` |
 
 - [ ] **Step 8: Run the tests and watch them pass**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ -v 2>&1 | tail -30
 ```
 
 Expected: all pass, including `TestInsertObservationsPreservesFractionalMeasurements`.
 
-- [ ] **Step 9: Add a UDP-path round-trip test**
+- [ ] **Step 9: Add a UDP-path round-trip test — and prove it bites**
 
 The REST path is now covered; the UDP path is not. Add to `internal/sqlite/writer_test.go`:
 
@@ -941,24 +1117,46 @@ changed to fractional values. `tempestudp` and `uuid` are already imported by th
 Run it and watch it pass:
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go test ./internal/sqlite/ -run TestWriter_PreservesFractionalMeasurements -v 2>&1 | tail -20
 ```
 
-If you run this **before** Steps 3–5, it fails with `wind_sample_interval = 1, want 1.5` — that is
-the same red state Step 2 already demonstrated for the REST path, and running it early is a
-legitimate way to prove this test bites too.
+**You MUST prove this test bites.** It is written after the implementation, so on its own it is a
+characterization test with no red state — and a per-task reviewer will reject a report that shows
+none. Demonstrate it by reverting the write path, running the test, and restoring:
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+git stash push -u -m "udp-red-probe-$(date +%s)" -- internal/sqlite/writer.go internal/sqlite/backfill.go
+STASH=$(git stash list --format='%H %gs' | grep udp-red-probe | head -1 | cut -d' ' -f1)
+go test ./internal/sqlite/ -run TestWriter_PreservesFractionalMeasurements 2>&1 | tail -8
+git stash apply "$STASH"
+git stash drop "$(git stash list --format='%gd %gs' | grep udp-red-probe | head -1 | cut -d' ' -f1)"
+```
+
+Expected during the probe: FAIL with `wind_sample_interval = 1, want 1.5`. Then confirm the
+restore left the tree correct by re-running the test — it must PASS.
+
+Note this is the ONE sanctioned use of `git stash` in this plan, it is tagged and applied by SHA
+(never `git stash pop`), and it is scoped to two files. Record the probe's failing output in your
+task report as the red-state evidence.
 
 - [ ] **Step 10: Run the full gate**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
-  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
-  go test -race ./... 2>&1 | tail -20
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 ```
 
 - [ ] **Step 11: Commit**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 git add internal/sqlite
 git status --porcelain
 git commit -m "fix(sqlite): stop truncating measurement columns on the write path
@@ -1029,6 +1227,10 @@ Replace the `tests` job (currently `:15-22`) with:
       # standard untagged suite runs -- `-tags integration` is deliberately not
       # enabled, because it holds the known-failing drain-on-close test (#111).
       postgres:
+        # Floating tag, deliberately: every action in this repo is SHA-pinned,
+        # but a test-only service container is not a supply-chain surface the
+        # way an action that runs with repo credentials is, and Renovate keeps
+        # the three copies of this block in step by matching the tag string.
         image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
@@ -1089,6 +1291,7 @@ unchanged:
 - [ ] **Step 5: Verify the workflows are valid**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12; echo "exit=$?"
 ```
 
@@ -1099,6 +1302,7 @@ actions.
 - [ ] **Step 6: Verify the tests actually run with a database**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 docker run --rm -d --name pg-conformance -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16
 until docker exec pg-conformance pg_isready -U postgres; do sleep 1; done
 POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
@@ -1106,16 +1310,33 @@ POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disab
 docker rm -f pg-conformance
 ```
 
-Expected: `TestBackfillPostgresIntegration` runs and PASSes rather than skipping. `internal/config`
-is included deliberately: its tests read and write `POSTGRES_URL` via `t.Setenv`, and this confirms
-a globally-set value does not disturb them. If any `internal/config` test fails only when
-`POSTGRES_URL` is set, stop and report — that is a real interaction the design flagged as needing
-verification.
+Expected: `TestBackfillPostgresIntegration` runs and PASSes rather than skipping.
+
+Then run the **whole** suite with the variable set — the root package's `backfill_cmd_test.go:234`
+sets `ENABLE_POSTGRES=true` without touching `POSTGRES_URL`, and `internal/config`'s tests read and
+write it via `t.Setenv`, so a globally-set value could disturb either:
+
+```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
+  go test -race ./... -count=1 2>&1 | tail -10
+docker rm -f pg-conformance
+```
+
+Expected: **390 passed** — one more than the 389 that pass without `POSTGRES_URL`, the extra being
+`TestBackfillPostgresIntegration` no longer skipping. If any test fails ONLY when `POSTGRES_URL` is
+set, stop and report; that is a real interaction, not a flake.
 
 - [ ] **Step 7: Run the full gate and commit**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && go test -race ./... 2>&1 | tail -10
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 git add .github
 git status --porcelain
 git commit -m "ci: run the Postgres suite against a real database
@@ -1235,6 +1456,7 @@ above.
 - [ ] **Step 2: Run it against a real database and watch the result**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 docker run --rm -d --name pg-conformance -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16
 until docker exec pg-conformance pg_isready -U postgres; do sleep 1; done
 POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
@@ -1279,6 +1501,7 @@ Then change the bind at `:159`:
 - [ ] **Step 4: Re-run and confirm the behaviour is unchanged**
 
 ```bash
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
 POSTGRES_URL='postgres://postgres:postgres@localhost:55432/weather?sslmode=disable' \
   go test ./internal/postgres/ -count=1 2>&1 | tail -20
 docker rm -f pg-conformance
@@ -1289,9 +1512,13 @@ Expected: still PASS, with the same `precip_type = 1`. A behaviour change here i
 - [ ] **Step 5: Run the full gate and commit**
 
 ```bash
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
-  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
-  go test -race ./... 2>&1 | tail -10
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 git add internal/postgres
 git status --porcelain
 git commit -m "refactor(postgres): make the precip_type truncation explicit
@@ -1322,7 +1549,10 @@ cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-c
 # 1. The three columns are REAL; precip_type is not
 go test ./internal/sqlite/ -run TestMigrateDeclaresMeasurementColumnsAsREAL -v 2>&1 | tail -5
 
-# 2. No truncating helper survives under its old name
+# 2. No truncating helper survives under its old name.
+# Satisfied by Task 3 Step 6 (deletes the function) AND Task 3 Step 7 (rewrites the
+# backfill_test.go:248-253 doc comment that names it). If this returns a hit in a
+# comment, Step 7 was skipped.
 git grep -n 'asInt64' -- ':!docs/'; echo "exit=$?"          # expect exit=1, no output
 
 # 3. The folded migration is gone and only 0001 remains
@@ -1335,9 +1565,13 @@ git grep -n '0002_add_timestamp_index' -- ':!docs/'; echo "exit=$?"   # expect e
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12; echo "exit=$?"   # expect exit=0
 
 # 6. Full gate, no database
-CGO_ENABLED=0 go build ./... && go vet ./... && gofmt -l . && \
-  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... && \
-  go test -race ./...
+cd /Users/acaudill/Projects/github/tempestwx-exporter/.claude/worktrees/schema-conformance
+CGO_ENABLED=0 go build ./... || exit 1
+go vet ./... || exit 1
+unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then echo "UNFORMATTED: $unformatted"; exit 1; fi
+GOLANGCI_LINT_CACHE=/tmp/golangci-schema-conformance \
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./... || exit 1
+go test -race ./... 2>&1 | tail -20
 
 # 7. Full gate, with a database -- the Postgres tests must RUN, not skip
 docker run --rm -d --name pg-final -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=weather -p 55432:5432 postgres:16

--- a/internal/httpserver/observations.go
+++ b/internal/httpserver/observations.go
@@ -67,7 +67,7 @@ type currentObservation struct {
 	WindAvg                    float64 `json:"windAvg"`
 	WindGust                   float64 `json:"windGust"`
 	WindDirection              float64 `json:"windDirection"`
-	WindSampleInterval         int64   `json:"windSampleInterval"`
+	WindSampleInterval         float64 `json:"windSampleInterval"`
 	StationPressure            float64 `json:"stationPressure"`
 	AirTemperature             float64 `json:"airTemperature"`
 	RelativeHumidity           float64 `json:"relativeHumidity"`
@@ -77,9 +77,9 @@ type currentObservation struct {
 	RainAccumulated            float64 `json:"rainAccumulated"`
 	PrecipitationType          int64   `json:"precipitationType"`
 	LightningStrikeAvgDistance float64 `json:"lightningStrikeAvgDistance"`
-	LightningStrikeCount       int64   `json:"lightningStrikeCount"`
+	LightningStrikeCount       float64 `json:"lightningStrikeCount"`
 	Battery                    float64 `json:"battery"`
-	ReportInterval             int64   `json:"reportInterval"`
+	ReportInterval             float64 `json:"reportInterval"`
 	LocalDayRainAccumulation   float64 `json:"localDayRainAccumulation"`
 	FeelsLike                  float64 `json:"feelsLike"`
 	DewPoint                   float64 `json:"dewPoint"`
@@ -127,7 +127,7 @@ type summaryResponse struct {
 	WindMax        *float64      `json:"windMax"`
 	GustMax        *float64      `json:"gustMax"`
 	RainTotal      *float64      `json:"rainTotal"`
-	LightningTotal *int64        `json:"lightningTotal"`
+	LightningTotal *float64      `json:"lightningTotal"`
 }
 
 // summaryQueryTimeout bounds handleSummary's SummarizeObservations call so a
@@ -277,7 +277,7 @@ func handleSummary(w http.ResponseWriter, r *http.Request, reader ObservationRea
 		WindMax:        f64(s.WindMax),
 		GustMax:        f64(s.GustMax),
 		RainTotal:      f64(s.RainTotal),
-		LightningTotal: i64(s.LightningTotal),
+		LightningTotal: f64(s.LightningTotal),
 	})
 }
 

--- a/internal/httpserver/observations_test.go
+++ b/internal/httpserver/observations_test.go
@@ -163,6 +163,61 @@ func TestAPI_CurrentObservation(t *testing.T) {
 		}
 	})
 
+	// TestAPI_CurrentObservation/fractional_measurements_survive_to_json pins
+	// the schema-conformance fix (SGE fix wave, Fix 2): WindSampleInterval,
+	// LightningStrikeCount, and ReportInterval are float64 on the wire, not
+	// int64. A regression that narrows any of them at the mapping site (the
+	// exact bug this branch removed at the SQLite/Postgres boundary) would
+	// leave TestAPI_CurrentObservation/returns_contract_c_shape green,
+	// because that subtest's fixtures are integral and it only asserts key
+	// presence for these fields. precipitationType stays an int on the wire
+	// (categorical enum) and is asserted unchanged alongside the three
+	// floats.
+	t.Run("fractional_measurements_survive_to_json", func(t *testing.T) {
+		windSample := 1.5
+		precip := int64(1)
+		lightningCount := 2.5
+		reportInterval := 5.9
+
+		reader := &fakeObservationReader{
+			obs: sqlite.Observation{
+				SerialNumber:         "ST-00001",
+				Timestamp:            1700000000,
+				WindSampleInterval:   &windSample,
+				PrecipType:           &precip,
+				LightningStrikeCount: &lightningCount,
+				ReportInterval:       &reportInterval,
+			},
+		}
+
+		srv := New(testDepsWithObservations(reader))
+		req := httptest.NewRequest(http.MethodGet, "/api/observations/current", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /api/observations/current = %d, want 200, body: %s", rec.Code, rec.Body.String())
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal response: %v (body: %s)", err, rec.Body.String())
+		}
+
+		if got["windSampleInterval"] != 1.5 {
+			t.Errorf("windSampleInterval = %v, want 1.5", got["windSampleInterval"])
+		}
+		if got["lightningStrikeCount"] != 2.5 {
+			t.Errorf("lightningStrikeCount = %v, want 2.5", got["lightningStrikeCount"])
+		}
+		if got["reportInterval"] != 5.9 {
+			t.Errorf("reportInterval = %v, want 5.9", got["reportInterval"])
+		}
+		if got["precipitationType"] != float64(1) {
+			t.Errorf("precipitationType = %v, want 1", got["precipitationType"])
+		}
+	})
+
 	t.Run("not_found_returns_404_json", func(t *testing.T) {
 		reader := &fakeObservationReader{obsErr: sqlite.ErrObservationNotFound}
 		srv := New(testDepsWithObservations(reader))

--- a/internal/httpserver/observations_test.go
+++ b/internal/httpserver/observations_test.go
@@ -64,12 +64,12 @@ func testDepsWithObservations(reader ObservationReader) Deps {
 // one derived (server-computed) field, and 404s with the sentinel error.
 func TestAPI_CurrentObservation(t *testing.T) {
 	t.Run("returns_contract_c_shape", func(t *testing.T) {
-		windSample := int64(3)
+		windSample := 3.0
 		precip := int64(1)
 		lightningDist := 2.1
-		lightningCount := int64(4)
+		lightningCount := 4.0
 		battery := 3.6
-		reportInterval := int64(5)
+		reportInterval := 5.0
 
 		reader := &fakeObservationReader{
 			obs: sqlite.Observation{
@@ -322,7 +322,7 @@ func TestHandleSummary_OK(t *testing.T) {
 		WindMax:        sql.NullFloat64{Float64: 8, Valid: true},
 		GustMax:        sql.NullFloat64{Float64: 12, Valid: true},
 		RainTotal:      sql.NullFloat64{Float64: 3.5, Valid: true},
-		LightningTotal: sql.NullInt64{Int64: 4, Valid: true},
+		LightningTotal: sql.NullFloat64{Float64: 4, Valid: true},
 	}}
 
 	srv := New(testDepsWithObservations(reader))

--- a/internal/postgres/backfill.go
+++ b/internal/postgres/backfill.go
@@ -135,6 +135,20 @@ func DistinctSerials(ctx context.Context, pool *pgxpool.Pool) ([]string, error) 
 	return out, nil
 }
 
+// asPrecipType converts a possibly-nil *float64 into a possibly-nil *int for
+// precip_type, which is INTEGER here and in SQLite. pgx already truncates a
+// float bind into an integer column silently; doing it here makes the
+// coercion visible and matches the daemon path (writer.go's
+// handleObservationReport) and internal/sqlite's helper of the same name.
+// Nil maps to SQL NULL.
+func asPrecipType(p *float64) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+
 // InsertObservations writes obs idempotently and reports how many rows were
 // actually new. CommandTag.RowsAffected() is 0 for a skipped conflict and 1
 // for an insert — the same semantics as SQLite's per-row RowsAffected, and
@@ -156,7 +170,7 @@ func InsertObservations(ctx context.Context, pool *pgxpool.Pool, obs []weather.O
 			uuid.Must(uuid.NewV7()), o.SerialNumber, o.Timestamp,
 			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
 			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
-			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, o.PrecipType,
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asPrecipType(o.PrecipType),
 			o.LightningDistance, o.LightningStrikeCount,
 			o.Battery, o.ReportInterval)
 	}

--- a/internal/postgres/backfill_test.go
+++ b/internal/postgres/backfill_test.go
@@ -438,6 +438,10 @@ func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
 
 	serial := "ST-FRAC"
 	stamp := time.Unix(1_900_000_000, 0).UTC()
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM tempest_observations WHERE serial_number = $1`, serial)
+	})
 	if _, err := pool.Exec(ctx,
 		`DELETE FROM tempest_observations WHERE serial_number = $1`, serial); err != nil {
 		t.Fatalf("clean: %v", err)

--- a/internal/postgres/backfill_test.go
+++ b/internal/postgres/backfill_test.go
@@ -413,3 +413,69 @@ func TestBackfillPostgresIntegration(t *testing.T) {
 		t.Errorf("did not find the %s hole [%v, %v]; got %+v", serialA, base, base.Add(time.Hour), gaps)
 	}
 }
+
+// TestInsertObservationsPreservesFractionalMeasurements is the Postgres half
+// of the cross-store conformance pinned on the SQLite side by
+// TestInsertObservationsPreservesFractionalMeasurements in internal/sqlite.
+// The three measurement columns are DOUBLE PRECISION here and REAL there, so
+// a fractional API value must survive both. precip_type is INTEGER in both
+// and truncates in both.
+func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("POSTGRES_URL not set; skipping Postgres integration test")
+	}
+
+	ctx := t.Context()
+	pool, err := OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("OpenPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := CreateSchema(ctx, pool); err != nil {
+		t.Fatalf("CreateSchema: %v", err)
+	}
+
+	serial := "ST-FRAC"
+	stamp := time.Unix(1_900_000_000, 0).UTC()
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM tempest_observations WHERE serial_number = $1`, serial); err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+
+	obs := []weather.Observation{{
+		SerialNumber:         serial,
+		Timestamp:            stamp,
+		WindSampleInterval:   f(1.5),
+		PrecipType:           f(1.9),
+		LightningStrikeCount: f(2.5),
+		ReportInterval:       f(5.9),
+	}}
+	if _, err := InsertObservations(ctx, pool, obs); err != nil {
+		t.Fatalf("InsertObservations: %v", err)
+	}
+
+	var windSampleInterval, lightningStrikeCount, reportInterval float64
+	var precipType int
+	err = pool.QueryRow(ctx, `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = $1 AND timestamp = $2`,
+		serial, stamp,
+	).Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	if windSampleInterval != 1.5 {
+		t.Errorf("wind_sample_interval = %v, want 1.5", windSampleInterval)
+	}
+	if lightningStrikeCount != 2.5 {
+		t.Errorf("lightning_strike_count = %v, want 2.5", lightningStrikeCount)
+	}
+	if reportInterval != 5.9 {
+		t.Errorf("report_interval = %v, want 5.9", reportInterval)
+	}
+	if precipType != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: truncated by design)", precipType)
+	}
+}

--- a/internal/sqlite/backfill.go
+++ b/internal/sqlite/backfill.go
@@ -149,7 +149,7 @@ func DistinctSerials(ctx context.Context, db *sql.DB) ([]string, error) {
 // The count is what makes the permanent-hole tradeoff visible: if the station
 // was genuinely offline, the API has no data either, and inserted stays 0
 // across runs. ON CONFLICT (serial_number, timestamp) DO NOTHING is backed by
-// a real UNIQUE constraint (migrations/0002_init.sql:13), and per-row
+// a real UNIQUE constraint (migrations/0002_init.sql:22), and per-row
 // RowsAffected returns 0 for a skipped conflict and 1 for an insert.
 //
 // The count is returned only after a successful Commit — execBatch rolls the

--- a/internal/sqlite/backfill.go
+++ b/internal/sqlite/backfill.go
@@ -170,11 +170,11 @@ func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observati
 	err := execBatch(ctx, db, insertObservationSQL, obs, func(stmt *sql.Stmt, o weather.Observation) error {
 		res, err := stmt.ExecContext(ctx,
 			uuid.Must(uuid.NewV7()).String(), o.SerialNumber, o.Timestamp.Unix(),
-			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, asInt64(o.WindSampleInterval),
+			o.WindLull, o.WindAvg, o.WindGust, o.WindDirection, o.WindSampleInterval,
 			o.Pressure, o.TempAir, wetBulb(o), o.Humidity,
-			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asInt64(o.PrecipType),
-			o.LightningDistance, asInt64(o.LightningStrikeCount),
-			o.Battery, asInt64(o.ReportInterval))
+			o.Illuminance, o.UVIndex, o.Irradiance, o.RainRate, asPrecipType(o.PrecipType),
+			o.LightningDistance, o.LightningStrikeCount,
+			o.Battery, o.ReportInterval)
 		if err != nil {
 			return err
 		}
@@ -191,15 +191,14 @@ func InsertObservations(ctx context.Context, db *sql.DB, obs []weather.Observati
 	return inserted, nil
 }
 
-// asInt64 converts a possibly-nil *float64 into a possibly-nil *int64,
-// matching how the UDP path stores wind_sample_interval, precip_type,
-// lightning_strike_count, and report_interval (writer.go:436-457, fix
-// B-LOW): the SQLite DDL declares these columns INTEGER, and the read model
-// scans them into *int64. Binding one of these fields as *float64 with a
-// fractional value stores it with REAL affinity, which then fails a *int64
-// scan for the whole row. int64(...) truncation, not rounding, mirrors the
-// UDP path exactly. Nil maps to SQL NULL.
-func asInt64(p *float64) *int64 {
+// asPrecipType converts a possibly-nil *float64 into a possibly-nil *int64
+// for precip_type, which is INTEGER in both stores. Unlike the three
+// measurement columns, precip_type is a categorical enum (0 none, 1 rain,
+// 2 hail, 3 rain + hail), so a fractional value is corrupt input and
+// int64(...) truncation -- matching the UDP path at writer.go's
+// handleObservationReport -- is the intended coercion, not data loss. Nil
+// maps to SQL NULL.
+func asPrecipType(p *float64) *int64 {
 	if p == nil {
 		return nil
 	}

--- a/internal/sqlite/backfill.go
+++ b/internal/sqlite/backfill.go
@@ -149,7 +149,7 @@ func DistinctSerials(ctx context.Context, db *sql.DB) ([]string, error) {
 // The count is what makes the permanent-hole tradeoff visible: if the station
 // was genuinely offline, the API has no data either, and inserted stays 0
 // across runs. ON CONFLICT (serial_number, timestamp) DO NOTHING is backed by
-// a real UNIQUE constraint (migrations/0001_init.sql:13), and per-row
+// a real UNIQUE constraint (migrations/0002_init.sql:13), and per-row
 // RowsAffected returns 0 for a skipped conflict and 1 for an insert.
 //
 // The count is returned only after a successful Commit — execBatch rolls the

--- a/internal/sqlite/backfill_test.go
+++ b/internal/sqlite/backfill_test.go
@@ -245,12 +245,11 @@ func TestInsertObservationsEmptyIsNoop(t *testing.T) {
 // column value and fails this test by name, rather than leaving the whole
 // suite green.
 //
-// wind_sample_interval, precip_type, lightning_strike_count, and
-// report_interval are declared INTEGER in migrations/0001_init.sql, so this
-// test keeps those four fields integral — this test's job is pinning bind
-// ORDER, not the *float64-into-INTEGER-column conversion, which is asInt64's
-// job and TestInsertObservationsStoresIntegerColumnsAsIntegers's coverage
-// (a FRACTIONAL value for these four, round-tripped through a *int64 scan).
+// wind_sample_interval, lightning_strike_count, and report_interval are REAL
+// in migrations/0001_init.sql and preserve fractional values; precip_type is
+// INTEGER and still truncates. This test keeps all four integral anyway —
+// its job is pinning bind ORDER, not value fidelity, which is
+// TestInsertObservationsPreservesFractionalMeasurements's coverage.
 func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 	db := newTestDB(t)
 	o := weather.Observation{
@@ -260,7 +259,7 @@ func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 		WindAvg:              f(3.5),
 		WindGust:             f(6.5),
 		WindDirection:        f(180),
-		WindSampleInterval:   f(3), // INTEGER column: kept integral
+		WindSampleInterval:   f(3), // REAL column: integral here; fidelity is pinned elsewhere
 		Pressure:             f(1013.25),
 		TempAir:              f(22.5),
 		Humidity:             f(65),
@@ -270,9 +269,9 @@ func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 		RainRate:             f(0.5),
 		PrecipType:           f(1), // INTEGER column: kept integral
 		LightningDistance:    f(12.5),
-		LightningStrikeCount: f(2), // INTEGER column: kept integral
+		LightningStrikeCount: f(2), // REAL column: integral here; fidelity is pinned elsewhere
 		Battery:              f(2.85),
-		ReportInterval:       f(5), // INTEGER column: kept integral
+		ReportInterval:       f(5), // REAL column: integral here; fidelity is pinned elsewhere
 	}
 
 	if _, err := InsertObservations(t.Context(), db, []weather.Observation{o}); err != nil {
@@ -347,18 +346,15 @@ func TestInsertObservationsRoundTripsAllColumns(t *testing.T) {
 	}
 }
 
-// TestInsertObservationsStoresIntegerColumnsAsIntegers pins the fix for the
-// *float64-into-INTEGER-column hazard: wind_sample_interval, precip_type,
-// lightning_strike_count, and report_interval are declared INTEGER in
-// migrations/0001_init.sql, and the UDP read model (writer.go, fix B-LOW)
-// scans them into *int64. Binding a *float64 with a FRACTIONAL value stores
-// it with SQLite REAL affinity, which then fails a *int64 scan for the WHOLE
-// ROW it is part of — not just that column. InsertObservations must convert
-// these four fields to an integral bind exactly the way the UDP path does
-// (writer.go handleObservationReport, fix B-LOW: int64(...) truncation)
-// before binding, so a fractional API value is stored — and reads back — as
-// an integer, indistinguishable from a live UDP-ingested row.
-func TestInsertObservationsStoresIntegerColumnsAsIntegers(t *testing.T) {
+// TestInsertObservationsPreservesFractionalMeasurements pins the cross-store
+// conformance fix: wind_sample_interval, lightning_strike_count, and
+// report_interval are REAL in SQLite and DOUBLE PRECISION in Postgres, so a
+// fractional API value must survive the SQLite write path unchanged rather
+// than being truncated in Go. precip_type is the deliberate exception -- a
+// categorical enum (0 none, 1 rain, 2 hail, 3 rain+hail), INTEGER in both
+// stores, where a fractional value is corrupt input and truncation is the
+// intended coercion.
+func TestInsertObservationsPreservesFractionalMeasurements(t *testing.T) {
 	db := newTestDB(t)
 	obs := []weather.Observation{
 		{
@@ -374,38 +370,40 @@ func TestInsertObservationsStoresIntegerColumnsAsIntegers(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	// Scan into *int64 — the read model's declared type for these columns.
-	// This is the exact scan that fails with "converting driver.Value type
-	// float64 (...) to a int64: invalid syntax" when a fractional value was
-	// bound as *float64 instead of converted to *int64 first.
-	var windSampleInterval, precipType, lightningStrikeCount, reportInterval sql.NullInt64
+	var windSampleInterval, lightningStrikeCount, reportInterval sql.NullFloat64
+	var precipType sql.NullInt64
 	row := db.QueryRowContext(t.Context(), `
 		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
 		FROM tempest_observations WHERE serial_number = ? AND timestamp = ?`,
 		"ST-A", ts(1000).Unix())
 	if err := row.Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval); err != nil {
-		t.Fatalf("scan into *int64 (the read model's declared type): %v", err)
+		t.Fatalf("scan: %v", err)
 	}
 
-	cases := []struct {
+	measurements := []struct {
 		column string
-		got    sql.NullInt64
-		want   int64
+		got    sql.NullFloat64
+		want   float64
 	}{
-		{"wind_sample_interval", windSampleInterval, 1},
-		{"precip_type", precipType, 1},
-		{"lightning_strike_count", lightningStrikeCount, 2},
-		{"report_interval", reportInterval, 5},
+		{"wind_sample_interval", windSampleInterval, 1.5},
+		{"lightning_strike_count", lightningStrikeCount, 2.5},
+		{"report_interval", reportInterval, 5.9},
 	}
-	for _, c := range cases {
+	for _, c := range measurements {
 		if !c.got.Valid {
-			t.Errorf("%s = NULL, want %d", c.column, c.want)
+			t.Errorf("%s = NULL, want %v", c.column, c.want)
 			continue
 		}
-		if c.got.Int64 != c.want {
-			t.Errorf("%s = %d, want %d (truncated from the fractional API value, matching "+
-				"the UDP path's int64(...) conversion)", c.column, c.got.Int64, c.want)
+		if c.got.Float64 != c.want {
+			t.Errorf("%s = %v, want %v (fractional API value must not be truncated)", c.column, c.got.Float64, c.want)
 		}
+	}
+
+	if !precipType.Valid {
+		t.Fatal("precip_type = NULL, want 1")
+	}
+	if precipType.Int64 != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: still truncated by design)", precipType.Int64)
 	}
 }
 

--- a/internal/sqlite/backfill_test.go
+++ b/internal/sqlite/backfill_test.go
@@ -246,7 +246,7 @@ func TestInsertObservationsEmptyIsNoop(t *testing.T) {
 // suite green.
 //
 // wind_sample_interval, lightning_strike_count, and report_interval are REAL
-// in migrations/0001_init.sql and preserve fractional values; precip_type is
+// in migrations/0002_init.sql and preserve fractional values; precip_type is
 // INTEGER and still truncates. This test keeps all four integral anyway —
 // its job is pinning bind ORDER, not value fidelity, which is
 // TestInsertObservationsPreservesFractionalMeasurements's coverage.

--- a/internal/sqlite/litestream_test.go
+++ b/internal/sqlite/litestream_test.go
@@ -44,10 +44,10 @@ func queryAllObservations(t *testing.T, db *sql.DB) []Observation {
 	var got []Observation
 	for rows.Next() {
 		var (
-			obs                                     Observation
-			windSampleInterval, precipType          sql.NullInt64
-			lightningStrikeCount, reportInterval    sql.NullInt64
-			tempWetbulb, lightningDistance, battery sql.NullFloat64
+			obs                                                      Observation
+			precipType                                               sql.NullInt64
+			windSampleInterval, lightningStrikeCount, reportInterval sql.NullFloat64
+			tempWetbulb, lightningDistance, battery                  sql.NullFloat64
 		)
 		if err := rows.Scan(
 			&obs.ID, &obs.SerialNumber, &obs.Timestamp,
@@ -60,7 +60,7 @@ func queryAllObservations(t *testing.T, db *sql.DB) []Observation {
 			t.Fatalf("scan observation row: %v", err)
 		}
 		if windSampleInterval.Valid {
-			obs.WindSampleInterval = &windSampleInterval.Int64
+			obs.WindSampleInterval = &windSampleInterval.Float64
 		}
 		if tempWetbulb.Valid {
 			obs.TempWetbulb = &tempWetbulb.Float64
@@ -72,13 +72,13 @@ func queryAllObservations(t *testing.T, db *sql.DB) []Observation {
 			obs.LightningDistance = &lightningDistance.Float64
 		}
 		if lightningStrikeCount.Valid {
-			obs.LightningStrikeCount = &lightningStrikeCount.Int64
+			obs.LightningStrikeCount = &lightningStrikeCount.Float64
 		}
 		if battery.Valid {
 			obs.Battery = &battery.Float64
 		}
 		if reportInterval.Valid {
-			obs.ReportInterval = &reportInterval.Int64
+			obs.ReportInterval = &reportInterval.Float64
 		}
 		got = append(got, obs)
 	}

--- a/internal/sqlite/migrations/0001_init.sql
+++ b/internal/sqlite/migrations/0001_init.sql
@@ -4,12 +4,12 @@ CREATE TABLE IF NOT EXISTS tempest_observations (
   serial_number TEXT NOT NULL,
   timestamp INTEGER NOT NULL,          -- ob[0] epoch
   wind_lull REAL, wind_avg REAL, wind_gust REAL, wind_direction REAL,
-  wind_sample_interval INTEGER,
+  wind_sample_interval REAL,
   pressure REAL, temp_air REAL, temp_wetbulb REAL, humidity REAL,
   illuminance REAL, uv_index REAL, irradiance REAL, rain_rate REAL,
-  precip_type INTEGER,
-  lightning_distance REAL, lightning_strike_count INTEGER,   -- INTEGER not float (fix B-LOW)
-  battery REAL, report_interval INTEGER,
+  precip_type INTEGER,                 -- categorical enum (0 none, 1 rain, 2 hail, 3 rain+hail), not a measurement
+  lightning_distance REAL, lightning_strike_count REAL,
+  battery REAL, report_interval REAL,
   UNIQUE(serial_number, timestamp)     -- backs ON CONFLICT DO NOTHING
 );
 CREATE TABLE IF NOT EXISTS tempest_rapid_wind (
@@ -27,4 +27,11 @@ CREATE TABLE IF NOT EXISTS tempest_events (
   UNIQUE(serial_number, timestamp, event_type)
 );
 CREATE INDEX IF NOT EXISTS idx_obs_serial_time ON tempest_observations(serial_number, timestamp);
+-- The read hot-path (LatestObservationAny's ORDER BY timestamp DESC LIMIT 1,
+-- HistoryPoints' WHERE timestamp BETWEEN ?) filters/sorts on timestamp alone.
+-- idx_obs_serial_time leads with serial_number, so neither query can use it and
+-- both fall back to a full table scan + sort, serialized against the single
+-- writer connection (SGE review I1). This index leads with timestamp so both
+-- queries can use it directly.
+CREATE INDEX IF NOT EXISTS idx_obs_time ON tempest_observations(timestamp);
 CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);

--- a/internal/sqlite/migrations/0002_add_timestamp_index.sql
+++ b/internal/sqlite/migrations/0002_add_timestamp_index.sql
@@ -1,7 +1,0 @@
--- The read hot-path (LatestObservationAny's ORDER BY timestamp DESC LIMIT 1,
--- HistoryPoints' WHERE timestamp BETWEEN ?) filters/sorts on timestamp alone.
--- idx_obs_serial_time (0001_init.sql) leads with serial_number, so neither
--- query can use it and both fall back to a full table scan + sort, serialized
--- against the single writer connection (SGE review I1). This index leads
--- with timestamp so both queries can use it directly.
-CREATE INDEX IF NOT EXISTS idx_obs_time ON tempest_observations(timestamp);

--- a/internal/sqlite/migrations/0002_init.sql
+++ b/internal/sqlite/migrations/0002_init.sql
@@ -1,3 +1,12 @@
+-- This file starts at 0002, not 0001: released v3.0.0/v3.1.0 already shipped
+-- 0001_init.sql AND 0002_add_timestamp_index.sql, so every database they ever
+-- created is at schema_version = 2. A migration numbered 0001 here would be
+-- skipped outright on any of those databases (Migrate applies only versions
+-- > current). This file folds both of those migrations together and keeps
+-- their combined version number so it is still applied as version 2 on a
+-- fresh install, matching what every released binary already reaches. The
+-- next migration after this one MUST be numbered 0003.
+--
 -- All timestamps stored as INTEGER unix-epoch seconds (UTC). UUIDv7 text PKs generated in Go.
 CREATE TABLE IF NOT EXISTS tempest_observations (
   id TEXT PRIMARY KEY,                 -- UUIDv7

--- a/internal/sqlite/schema.go
+++ b/internal/sqlite/schema.go
@@ -31,22 +31,47 @@ func Migrate(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("determine current schema version: %w", err)
 	}
 
+	type migration struct {
+		name    string
+		version int
+	}
+	migrations := make([]migration, 0, len(entries))
+	highest := 0
 	for _, entry := range entries {
 		version, err := migrationVersion(entry.Name())
 		if err != nil {
 			return fmt.Errorf("parse migration version from %q: %w", entry.Name(), err)
 		}
-		if version <= current {
+		migrations = append(migrations, migration{name: entry.Name(), version: version})
+		if version > highest {
+			highest = version
+		}
+	}
+
+	// A database newer than this binary must fail loudly. The loop below
+	// skips any migration whose version is <= current, so an older binary
+	// pointed at a newer database would apply nothing and report success --
+	// and would go on silently skipping every future migration numbered at
+	// or below the version the database already records.
+	if current > highest {
+		return fmt.Errorf(
+			"database schema version %d is newer than the highest bundled migration (%d): "+
+				"this binary is older than the database it was pointed at",
+			current, highest)
+	}
+
+	for _, m := range migrations {
+		if m.version <= current {
 			continue
 		}
 
-		content, err := migrationsFS.ReadFile(migrationsDir + "/" + entry.Name())
+		content, err := migrationsFS.ReadFile(migrationsDir + "/" + m.name)
 		if err != nil {
-			return fmt.Errorf("read migration %q: %w", entry.Name(), err)
+			return fmt.Errorf("read migration %q: %w", m.name, err)
 		}
 
-		if err := applyMigration(ctx, db, version, string(content)); err != nil {
-			return fmt.Errorf("apply migration %q: %w", entry.Name(), err)
+		if err := applyMigration(ctx, db, m.version, string(content)); err != nil {
+			return fmt.Errorf("apply migration %q: %w", m.name, err)
 		}
 	}
 

--- a/internal/sqlite/schema.go
+++ b/internal/sqlite/schema.go
@@ -55,8 +55,9 @@ func Migrate(ctx context.Context, db *sql.DB) error {
 	// or below the version the database already records.
 	if current > highest {
 		return fmt.Errorf(
-			"database schema version %d is newer than the highest bundled migration (%d): "+
-				"this binary is older than the database it was pointed at",
+			"database schema version %d exceeds the highest migration bundled in this binary (%d): "+
+				"the database was written by a newer build, so this one cannot safely open it — "+
+				"upgrade the binary rather than downgrading the database",
 			current, highest)
 	}
 
@@ -143,7 +144,7 @@ func splitStatements(content string) []string {
 }
 
 // migrationVersion parses the numeric version prefix from a migration
-// filename (e.g. "0001_init.sql" -> 1). Version prefixes must be
+// filename (e.g. "0002_init.sql" -> 2). Version prefixes must be
 // zero-padded consistently so that lexicographic filename ordering (used by
 // fs.ReadDir) matches numeric version ordering.
 func migrationVersion(filename string) (int, error) {

--- a/internal/sqlite/schema_test.go
+++ b/internal/sqlite/schema_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -34,20 +35,75 @@ func TestMigrate_CreatesTablesAndVersion(t *testing.T) {
 		assertTableExists(t, db, table)
 	}
 	assertIndexExists(t, db, "idx_obs_serial_time")
-	// idx_obs_time (0002_add_timestamp_index.sql) leads with timestamp alone
+	// idx_obs_time leads with timestamp alone
 	// so the read hot-path (LatestObservationAny's ORDER BY timestamp DESC
 	// LIMIT 1 and HistoryPoints' WHERE timestamp BETWEEN ?) can use an index
 	// instead of a full table scan + sort -- idx_obs_serial_time can't serve
 	// either query since it leads with serial_number (SGE review I1).
 	assertIndexExists(t, db, "idx_obs_time")
-	assertSchemaVersion(t, db, 2)
+	assertSchemaVersion(t, db, 1)
 
 	// Idempotent: running Migrate again must not fail and must leave the
 	// schema at the same version.
 	if err := Migrate(ctx, db); err != nil {
 		t.Fatalf("second Migrate() error = %v", err)
 	}
-	assertSchemaVersion(t, db, 2)
+	assertSchemaVersion(t, db, 1)
+}
+
+func TestMigrateDeclaresMeasurementColumnsAsREAL(t *testing.T) {
+	ctx := t.Context()
+	db := newTestDB(t)
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	// precip_type is deliberately excluded: it is a categorical enum
+	// (0 none, 1 rain, 2 hail, 3 rain+hail), not a measurement, and stays
+	// INTEGER so it matches internal/postgres/schema.go:55.
+	want := map[string]string{
+		"wind_sample_interval":   "REAL",
+		"lightning_strike_count": "REAL",
+		"report_interval":        "REAL",
+		"precip_type":            "INTEGER",
+	}
+	for column, wantType := range want {
+		var got string
+		err := db.QueryRowContext(ctx,
+			`SELECT type FROM pragma_table_info('tempest_observations') WHERE name = ?`,
+			column,
+		).Scan(&got)
+		if err != nil {
+			t.Fatalf("pragma_table_info for %q: %v", column, err)
+		}
+		if got != wantType {
+			t.Errorf("%s declared %s, want %s", column, got, wantType)
+		}
+	}
+}
+
+func TestMigrateRejectsDatabaseNewerThanBundledMigrations(t *testing.T) {
+	ctx := t.Context()
+	db := newTestDB(t)
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("first Migrate() error = %v", err)
+	}
+
+	// Simulate a database written by a NEWER binary. Migrate skips any
+	// migration whose version is <= current, so without a guard this would
+	// silently apply nothing and report success -- and would keep skipping
+	// every future migration numbered at or below 99.
+	if _, err := db.ExecContext(ctx, `INSERT INTO schema_version (version) VALUES (99)`); err != nil {
+		t.Fatalf("seed future schema version: %v", err)
+	}
+
+	err := Migrate(ctx, db)
+	if err == nil {
+		t.Fatal("Migrate() = nil, want an error for a database newer than the bundled migrations")
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error %q does not name the database's version (99)", err)
+	}
 }
 
 func assertTableExists(t *testing.T, db *sql.DB, name string) {

--- a/internal/sqlite/schema_test.go
+++ b/internal/sqlite/schema_test.go
@@ -41,14 +41,14 @@ func TestMigrate_CreatesTablesAndVersion(t *testing.T) {
 	// instead of a full table scan + sort -- idx_obs_serial_time can't serve
 	// either query since it leads with serial_number (SGE review I1).
 	assertIndexExists(t, db, "idx_obs_time")
-	assertSchemaVersion(t, db, 1)
+	assertSchemaVersion(t, db, 2)
 
 	// Idempotent: running Migrate again must not fail and must leave the
 	// schema at the same version.
 	if err := Migrate(ctx, db); err != nil {
 		t.Fatalf("second Migrate() error = %v", err)
 	}
-	assertSchemaVersion(t, db, 1)
+	assertSchemaVersion(t, db, 2)
 }
 
 func TestMigrateDeclaresMeasurementColumnsAsREAL(t *testing.T) {

--- a/internal/sqlite/summary_test.go
+++ b/internal/sqlite/summary_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"math"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // TestSummarizeObservations proves SummarizeObservations aggregates a
@@ -19,7 +21,7 @@ func TestSummarizeObservations(t *testing.T) {
 	db := w.db
 	ctx := t.Context()
 
-	seed := func(id string, ts int64, temp, hum, pres, wavg, wgust, rain float64, ls sql.NullInt64) {
+	seed := func(id string, ts int64, temp, hum, pres, wavg, wgust, rain float64, ls sql.NullFloat64) {
 		_, err := db.ExecContext(ctx, `INSERT INTO tempest_observations
 			(id, serial_number, timestamp, temp_air, humidity, pressure, wind_avg, wind_gust, rain_rate, lightning_strike_count)
 			VALUES (?,?,?,?,?,?,?,?,?,?)`,
@@ -28,9 +30,9 @@ func TestSummarizeObservations(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	seed("a", 100, 10, 40, 1000, 3, 5, 0.5, sql.NullInt64{Int64: 2, Valid: true})
-	seed("b", 200, 25, 90, 1020, 8, 12, 1.0, sql.NullInt64{}) // NULL lightning
-	seed("c", 300, 18, 60, 1010, 5, 9, 0.25, sql.NullInt64{Int64: 3, Valid: true})
+	seed("a", 100, 10, 40, 1000, 3, 5, 0.5, sql.NullFloat64{Float64: 2, Valid: true})
+	seed("b", 200, 25, 90, 1020, 8, 12, 1.0, sql.NullFloat64{}) // NULL lightning
+	seed("c", 300, 18, 60, 1010, 5, 9, 0.25, sql.NullFloat64{Float64: 3, Valid: true})
 
 	s, err := w.SummarizeObservations(ctx, 100, 300)
 	if err != nil {
@@ -48,8 +50,8 @@ func TestSummarizeObservations(t *testing.T) {
 	if math.Abs(s.RainTotal.Float64-1.75) > 1e-9 {
 		t.Fatalf("rain %v", s.RainTotal)
 	}
-	if s.LightningTotal.Int64 != 5 {
-		t.Fatalf("lightning=%d (want 5, NULL row skipped)", s.LightningTotal.Int64)
+	if s.LightningTotal.Float64 != 5 {
+		t.Fatalf("lightning=%v (want 5, NULL row skipped)", s.LightningTotal.Float64)
 	}
 	if s.CoveredFrom.Int64 != 100 || s.CoveredTo.Int64 != 300 {
 		t.Fatalf("coverage %v/%v", s.CoveredFrom, s.CoveredTo)
@@ -61,5 +63,37 @@ func TestSummarizeObservations(t *testing.T) {
 	}
 	if empty.Count != 0 || empty.TempMax.Valid || empty.RainTotal.Valid || empty.CoveredFrom.Valid {
 		t.Fatalf("empty window not all-null: %+v", empty)
+	}
+}
+
+// TestSummarizeObservationsPreservesFractionalLightningTotal proves
+// LightningTotal survives a fractional SUM. A fractional sum is the only
+// thing that distinguishes a NullFloat64 LightningTotal from a NullInt64
+// one: SUM(2,3) over a REAL column is 5.0, which a NullInt64 scan still
+// accepts. SUM(2.5,3) is 5.5, which it rejects with "converting driver.Value
+// type float64 to a int64".
+func TestSummarizeObservationsPreservesFractionalLightningTotal(t *testing.T) {
+	w := newTestWriter(t)
+	ctx := t.Context()
+
+	for i, v := range []float64{2.5, 3} {
+		_, err := w.db.ExecContext(ctx, `
+			INSERT INTO tempest_observations (id, serial_number, timestamp, lightning_strike_count)
+			VALUES (?, ?, ?, ?)`,
+			uuid.Must(uuid.NewV7()).String(), "ST-A", int64(100+i), v)
+		if err != nil {
+			t.Fatalf("seed row %d: %v", i, err)
+		}
+	}
+
+	s, err := w.SummarizeObservations(ctx, 0, 1000)
+	if err != nil {
+		t.Fatalf("SummarizeObservations: %v", err)
+	}
+	if !s.LightningTotal.Valid {
+		t.Fatal("LightningTotal is NULL, want 5.5")
+	}
+	if s.LightningTotal.Float64 != 5.5 {
+		t.Errorf("LightningTotal = %v, want 5.5", s.LightningTotal.Float64)
 	}
 }

--- a/internal/sqlite/writer.go
+++ b/internal/sqlite/writer.go
@@ -717,7 +717,7 @@ type Observation struct {
 	WindAvg              float64
 	WindGust             float64
 	WindDirection        float64
-	WindSampleInterval   *int64
+	WindSampleInterval   *float64
 	Pressure             float64
 	TempAir              float64
 	TempWetbulb          *float64
@@ -728,9 +728,9 @@ type Observation struct {
 	RainRate             float64
 	PrecipType           *int64
 	LightningDistance    *float64
-	LightningStrikeCount *int64
+	LightningStrikeCount *float64
 	Battery              *float64
-	ReportInterval       *int64
+	ReportInterval       *float64
 }
 
 const selectLatestObservationSQL = `
@@ -756,10 +756,10 @@ const selectLatestObservationSQL = `
 // that shared knowledge is exactly what this extraction single-sources.
 func scanObservation(row *sql.Row) (Observation, error) {
 	var (
-		obs                                     Observation
-		windSampleInterval, precipType          sql.NullInt64
-		lightningStrikeCount, reportInterval    sql.NullInt64
-		tempWetbulb, lightningDistance, battery sql.NullFloat64
+		obs                                                      Observation
+		precipType                                               sql.NullInt64
+		windSampleInterval, lightningStrikeCount, reportInterval sql.NullFloat64
+		tempWetbulb, lightningDistance, battery                  sql.NullFloat64
 	)
 
 	err := row.Scan(
@@ -775,7 +775,7 @@ func scanObservation(row *sql.Row) (Observation, error) {
 	}
 
 	if windSampleInterval.Valid {
-		obs.WindSampleInterval = &windSampleInterval.Int64
+		obs.WindSampleInterval = &windSampleInterval.Float64
 	}
 	if tempWetbulb.Valid {
 		obs.TempWetbulb = &tempWetbulb.Float64
@@ -787,13 +787,13 @@ func scanObservation(row *sql.Row) (Observation, error) {
 		obs.LightningDistance = &lightningDistance.Float64
 	}
 	if lightningStrikeCount.Valid {
-		obs.LightningStrikeCount = &lightningStrikeCount.Int64
+		obs.LightningStrikeCount = &lightningStrikeCount.Float64
 	}
 	if battery.Valid {
 		obs.Battery = &battery.Float64
 	}
 	if reportInterval.Valid {
-		obs.ReportInterval = &reportInterval.Int64
+		obs.ReportInterval = &reportInterval.Float64
 	}
 
 	return obs, nil
@@ -945,7 +945,7 @@ type Summary struct {
 	WindMax        sql.NullFloat64
 	GustMax        sql.NullFloat64
 	RainTotal      sql.NullFloat64
-	LightningTotal sql.NullInt64
+	LightningTotal sql.NullFloat64
 }
 
 const summarizeObservationsSQL = `

--- a/internal/sqlite/writer.go
+++ b/internal/sqlite/writer.go
@@ -87,12 +87,11 @@ type rowEnvelope struct {
 // observationRow mirrors tempest_observations. Nullable columns (the "if
 // len(ob) >= N" fields in the UDP report) use pointers so a nil is stored as
 // SQL NULL rather than a zero value — see internal/postgres/writer.go's
-// observationRow, which this mirrors field-for-field except that the
-// INTEGER-typed columns here (wind_sample_interval, precip_type,
-// lightning_strike_count, report_interval) are *int64, not *float64 (fix
-// B-LOW: the SQLite DDL declares these INTEGER), and timestamp is a raw
-// unix-epoch int64 rather than time.Time (design §12: SQLite stores epoch
-// integers, not TIMESTAMPTZ).
+// observationRow, which this mirrors field-for-field except that
+// precip_type here is *int64 rather than *float64 -- it is a categorical
+// enum, INTEGER in both stores -- and timestamp is a raw unix-epoch int64
+// rather than time.Time (design §12: SQLite stores epoch integers, not
+// TIMESTAMPTZ). The three measurement columns match Postgres exactly.
 type observationRow struct {
 	id                   uuid.UUID
 	serialNumber         string
@@ -101,7 +100,7 @@ type observationRow struct {
 	windAvg              float64
 	windGust             float64
 	windDirection        float64
-	windSampleInterval   *int64
+	windSampleInterval   *float64
 	pressure             float64
 	tempAir              float64
 	tempWetbulb          *float64 // nil (SQL NULL) when WetBulbTemperatureC is non-convergent (NaN)
@@ -112,9 +111,9 @@ type observationRow struct {
 	rainRate             float64
 	precipType           *int64
 	lightningDistance    *float64
-	lightningStrikeCount *int64
+	lightningStrikeCount *float64
 	battery              *float64
-	reportInterval       *int64
+	reportInterval       *float64
 }
 
 type rapidWindRow struct {
@@ -398,9 +397,9 @@ func (w *Writer) WriteReport(ctx context.Context, report tempestudp.Report) erro
 
 // handleObservationReport mirrors internal/postgres/writer.go's
 // handleObservationReport field-for-field (see that file's comment at
-// handleObservationReport for the field-index table), except INTEGER-typed
-// columns are converted to int64 (fix B-LOW) and timestamp is stored as a
-// raw unix-epoch int64 (design §12).
+// handleObservationReport for the field-index table), except precip_type is
+// converted to int64 (categorical enum, INTEGER in both stores) and timestamp
+// is stored as a raw unix-epoch int64 (design §12).
 func (w *Writer) handleObservationReport(ctx context.Context, r *tempestudp.TempestObservationReport) error {
 	for _, ob := range r.Obs {
 		if len(ob) < 13 {
@@ -434,7 +433,7 @@ func (w *Writer) handleObservationReport(ctx context.Context, r *tempestudp.Temp
 		}
 
 		if len(ob) >= 6 {
-			interval := int64(ob[5])
+			interval := ob[5]
 			row.windSampleInterval = &interval
 		}
 		if len(ob) >= 14 {
@@ -443,7 +442,7 @@ func (w *Writer) handleObservationReport(ctx context.Context, r *tempestudp.Temp
 		}
 		if len(ob) >= 16 {
 			distance := ob[14]
-			count := int64(ob[15])
+			count := ob[15]
 			row.lightningDistance = &distance
 			row.lightningStrikeCount = &count
 		}
@@ -452,7 +451,7 @@ func (w *Writer) handleObservationReport(ctx context.Context, r *tempestudp.Temp
 			row.battery = &battery
 		}
 		if len(ob) >= 18 {
-			interval := int64(ob[17])
+			interval := ob[17]
 			row.reportInterval = &interval
 		}
 

--- a/internal/sqlite/writer_test.go
+++ b/internal/sqlite/writer_test.go
@@ -73,14 +73,14 @@ func TestWriter_InsertsObservation(t *testing.T) {
 			serial                                     string
 			ts                                         int64
 			windLull, windAvg, windGust, windDirection float64
-			windSampleInterval                         int64
+			windSampleInterval                         float64
 			pressure, tempAir, tempWetbulb, humidity   float64
 			illuminance, uvIndex, irradiance, rainRate float64
 			precipType                                 int64
 			lightningDistance                          float64
-			lightningStrikeCount                       int64
+			lightningStrikeCount                       float64
 			battery                                    float64
-			reportInterval                             int64
+			reportInterval                             float64
 		)
 		row := w.db.QueryRowContext(ctx, `SELECT
 			id, serial_number, timestamp,
@@ -196,9 +196,10 @@ func TestWriter_InsertsObservation(t *testing.T) {
 		}
 
 		var (
-			windSampleInterval                               int64
-			precipType, lightningStrikeCount, reportInterval sql.NullInt64
-			lightningDistance, battery                       sql.NullFloat64
+			windSampleInterval                   float64
+			precipType                           sql.NullInt64
+			lightningStrikeCount, reportInterval sql.NullFloat64
+			lightningDistance, battery           sql.NullFloat64
 		)
 		row := w.db.QueryRowContext(ctx, `SELECT
 			wind_sample_interval, precip_type, lightning_distance, lightning_strike_count,
@@ -214,7 +215,7 @@ func TestWriter_InsertsObservation(t *testing.T) {
 		// wind_sample_interval (index 5) IS present at the minimum valid
 		// length of 13 -> must NOT be NULL.
 		if windSampleInterval != 1 {
-			t.Errorf("wind_sample_interval = %d, want 1 (present at len=13)", windSampleInterval)
+			t.Errorf("wind_sample_interval = %v, want 1 (present at len=13)", windSampleInterval)
 		}
 		if precipType.Valid {
 			t.Errorf("precip_type should be NULL, got %v", precipType.Int64)
@@ -223,13 +224,13 @@ func TestWriter_InsertsObservation(t *testing.T) {
 			t.Errorf("lightning_distance should be NULL, got %v", lightningDistance.Float64)
 		}
 		if lightningStrikeCount.Valid {
-			t.Errorf("lightning_strike_count should be NULL, got %v", lightningStrikeCount.Int64)
+			t.Errorf("lightning_strike_count should be NULL, got %v", lightningStrikeCount.Float64)
 		}
 		if battery.Valid {
 			t.Errorf("battery should be NULL, got %v", battery.Float64)
 		}
 		if reportInterval.Valid {
-			t.Errorf("report_interval should be NULL, got %v", reportInterval.Int64)
+			t.Errorf("report_interval should be NULL, got %v", reportInterval.Float64)
 		}
 	})
 }

--- a/internal/sqlite/writer_test.go
+++ b/internal/sqlite/writer_test.go
@@ -235,6 +235,56 @@ func TestWriter_InsertsObservation(t *testing.T) {
 	})
 }
 
+// TestWriter_PreservesFractionalMeasurements is the UDP-path counterpart to
+// internal/sqlite's TestInsertObservationsPreservesFractionalMeasurements.
+// obs_st indices: 0 epoch, 5 wind sample interval, 13 precip type, 15
+// lightning strike count, 17 report interval. The three measurements must
+// survive fractionally; precip_type must still truncate.
+func TestWriter_PreservesFractionalMeasurements(t *testing.T) {
+	w := newTestWriter(t)
+	ctx := t.Context()
+
+	report := &tempestudp.TempestObservationReport{
+		SerialNumber: "ST-FRAC",
+		Obs: [][]float64{
+			//  0           1    2    3    4    5     6        7     8     9      10  11   12   13   14   15   16   17
+			{1700000100, 1.5, 2.0, 2.5, 180, 1.5, 1013.25, 20.5, 55.0, 50000, 3, 500, 0.5, 1.9, 2.1, 2.5, 3.6, 5.9},
+		},
+	}
+
+	if err := w.WriteReport(ctx, report); err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+	if err := w.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	var (
+		windSampleInterval, lightningStrikeCount, reportInterval float64
+		precipType                                               int64
+	)
+	err := w.db.QueryRowContext(ctx, `
+		SELECT wind_sample_interval, precip_type, lightning_strike_count, report_interval
+		FROM tempest_observations WHERE serial_number = ?`, "ST-FRAC",
+	).Scan(&windSampleInterval, &precipType, &lightningStrikeCount, &reportInterval)
+	if err != nil {
+		t.Fatalf("scan observation row: %v", err)
+	}
+
+	if windSampleInterval != 1.5 {
+		t.Errorf("wind_sample_interval = %v, want 1.5", windSampleInterval)
+	}
+	if lightningStrikeCount != 2.5 {
+		t.Errorf("lightning_strike_count = %v, want 2.5", lightningStrikeCount)
+	}
+	if reportInterval != 5.9 {
+		t.Errorf("report_interval = %v, want 5.9", reportInterval)
+	}
+	if precipType != 1 {
+		t.Errorf("precip_type = %d, want 1 (categorical enum: truncated by design)", precipType)
+	}
+}
+
 // TestWriter_OnConflictIdempotent proves writing the same (serial_number,
 // timestamp) observation twice yields exactly one row (ON CONFLICT DO
 // NOTHING on the UNIQUE(serial_number, timestamp) constraint).


### PR DESCRIPTION
Closes #107.

Three `tempest_observations` columns — `wind_sample_interval`, `lightning_strike_count`, `report_interval` — were `INTEGER` in SQLite but `DOUBLE PRECISION` in Postgres.

## #107 misdiagnoses its own bug

The issue describes a *read* failure: a fractional value stored with `REAL` affinity breaking the `*int64` read model and taking down the current-observation endpoint. **The mechanism is real; the reachability claim is not.** No fractional value could reach those columns, because both SQLite write paths truncated in Go before binding — `int64(ob[5])` etc. in `handleObservationReport`, and `asInt64` in `InsertObservations`, whose own doc comment named the crash it existed to prevent.

The actual defect was that truncation: the same observation stored as `1.5` in Postgres and `1` in SQLite. A live cross-store divergence, reachable through the normal backfill path.

Measured, not assumed: SQLite `INTEGER` affinity stores `1.5` as `REAL` rather than truncating, so the DDL was never the lossy part. Go was.

## What changed

| Area | Change |
|---|---|
| Schema | the three columns → `REAL`; `0002_add_timestamp_index.sql` folded into the init migration |
| Read path | `sqlite.Observation`, `scanObservation`, `Summary.LightningTotal` → `float64` |
| Write path | truncation removed from both the UDP and REST paths |
| JSON API | `windSampleInterval`, `lightningStrikeCount`, `reportInterval`, `lightningTotal` → `float64` |
| Migrations | `Migrate` fails loudly when a database is newer than the bundled migrations |
| CI | Postgres service container, so the Postgres suite runs instead of always skipping |

**`precip_type` deliberately stays `INTEGER` in both stores and still truncates.** It is a categorical enum (`0 none, 1 rain, 2 hail, 3 rain+hail`), not a measurement — `1.9` there is corrupt input, and coercing it to `1` is intended. `rain_rate` is the precipitation *amount* and was already `REAL`/`DOUBLE PRECISION`; untouched. Postgres needed no schema change.

Task order was load-bearing: the read path widened **before** writes stopped truncating. Reversed, a fractional value lands while the read model is still `sql.NullInt64` and the endpoint breaks between commits.

## Wire compatibility

Nearly invisible. Go marshals `float64(5)` as `5`, not `5.0`, so every integral value serialises byte-identically; only a genuinely fractional value looks different — which is the point. `web/src/types/weather.ts` already types these as `number`, so no TypeScript change was needed.

## Migration numbering

The folded init ships as `0002_init.sql`, not `0001`. Released v3.0.0 and v3.1.0 both shipped `0001` **and** `0002`, so every database they created is at `schema_version = 2`. Numbering the fold `0001` made the new fail-loud guard reject those databases outright — and worse, made roll-forward permanently impossible after any rollback to v3.1.0. Reproduced end to end and fixed before merge; **the next migration must be `0003`**, recorded in the migration file itself.

A legacy v3.x database is accepted and round-trips fractional values correctly, because SQLite affinity is lossless and the read path is now float-tolerant — the old declaration is cosmetically stale but functionally fine.

## Verification

- `go test` — **394 passed** (389 at the branch point)
- with a live `postgres:16` — **396 passed**; two of those had *always* skipped in CI before this branch
- golangci-lint 0 issues · actionlint exit 0 · build / vet / gofmt clean

Reviewed at three gates (design, plan, whole-branch) plus per-task. The whole-branch review found the migration-numbering defect above; it was reproduced, fixed, and re-reviewed.

## Known follow-ups, not in this PR

- The UI renders these raw, so a fractional value would display as "2.5 strikes" (`LightningCard.tsx`, `RecordsCard.tsx`). Cosmetic, and only if the API ever returns one.
- `-tags integration` is deliberately still off in CI — it holds #111's known-failing `TestPostgresWriter_DrainOnClose_Integration`.
- Whether WeatherFlow ever actually returns a fractional value for these fields is unverified (no token). This is correctness insurance against a possibly-latent divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D
