### PR TITLE
fix(backfill): close the three observability and seam gaps (#108, #109, #110)

### DIFF
--- a/backfill_cmd.go
+++ b/backfill_cmd.go
@@ -31,6 +31,29 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// backfillAPI is the REST surface runBackfill is allowed to touch, and it is
+// deliberately narrow.
+//
+// ListDevices and ListStations have identical signatures, and ListStations
+// collapses each station to a single ST device (its device loop has no
+// break, so the last one wins). Calling the wrong one on a two-sensor
+// station would leave one sensor's gaps permanently unrepaired and unlogged,
+// while compiling and passing every test — the maintainer runs a single
+// Tempest, so it would never surface locally (#110).
+//
+// Narrowing the type is what fixes that: ListStations is not a member here,
+// so the swap does not build. This is a type-level guarantee, not an
+// assertion some future test refactor could delete.
+type backfillAPI interface {
+	ListDevices(ctx context.Context) ([]tempestapi.Station, error)
+	backfill.ObservationSource
+}
+
+// newBackfillAPI is the injection point. It returns the narrow interface
+// rather than *tempestapi.Client so the concrete client — and with it
+// ListStations — never enters runBackfill's scope.
+var newBackfillAPI = func(token string) backfillAPI { return tempestapi.NewClient(token) }
+
 // parseBackfillFlags reads the backfill subcommand's own FlagSet.
 //
 // Each subcommand owning its FlagSet (parsed from os.Args[2:]) is the seam a
@@ -321,11 +344,11 @@ func runBackfill(ctx context.Context, args []string) int {
 	defer cleanupStore()
 	slog.Info("backfill: store selected", "store", target)
 
-	client := tempestapi.NewClient(token)
-	// ListDevices, NOT ListStations: ListStations collapses each station to a
-	// single ST device, so a two-sensor station would leave one sensor's gaps
-	// permanently unrepaired and unlogged.
-	devices, err := client.ListDevices(ctx)
+	// The narrow seam, not *tempestapi.Client: ListStations is unreachable
+	// from here, so the identical-signature swap that would drop a sensor is
+	// a compile error rather than something a test has to notice.
+	api := newBackfillAPI(token)
+	devices, err := api.ListDevices(ctx)
 	if err != nil {
 		slog.Error("backfill: list devices", "error", err)
 		return 1
@@ -336,7 +359,7 @@ func runBackfill(ctx context.Context, args []string) int {
 	}
 	slog.Info("backfill: devices discovered", "count", len(devices))
 
-	stats, err := backfill.Run(ctx, cfg, client, store, devices, time.Now().UTC())
+	stats, err := backfill.Run(ctx, cfg, api, store, devices, time.Now().UTC())
 	slog.Info("backfill: complete",
 		"gaps", stats.Gaps, "returned", stats.Returned,
 		"inserted", stats.Inserted, "failed", stats.Failed, "dry_run", cfg.DryRun)

--- a/backfill_cmd_test.go
+++ b/backfill_cmd_test.go
@@ -5,10 +5,49 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"tempestwx-utilities/internal/tempestapi"
 )
+
+// runBackfill must discover devices with ListDevices, never ListStations:
+// ListStations collapses each station to a single ST device (its device loop
+// has no break, so the last one wins), which on a two-sensor station would
+// leave one sensor's gaps permanently unrepaired and unlogged.
+//
+// The two calls have IDENTICAL signatures —
+//
+//	func (c *Client) ListDevices(ctx context.Context) ([]Station, error)
+//	func (c *Client) ListStations(ctx context.Context) ([]Station, error)
+//
+// — which is exactly why swapping them was a test-green mutant (#110). The
+// fix is structural rather than assertive: runBackfill holds the narrow
+// backfillAPI, which does not carry ListStations at all, so the swap is a
+// compile error and no test has to catch it.
+//
+// This test guards the narrowness itself. Widening backfillAPI to embed the
+// whole client would silently restore the mutant.
+func TestBackfillAPISeamDoesNotExposeListStations(t *testing.T) {
+	typ := reflect.TypeFor[backfillAPI]()
+
+	if _, ok := typ.MethodByName("ListDevices"); !ok {
+		t.Error("backfillAPI must expose ListDevices — it is how runBackfill discovers every ST device")
+	}
+	if _, ok := typ.MethodByName("Observations"); !ok {
+		t.Error("backfillAPI must expose Observations — backfill.Run consumes it as the ObservationSource")
+	}
+	if _, ok := typ.MethodByName("ListStations"); ok {
+		t.Error("backfillAPI must NOT expose ListStations: reachable through this interface, the " +
+			"identical-signature swap silently drops a sensor on a two-unit station and compiles clean")
+	}
+}
+
+// The seam must still be satisfied by the real client, or the narrowing
+// traded a silent bug for a broken binary.
+var _ backfillAPI = (*tempestapi.Client)(nil)
 
 func TestParseBackfillFlagsDefaults(t *testing.T) {
 	cfg, _, err := parseBackfillFlags(nil)

--- a/internal/backfill/backfill.go
+++ b/internal/backfill/backfill.go
@@ -156,11 +156,9 @@ func Run(
 	}
 	stats.Gaps = len(gaps)
 
+	logPlan(cfg, gaps, detectFrom, detectTo)
+
 	if cfg.DryRun {
-		for _, g := range gaps {
-			slog.Info("backfill: planned gap (dry run)",
-				"serial", g.SerialNumber, "from", g.From, "to", g.To, "duration", g.Duration())
-		}
 		return stats, nil
 	}
 
@@ -204,6 +202,31 @@ func Run(
 	return stats, nil
 }
 
+// logPlan emits the run's intent before any fetching starts, on BOTH the dry
+// and real paths. A real run against a long-lived station is hours of
+// windows, and previously nothing was emitted between "devices discovered"
+// and the first "gap filled" — an operator could not tell working from
+// wedged (#108).
+//
+// The detection range is only printed when it was actually used: an explicit
+// --from/--to never reads detectFrom/detectTo (see detectionRange's doc
+// comment), so printing them there would be noise at best and misleading at
+// worst.
+//
+// Extracted from Run rather than inlined: Run was already at the gocyclo
+// ceiling, and the plan announcement is a cohesive unit with one reason to
+// change.
+func logPlan(cfg Config, gaps []weather.Gap, detectFrom, detectTo time.Time) {
+	if cfg.From.IsZero() || cfg.To.IsZero() {
+		slog.Info("backfill: detection range", "from", detectFrom, "to", detectTo)
+	}
+	slog.Info("backfill: plan", "gaps", len(gaps), "dry_run", cfg.DryRun)
+	for _, g := range gaps {
+		slog.Info("backfill: planned gap",
+			"serial", g.SerialNumber, "from", g.From, "to", g.To, "duration", g.Duration())
+	}
+}
+
 // detectionRange resolves the auto-detect window: from the earliest station
 // creation time to now-MinGap (trailing MinGap so the most recent,
 // still-arriving interval is not mistaken for a hole).
@@ -219,12 +242,31 @@ func detectionRange(cfg Config, stations []tempestapi.Station, now time.Time) (t
 	detectTo := now.Add(-cfg.MinGap)
 	detectFrom := detectTo
 	for _, s := range stations {
+		// An absent or zero created_epoch decodes to the Unix epoch
+		// (client.go builds CreatedAt as time.Unix(station.CreatedEpoch, 0)),
+		// which is NOT IsZero() — so nothing rejected it and a single gap of
+		// roughly 20,600 daily windows got planned.
+		//
+		// Only the sentinel is rejected, not everything before some plausible
+		// date: the sentinel is the actual failure, and a date floor would
+		// bake in a constant with no defensible value.
+		if s.CreatedAt.Equal(epochSentinel) {
+			slog.Warn("backfill: ignoring station creation time, no usable created_epoch",
+				"serial", s.SerialNumber, "created_at", s.CreatedAt)
+			continue
+		}
 		if s.CreatedAt.Before(detectFrom) {
 			detectFrom = s.CreatedAt
 		}
 	}
 	return detectFrom, detectTo
 }
+
+// epochSentinel is what an absent or zero created_epoch decodes to. If every
+// station carries it, detectFrom stays at detectTo and the window collapses
+// to zero width: the run does nothing, loudly, rather than hammering the API
+// back to 1970.
+var epochSentinel = time.Unix(0, 0)
 
 // plannedGaps is the whole detection domain: SQL's interior gaps plus the
 // head, tail, and empty-store cases LAG cannot see. An explicit --from/--to

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -683,6 +683,110 @@ func TestRunRejectsHalfSpecifiedRange(t *testing.T) {
 	}
 }
 
+// captureLogs installs a buffer as the slog default at the given level and
+// restores the previous default on cleanup. internal/backfill's TestMain
+// discards slog package-wide, so any test asserting on log output has to opt
+// back in. Three tests below need this; the shared helper is the shared
+// knowledge, not a coincidence of shape.
+func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// A station whose created_epoch is absent or zero decodes to time.Unix(0,0)
+// — 1970 — which is not IsZero(), so nothing rejected it. It then dragged
+// detectFrom back to the epoch and planned a single gap of roughly 20,600
+// daily windows at up to 4 retries each (#108).
+//
+// The guard rejects the epoch sentinel specifically rather than flooring at
+// some plausible product-launch date: the sentinel is the actual observed
+// failure, and a date floor would bake in a constant nobody can justify.
+func TestDetectionRangeExcludesEpochSentinelCreatedAt(t *testing.T) {
+	buf := captureLogs(t, slog.LevelWarn)
+
+	now := at(2000000)
+	cfg := Config{MinGap: 30 * time.Minute}
+	sentinel := tempestapi.Station{SerialNumber: "ST-BAD", DeviceID: 2, CreatedAt: time.Unix(0, 0).UTC()}
+
+	detectFrom, _ := detectionRange(cfg, []tempestapi.Station{sentinel, station("ST-A")}, now)
+
+	want := time.Unix(1000, 0).UTC() // station("ST-A")'s CreatedAt
+	if !detectFrom.Equal(want) {
+		t.Errorf("detectFrom = %v, want %v — the epoch-sentinel station must not drag the range to 1970",
+			detectFrom, want)
+	}
+	if !strings.Contains(buf.String(), "ST-BAD") {
+		t.Errorf("the rejected station must be named in a warning; got:\n%s", buf.String())
+	}
+}
+
+// If EVERY station carries the sentinel there is no trustworthy lower bound,
+// so the detection window collapses to zero width and the run does nothing.
+// Doing nothing loudly beats hammering the API across 20,600 windows.
+func TestDetectionRangeAllSentinelCollapsesToEmptyWindow(t *testing.T) {
+	buf := captureLogs(t, slog.LevelWarn)
+
+	now := at(2000000)
+	cfg := Config{MinGap: 30 * time.Minute}
+	stations := []tempestapi.Station{
+		{SerialNumber: "ST-BAD1", DeviceID: 1, CreatedAt: time.Unix(0, 0).UTC()},
+		{SerialNumber: "ST-BAD2", DeviceID: 2, CreatedAt: time.Unix(0, 0).UTC()},
+	}
+
+	detectFrom, detectTo := detectionRange(cfg, stations, now)
+
+	if !detectFrom.Equal(detectTo) {
+		t.Errorf("detectFrom = %v, detectTo = %v — with no usable creation time the window must be empty, not 1970-to-now",
+			detectFrom, detectTo)
+	}
+	if strings.Count(buf.String(), "ST-BAD") < 2 {
+		t.Errorf("every rejected station must be warned about; got:\n%s", buf.String())
+	}
+}
+
+// Before this, Run logged nothing between "devices discovered" and the first
+// "gap filled": the planned-gap loop sat behind the DryRun guard, so an
+// operator on a live box got one line and then potentially hours of silence
+// with no way to tell working from wedged (#108).
+//
+// Asserting the plan appears BEFORE the first fill is the whole point — a
+// plan logged after the loop would restore the silence this fixes.
+func TestRunLogsThePlanBeforeFillingOnTheRealPath(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{}
+	from := at(0)
+	to := from.Add(time.Hour)
+	cfg := Config{From: from, To: to, MinGap: 30 * time.Minute} // DryRun deliberately false
+
+	if _, err := Run(t.Context(), cfg, src, store, []tempestapi.Station{station("ST-A")}, to); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	logged := buf.String()
+	planIdx := strings.Index(logged, "backfill: planned gap")
+	fillIdx := strings.Index(logged, "backfill: gap filled")
+
+	if planIdx < 0 {
+		t.Fatalf("the real path must log its planned gaps, not just the dry-run path; got:\n%s", logged)
+	}
+	if fillIdx < 0 {
+		t.Fatalf("expected a gap-filled line too; got:\n%s", logged)
+	}
+	if planIdx > fillIdx {
+		t.Errorf("the plan was logged AFTER the first fill (plan@%d, fill@%d) — it must precede the loop, "+
+			"otherwise the operator is still staring at silence; got:\n%s", planIdx, fillIdx, logged)
+	}
+	if !strings.Contains(logged, "gaps=1") {
+		t.Errorf("the plan summary must carry the gap count; got:\n%s", logged)
+	}
+}
+
 // The per-gap "gap filled" line is the machine-readable convergence surface
 // the design chose *instead of* a bespoke summary format
 // (docs/designs/2026-07-28-api-backfill-tool-design.md): automation keys on
@@ -693,10 +797,7 @@ func TestRunRejectsHalfSpecifiedRange(t *testing.T) {
 // TestMain discards slog package-wide, so this test installs its own buffer
 // at Info and restores the previous default on cleanup.
 func TestRunLogsPerGapConvergenceAttrs(t *testing.T) {
-	var buf bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	buf := captureLogs(t, slog.LevelInfo)
 
 	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
 	store := &fakeStore{}

--- a/internal/backfill/backfill_test.go
+++ b/internal/backfill/backfill_test.go
@@ -1,6 +1,7 @@
 package backfill
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -679,5 +680,59 @@ func TestRunRejectsHalfSpecifiedRange(t *testing.T) {
 				t.Errorf("made %d inserts for a rejected config, want 0", len(store.inserted))
 			}
 		})
+	}
+}
+
+// The per-gap "gap filled" line is the machine-readable convergence surface
+// the design chose *instead of* a bespoke summary format
+// (docs/designs/2026-07-28-api-backfill-tool-design.md): automation keys on
+// the returned>0 / inserted==0 pairing to tell "the store already had it"
+// from a genuine permanent hole. Without this test the whole slog.Info block
+// deletes with the package still green (#109).
+//
+// TestMain discards slog package-wide, so this test installs its own buffer
+// at Info and restores the previous default on cleanup.
+func TestRunLogsPerGapConvergenceAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	src := &fakeSource{obs: []weather.Observation{obsAt("ST-A", 5000)}}
+	store := &fakeStore{}
+
+	from := at(0)
+	to := from.Add(time.Hour)
+	cfg := Config{From: from, To: to, MinGap: 30 * time.Minute}
+	stations := []tempestapi.Station{station("ST-A")}
+
+	// First pass inserts the row; the second returns the same row and
+	// inserts nothing. Asserting on the second pass pins returned>0 AND
+	// inserted==0 together — the pairing automation actually watches for.
+	if _, err := Run(t.Context(), cfg, src, store, stations, to); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	buf.Reset()
+	if _, err := Run(t.Context(), cfg, src, store, stations, to); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "backfill: gap filled") {
+		t.Fatalf("the per-gap success line is missing; got:\n%s", logged)
+	}
+	// Each attr is asserted by name=value: renaming a key or dropping one
+	// breaks automation just as surely as deleting the whole line.
+	for _, want := range []string{"serial=ST-A", "returned=1", "inserted=0"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("missing %q in the gap-filled line; got:\n%s", want, logged)
+		}
+	}
+	// from/to carry the gap identity — without them a multi-gap run's lines
+	// are indistinguishable.
+	for _, want := range []string{"from=", "to="} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("missing %q attr in the gap-filled line; got:\n%s", want, logged)
+		}
 	}
 }


