### PR TITLE
chore(gitignore): ignore .auto-claude/ and docs/screenshots/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ deploy/.env
 # Agent scaffolding
 .superpowers/
 docs/prompts/
+.auto-claude/
+
+# UI screenshots (local scratch)
+docs/screenshots/
 
 # Built binaries (this repo's, by name — the managed block's bin/ does not cover
 # a binary written to the repo root, which `go build .` does by default)


### PR DESCRIPTION
Both are local scratch directories that should never be committed:

- `.auto-claude/` — agent state
- `docs/screenshots/` — UI screenshots kept locally, out of the repo

Placed alongside the existing agent-scaffolding entries, **below** the
github-actions-align end marker so they survive template regeneration.

`docs/prompts/` was already carried upstream by the managed-block migration,
so it is not re-added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)