### PR TITLE
fix(deps): move to maplibre-gl v6 (ESM-only)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.0.0",
         "pmtiles": "^4.4.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1288,29 +1288,20 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
-      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.2"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
@@ -1323,12 +1314,12 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
-      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
+      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
         "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
@@ -1340,12 +1331,6 @@
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
-      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/@maplibre/mlt": {
       "version": "1.1.12",
@@ -1365,18 +1350,6 @@
         "@mapbox/point-geometry": "^1.1.0",
         "@types/geojson": "^7946.0.16",
         "pbf": "^5.1.0"
-      }
-    },
-    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
-      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3547,27 +3520,25 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.1.0.tgz",
+      "integrity": "sha512-vLRukjvbUai4SXW2/jKo8rPsw6YMXuA/b4fKFVSulZKFVRHkOvk4ZmNlDSVZpTYPV0/7/iTqq8ltYdyr764b7w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
+        "@maplibre/mlt": "^1.1.12",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -3783,9 +3754,9 @@
       "license": "MIT"
     },
     "node_modules/pbf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
-      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.0.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/web/src/components/RadarCard.test.tsx
+++ b/web/src/components/RadarCard.test.tsx
@@ -65,12 +65,14 @@ const { mapInstances, attributionControlInstances, setDataMock, addProtocolMock,
     return { mapInstances, attributionControlInstances, setDataMock, addProtocolMock, MockMap, MockAttributionControl };
   });
 
+// Flat, not wrapped in `default`: RadarCard now uses a namespace import, so
+// `maplibregl.Map` resolves against the module's top-level exports. Leaving the
+// `default: {...}` shape here would typecheck fine and then fail at run time
+// with "maplibregl.Map is not a constructor".
 vi.mock('maplibre-gl', () => ({
-  default: {
-    Map: MockMap,
-    AttributionControl: MockAttributionControl,
-    addProtocol: addProtocolMock,
-  },
+  Map: MockMap,
+  AttributionControl: MockAttributionControl,
+  addProtocol: addProtocolMock,
 }));
 
 vi.mock('pmtiles', () => ({

--- a/web/src/components/RadarCard.tsx
+++ b/web/src/components/RadarCard.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import maplibregl from 'maplibre-gl';
+// Namespace import, not default: maplibre-gl v6 is ESM-only and dropped the UMD
+// default export. tsconfig.app.json sets verbatimModuleSyntax with no
+// esModuleInterop, so a default import fails with TS1192.
+import * as maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Protocol } from 'pmtiles';
 import type { StationMeta } from '../types/weather';


### PR DESCRIPTION
Takes **#95**, which cannot merge as opened. maplibre-gl v6 is ESM-only and dropped the UMD default export, so the existing default import fails typecheck:

```
RadarCard.tsx(2,8): error TS1192: Module '.../maplibre-gl' has no default export
```

`tsconfig.app.json` sets `verbatimModuleSyntax` with neither `esModuleInterop` nor `allowSyntheticDefaultImports`, so TypeScript reports the real module shape rather than synthesising a default. The fix is the namespace import the v5→v6 migration guide prescribes.

## The second half is the one that's easy to miss

`RadarCard.test.tsx` mocked the module in the old default-export shape. With a namespace import, `maplibregl.Map` resolves against the module's **top-level** exports, not `module.default` — so the stale mock typechecks cleanly and then fails at run time with `maplibregl.Map is not a constructor`.

**Mutation-verified rather than assumed:** restoring the `default: {…}` wrapper fails **8 of the 9** RadarCard tests. Fixing only the import would have converted a loud typecheck error into a broken suite — a strictly worse failure mode.

## Nothing else needed changing

Checked every maplibre call in this file against the v6 notes — `addProtocol`, `new Map`, `AttributionControl`, `addSource`, `addLayer`, `getSource`/`GeoJSONSource`, and the `error`/`load` handlers are all unchanged. `GeoJSONSource.setData` did drop its second parameter in v6, but this call site already passed one argument. `RadarCard.tsx` is the only importer of maplibre-gl in the repo.

## Verification

- `tsc -b --noEmit` — clean
- `eslint --max-warnings 0` — clean
- **83/83 tests** across 14 files

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2gxnijhMiDjc7hC1PVB9D