### PR TITLE
ci: wire the radar Python sidecar into the gate

### DIFF
--- a/.taskfiles/python.yml
+++ b/.taskfiles/python.yml
@@ -1,0 +1,68 @@
+# Python sidecar — include with `dir:`; uv only, never python/pip/pipx. Rationale: github-actions-align/templates/README.md#pythonyml
+version: '3'
+
+vars:
+  # Pinned: an unpinned ruff release can turn the fleet red overnight with
+  # nothing to bisect against.
+  # renovate: datasource=pypi depName=ruff
+  RUFF: ruff@0.14.4
+
+tasks:
+  ci:
+    desc: All Python checks
+    cmds:
+      - task: fmt:check
+      - task: lint
+      - task: typecheck
+      - task: test
+
+  lint:
+    desc: ruff
+    cmds:
+      - uvx {{.RUFF}} check .
+
+  fmt:
+    desc: Fix formatting
+    cmds:
+      - uvx {{.RUFF}} format .
+      - uvx {{.RUFF}} check --fix .
+
+  fmt:check:
+    desc: Fail if sources are unformatted
+    cmds:
+      - uvx {{.RUFF}} format --check .
+
+  typecheck:
+    desc: Static type check
+    cmds:
+      - |
+        set -eu
+        [ -f pyproject.toml ] || { echo "no pyproject.toml — skipping typecheck"; exit 0; }
+        uvx ty check .
+
+  test:
+    desc: Run tests
+    cmds:
+      # `uv run`, NOT `uvx`: uvx builds an isolated env containing only the named
+      # tool, so the project and its dependencies are not importable and every
+      # test fails at collection with ModuleNotFoundError.
+      #
+      # Deviation from the template: it runs `uv run --with pytest pytest`, which
+      # assumes a pyproject.toml for uv to resolve the project's dependencies
+      # from. This sidecar has only a pinned requirements.txt, so that form gives
+      # an environment holding pytest and nothing else -- and the tests import
+      # `decode`, which imports matplotlib/numpy/pyart. Collection would fail on
+      # ModuleNotFoundError, the exact trap the comment above warns about,
+      # arriving by a different route. --with-requirements installs the pinned
+      # set, so tests run against the versions radar actually ships.
+      - |
+        set -eu
+        if [ -d tests ] || [ -d test ]; then
+          if [ -f requirements.txt ]; then
+            uv run --with-requirements requirements.txt pytest
+          else
+            uv run --with pytest pytest
+          fi
+        else
+          echo "::warning::no tests/ directory — no Python tests are running"
+        fi

--- a/radar/decode.py
+++ b/radar/decode.py
@@ -9,12 +9,11 @@ os.environ.setdefault("MPLBACKEND", "Agg")
 import matplotlib
 
 matplotlib.use("Agg")
+import geojsoncontour
 import matplotlib.pyplot as plt
 import numpy as np
 import pyart
 from pyart.io.nexrad_level3 import NEXRADLevel3File
-
-import geojsoncontour
 
 # Isoband steps over the NWS reflectivity scale (dBZ), 5-dBZ bands.
 _DBZ_LEVELS = list(range(5, 80, 5))
@@ -62,7 +61,11 @@ def _read_site_code(path: str) -> str:
     """Parse the 3-char site code from the NIDS text header's AWIPS ID (e.g. 'N0BTLX' -> 'TLX')."""
     nfile = NEXRADLevel3File(path)
     try:
-        lines = [line for line in nfile.text_header.decode("ascii", "replace").splitlines() if line.strip()]
+        lines = [
+            line
+            for line in nfile.text_header.decode("ascii", "replace").splitlines()
+            if line.strip()
+        ]
         awips_id = lines[-1].strip()
         return awips_id[3:]
     finally:
@@ -83,7 +86,9 @@ def _contour_reflectivity(radar) -> tuple[dict[str, Any], list[float]]:
     fig, ax = plt.subplots()
     try:
         contour_set = ax.tricontourf(lon, lat, values, levels=_DBZ_LEVELS, extend="neither")
-        feature_collection = geojsoncontour.contourf_to_geojson(contour_set, ndigits=5, serialize=False)
+        feature_collection = geojsoncontour.contourf_to_geojson(
+            contour_set, ndigits=5, serialize=False
+        )
     finally:
         plt.close(fig)
 
@@ -98,4 +103,6 @@ def _contour_reflectivity(radar) -> tuple[dict[str, Any], list[float]]:
 def _parse_band(title: str) -> tuple[int, int]:
     """Parse geojsoncontour's 'LOW.00-HIGH.00 ' title into integer 5-dBZ band bounds."""
     low_str, high_str = title.strip().split("-")
