### PR TITLE
chore(renovate): group routine Docker image updates into one PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,14 @@
     "github>jacaudi/renovate-config:base",
     "github>jacaudi/renovate-config:go",
     "github>jacaudi/renovate-config:fork"
+  ],
+  "packageRules": [
+    {
+      "description": "Collapse routine Docker image updates into a single PR instead of one PR per image. Majors are deliberately NOT grouped: holding one major (python 3.14, grafana 13) would otherwise block every routine digest and patch bump riding in the same PR.",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "matchPackageNames": ["**", "!golang"],
+      "groupName": "docker-images"
+    }
   ]
 }


### PR DESCRIPTION
Collapses routine Docker image updates into a single grouped PR instead of one
PR per image.

```json
{
  "matchDatasources": ["docker"],
  "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
  "matchPackageNames": ["**", "!golang"],
  "groupName": "docker-images"
}
```

## What this does and does not fix

**It reduces PR volume.** Seven separate Docker PRs merged in the last two weeks —
`cgr.dev/chainguard/static` (#101, #129), `litestream` (#86, #130), `busybox` (#84),
`otel-collector` (#87), `prometheus` (#88), `grafana` (#85), `minio` — one per image.
Those would now arrive as one PR.

**It does not fix duplicate or drifting Docker tags, because there are none.** This was
audited before writing the rule, and the premise did not survive:

- Every tracked image appears in exactly **one** location.
- `python` appears twice (`radar/Dockerfile:5` and `:24`), but Renovate already collapses
  them — #73's diff is `+2 -2` in one file, one PR.
- The back-to-back `chainguard/static` and `litestream` PRs are sequential digest churn,
  not concurrent duplicates.

So this is a PR-volume change, not a correctness fix. Framing it otherwise would be wrong.

## Two deliberate exclusions

**Majors are not grouped.** #73 (python 3.14) and #99 (grafana 13) are held for verified
reasons. If majors joined the group, holding either would block every routine digest bump
riding in the same PR — the grouping would make the workflow worse, not better. Majors stay
as individual PRs.

**`golang` is excluded.** `Dockerfile:17` pins `golang:1.26-alpine`, and the `:go` preset
groups `go` + `golang` into `go-toolchain` so the image and the `go.mod` directive move
together. Local `packageRules` evaluate *after* extended presets, so an unguarded docker
rule would silently pull `golang` out of that group and let the two drift.

`**` rather than `*` because Docker image names contain slashes (`cgr.dev/chainguard/static`).

## Verification

`npx renovate-config-validator .github/renovate.json` → `Config validated successfully`.

## Follow-up, deliberately not in this PR

`postgres` has drifted across four sites and `packageRules` cannot fix it — Renovate opens
no PR against prose:

| Location | Pin |
|---|---|
| `.github/workflows/ci-test.yml:37` | `postgres:18` (real CI) |
| `CLAUDE.md:234` | `postgres:16` |
| `CLAUDE.md:343` | `postgres:16` |
| `deploy/.env.example:49` | `postgres:16` |

Worth a separate doc fix, or a `customManagers` regex if it should be tracked going forward.

Note this rule is repo-local. `jacaudi/renovate-config` has no `docker.json` preset — if this
shape is wanted everywhere, it belongs there instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)