### PR TITLE
ci: bound every job with timeout-minutes

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,6 +54,11 @@ jobs:
   build:
     name: build + push image
     runs-on: ubuntu-latest
+    # The arm64 leg runs under QEMU, which can crash (SIGILL) without failing
+    # the step — BuildKit then waits forever. Healthy builds finish in ~11-14
+    # min, so 45 is ample headroom while capping a hang well under GitHub's
+    # 6-hour default.
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -34,6 +34,7 @@ jobs:
   release:
     name: release-please
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -24,6 +24,8 @@ jobs:
   smoke:
     name: smoke test image
     runs-on: ubuntu-latest
+    # Polls the container for up to 60s; a bad image could otherwise hang here.
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: ${{ inputs.task }}
     runs-on: ubuntu-latest
+    # Observed 2-4 min; the headroom covers the scientific Python install.
+    timeout-minutes: 20
     services:
       # The Postgres-backed tests in internal/postgres are guarded on
       # POSTGRES_URL and skip without it, so without this the Postgres half of

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
   context:
     name: context
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -147,6 +148,7 @@ jobs:
     needs: [context, test, build, smoke]
     if: ${{ !cancelled() }}   # required: else this is SKIPPED on failure, which can satisfy protection
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Assert required stages
         env:

--- a/.github/workflows/release-republish.yml
+++ b/.github/workflows/release-republish.yml
@@ -29,6 +29,7 @@ jobs:
     name: retag ${{ inputs.tag }}
     if: ${{ inputs.mode == 'retag' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Closes #133.

No job set `timeout-minutes`, so a hung job ran to GitHub's 6-hour default. On
2026-08-04 three runs burned ~18 hours of runner time producing no signal: QEMU
crashes (SIGILL) on the arm64 `npm ci` leg without failing the step, so BuildKit
waits until GitHub force-cancels the job.

## What changed

Timeouts on the **seven jobs that actually run steps**:

| Job | Workflow | Timeout |
|---|---|---|
| `build` | `ci-build.yml` | 45 |
| `test` | `ci-test.yml` | 20 |
| `smoke` | `ci-smoke.yml` | 10 |
| `release` | `ci-release.yml` | 10 |
| `context` | `ci.yaml` | 5 |
| `ci` (gate) | `ci.yaml` | 5 |
| `retag` | `release-republish.yml` | 15 |

Reusable-workflow **caller** jobs are deliberately untouched — GitHub does not
accept `timeout-minutes` alongside `uses:`. They inherit the cap from the called
workflow's own job, so coverage is complete: all 8 callers delegate into the four
reusable workflows above.

## How the values were chosen

Measured across six successful `main` runs rather than guessed:

| Job | median | max | timeout | headroom |
|---|---|---|---|---|
| build | 11.1 | 13.8 | 45 | ~3.3x |
| test | 2.0 | 3.9 | 20 | ~5x |
| smoke | 0.3 | 0.3 | 10 | large |
| release | 0.6 | 0.7 | 10 | large |
| context / gate | 0.1 | 0.1 | 5 | large |

A hang now fails in under an hour instead of six, while legitimate slow runs
(cold cache, added arches) stay comfortably inside the cap.

## Verification

- `actionlint` clean.
- `task go:ci`, `task node:ci` (83/83), `task python:ci` (2/2) all pass.
- Coverage asserted programmatically: every step-running job has a timeout, every
  `uses:` caller has none.

## Not addressed

The issue's optional follow-up — pinning/bumping `docker/setup-qemu-action` to
address the SIGILL at its source — is left alone; this change bounds the blast
radius rather than fixing the flake.

Per the issue's scope note, the same gap exists upstream in the
`github-actions-align` templates and is worth mirroring there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)