-    return int(round(float(low_str))), int(round(float(high_str)))
+    # round() on a float already returns an int in Python 3, so the int() wrapper
+    # this used to carry was a no-op (RUF046).
+    return round(float(low_str)), round(float(high_str))

--- a/radar/ruff.toml
+++ b/radar/ruff.toml
@@ -1,0 +1,26 @@
+# Fleet baseline for Python sidecars; goes in the PROJECT dir, not the repo root. Rationale: github-actions-align/templates/README.md#rufftoml
+line-length = 100
+
+[lint]
+select = [
+  "E",    # pycodestyle errors
+  "W",    # pycodestyle warnings
+  "F",    # pyflakes
+  "I",    # import sorting
+  "B",    # bugbear
+  "C4",   # comprehensions
+  "UP",   # pyupgrade
+  "S",    # bandit
+  "RUF",  # ruff-specific
+]
+ignore = [
+  "E501",  # line length is the formatter's job
+]
+
+[lint.per-file-ignores]
+"tests/**" = ["S101", "S105", "S106"]
+"**/test_*.py" = ["S101", "S105", "S106"]
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -13,6 +13,10 @@ includes:
     taskfile: .taskfiles/node.yml
     dir: web
 
+  python:
+    taskfile: .taskfiles/python.yml
+    dir: radar
+
 tasks:
   default:
     desc: List all tasks
@@ -25,6 +29,7 @@ tasks:
       - task: repo:ci
       - task: go:ci
       - task: node:ci
+      - task: python:ci
 
   lint:
     desc: Static checks only
@@ -32,12 +37,14 @@ tasks:
       - task: repo:ci
       - task: go:lint
       - task: node:lint
+      - task: python:lint
 
   test:
     desc: Tests only
     cmds:
       - task: go:test
       - task: node:test
+      - task: python:test
 
   build:
     desc: Build artefacts


### PR DESCRIPTION
Closes the last gap against the CI standard. `detect.sh` reports `python=true` and the setup action already installs `uv` on that basis, but `taskfile.yml` only ever included `repo`/`go`/`node` — so `radar/` sat outside the contract entirely:

- `radar/app.py` and `radar/decode.py` were never linted
- `radar/tests/test_decode.py` was **run by nothing** — a test file in the tree that no gate had ever executed

The standard says the taskfile wires one entry per language present, so this was a real deviation rather than a rough edge.

Adds `.taskfiles/python.yml` and `radar/ruff.toml`, and includes `python` with `dir: radar`. No workflow change needed — `ci-test.yml` runs `task ci`, and the setup action already provisions `uv`.

## One deviation from the template, and it was necessary

The template's `test` target is:

```
uv run --with pytest pytest
```

That assumes a `pyproject.toml` for uv to resolve the project's dependencies from. This sidecar has only a pinned `requirements.txt`, so that form yields an environment holding pytest and nothing else — and the tests import `decode`, which imports `matplotlib`, `numpy` and `pyart`. Collection dies on `ModuleNotFoundError`, which is the exact trap the template's own comment warns about, reached by a different route.

`--with-requirements requirements.txt` installs the pinned set, so the tests run against the versions radar actually ships. The template form is kept as the fallback for a sidecar with no `requirements.txt`.

`typecheck` correctly self-skips — no `pyproject.toml`, so there's no package metadata to resolve against, exactly as the template intends.

## Three ruff findings, all absorbed

| Rule | Where |
|---|---|
| `I001` | `decode.py` import block unsorted |
| `RUF046` ×2 | `decode.py` `int(round(float(x)))` — `round()` already returns `int` |

**The `I001` fix got checked rather than blind-`--fix`ed, because the import order there is load-bearing.** `matplotlib.use("Agg")` must run *before* `matplotlib.pyplot` is imported, or the headless backend isn't selected — and a naive sort that hoisted `pyplot` above it would break rendering in the container while leaving lint green.

It's safe here: the block ruff sorts begins *below* that call, so `import matplotlib` and `matplotlib.use("Agg")` are untouched and `pyplot` stays after them. Verified by reading the result, not by trusting the fixer.

The formatter also rewrapped two long calls (line-length 100).

## Verification

- Full **`task ci` exits 0 across all 19 stages**, four of them new
- radar's **2 tests now actually run** — ~40s including installing 85 packages
- **Mutation-checked, not merely green:** perturbing `_parse_band` (the function `RUF046` touched) fails `test_decode_nids_to_isobands` with `assert (6 % 5) == 0`, so that path is genuinely covered

## Note on the commit

This commit is **unsigned**, by explicit one-time exception — 1Password's SSH agent had dropped its keys mid-session (`ssh-add -l` → "The agent has no identities"), which blocked both signing and SSH auth. It was pushed over HTTPS using the `gh` credential helper. Every other commit in this repo is signed; happy to amend and re-sign once the vault is unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D