### PR DESCRIPTION
Closes #108
Closes #109
Closes #110

Three backfill gaps left unpinned by the original work. Two design forks were
decided by Adam before implementation; both took the narrower option.

## #109 — the convergence log was deletable

`TestRunLogsPerGapConvergenceAttrs` asserts on a **second** `Run` pass so
`returned>0` and `inserted==0` are pinned *together* — that pairing is the signal
automation reads, and asserting them separately would miss a regression that
breaks only the combination. Each attr is checked as `name=value`, so renaming a
key fails too.

## #108 — no floor on `detectFrom`, and a silent run

**Epoch sentinel only.** `detectionRange` skips stations whose `CreatedAt` equals
`time.Unix(0,0)` and warns with the serial. Deliberately *not* a date floor: the
sentinel is the actual failure mode, and a floor like "2017" would bake in a
constant with no defensible source and could clamp a legitimately old sensor.

Behaviour is unchanged for any station with a real `created_epoch`. The single
change is all-sentinel input, where the window now collapses to empty instead of
reaching back to 1970 (~20,600 daily windows at up to 4 retries each).
`--from/--to` covers that case.

**Silent run.** The plan moved out from under the `DryRun` guard into `logPlan`,
emitted before the fill loop on both paths. Detection range prints only when
auto-detecting, since an explicit `--from/--to` never reads it.

## #110 — nothing pinned `ListDevices` over `ListStations`

`ListDevices` and `ListStations` have **identical signatures**, which is the
mechanical reason swapping them was a test-green mutant — the compiler had no
opinion.

Rather than catch the swap in a test, this makes it unrepresentable. `runBackfill`
now holds `backfillAPI` — `ListDevices` plus `backfill.ObservationSource`, nothing
else — built through a `newBackfillAPI` seam, so `*tempestapi.Client` never enters
scope. This stayed small: four lines in `runBackfill` plus the type and seam, because
`backfill.Run` already accepted `ObservationSource` as an interface.

## Verification

Every claim below was reproduced independently of the implementer, because this
branch's history includes a mutant surviving five consecutive task reviews.

| Mutation | Result |
|---|---|
| Delete the `gap filled` block | `TestRunLogsPerGapConvergenceAttrs` FAILS |
| Remove the epoch-sentinel guard | `TestDetectionRangeExcludesEpochSentinelCreatedAt` + `...AllSentinelCollapsesToEmptyWindow` FAIL |
| Move `logPlan` back under `DryRun` | `TestRunLogsThePlanBeforeFillingOnTheRealPath` FAILS |
| Widen `backfillAPI` to re-expose `ListStations` | `TestBackfillAPISeamDoesNotExposeListStations` FAILS |

#110's proof is a compiler error, not a passing test — a green test is the wrong
evidence for "this can no longer be expressed":

```
./backfill_cmd.go:351:22: api.ListStations undefined
    (type backfillAPI has no field or method ListStations)
```

All mutations reverted; working tree clean. `task ci` exits **0**; full suite
**401 passed across 16 packages**.

Two lint fixes were needed along the way, both self-inflicted: `gocyclo` flagged
`Run` at complexity 17 once the guard branch landed (which is why `logPlan` is
extracted rather than inline), and `modernize` flagged `reflect.TypeOf(...).Elem()`,
now `reflect.TypeFor[backfillAPI]()`.

Note `actionlint` self-skips here (`no workflow changes since HEAD~1`) — expected,
since this branch touches no workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)