### PR TITLE
fix: stop losing rows on shutdown in both writers

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,9 +22,10 @@ jobs:
     services:
       # The Postgres-backed tests in internal/postgres are guarded on
       # POSTGRES_URL and skip without it, so without this the Postgres half of
-      # the store is asserted by nothing. Only the standard untagged suite runs
-      # -- `-tags integration` is deliberately not enabled, because it holds the
-      # known-failing drain-on-close test (#111).
+      # the store is asserted by nothing. `task test` now also passes
+      # `-tags integration`, so the drain-on-close test (#111) runs here too --
+      # it was excluded while it was known-failing, which is precisely how a
+      # real row-loss bug stayed red and invisible for months.
       #
       # `services:` is a job-level key, so a composite action cannot declare
       # one. Before this migration that forced the block to be triplicated

--- a/.taskfiles/go.yml
+++ b/.taskfiles/go.yml
@@ -45,7 +45,17 @@ tasks:
   test:
     desc: Run tests with the race detector
     cmds:
-      - go test ./... -race
+      # -tags integration is a SUPERSET, not a switch: untagged files always
+      # compile, so this runs the standard suite plus the //go:build
+      # integration files. It was previously omitted because the tagged suite
+      # held the known-failing drain-on-close test (#111); with that fixed,
+      # leaving it off is what let a real row-loss bug sit red and unseen.
+      #
+      # The tagged tests self-guard on POSTGRES_URL and skip when it is unset,
+      # so this stays runnable locally with no database — and CI already
+      # provides one (see ci-test.yml's postgres service), which is why
+      # enabling this costs no new infrastructure.
+      - go test ./... -race -tags integration
 
   build:
     desc: Build binaries into ./bin/

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -196,16 +196,35 @@ func NewPostgresWriter(ctx context.Context, databaseURL string) (*PostgresWriter
 func (w *PostgresWriter) batchObservations() {
 	defer w.wg.Done()
 
+	flushCtx := steadyStateFlushCtx(w.ctx)
+
 	for {
 		select {
 		case row := <-w.obsBatch:
 			// Immediate flush for observations
-			w.flushObservations(w.ctx, []observationRow{row})
+			w.flushObservations(flushCtx, []observationRow{row})
 
 		case <-w.done:
 			return
 		}
 	}
+}
+
+// steadyStateFlushCtx returns the context a batch worker must use for its
+// ordinary (non-shutdown) flushes. It deliberately drops cancellation from
+// w.ctx: SIGTERM cancels w.ctx *before* Close is called, and a row a worker
+// has already taken off its channel is no longer visible to Close's
+// drainChannel — so a flush that fails on the dead ctx loses that row
+// outright, with no second chance to recover it (#111). That is the same
+// failure the shutdownCtx field comment describes for the local in-flight
+// batch; the C-H1 fix only ever covered the <-w.done branch, leaving every
+// steady-state flush still bound to w.ctx.
+//
+// Detaching cancellation does not make a flush unbounded: every insert*
+// method derives its own context.WithTimeout, and flushWithRetry caps
+// attempts at w.maxRetries.
+func steadyStateFlushCtx(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
 }
 
 // closeBatchResults closes a pgx batch result set, logging any error.
@@ -278,6 +297,7 @@ func (w *PostgresWriter) batchRapidWind() {
 	defer w.wg.Done()
 
 	batch := make([]rapidWindRow, 0, w.batchSize)
+	flushCtx := steadyStateFlushCtx(w.ctx)
 	ticker := time.NewTicker(w.flushInterval)
 	defer ticker.Stop()
 
@@ -288,14 +308,14 @@ func (w *PostgresWriter) batchRapidWind() {
 
 			// Flush when batch is full
 			if len(batch) >= w.batchSize {
-				w.flushRapidWind(w.ctx, batch)
+				w.flushRapidWind(flushCtx, batch)
 				batch = batch[:0]
 			}
 
 		case <-ticker.C:
 			// Periodic flush
 			if len(batch) > 0 {
-				w.flushRapidWind(w.ctx, batch)
+				w.flushRapidWind(flushCtx, batch)
 				batch = batch[:0]
 			}
 
@@ -355,6 +375,7 @@ func (w *PostgresWriter) batchHubStatus() {
 	defer w.wg.Done()
 
 	batch := make([]hubStatusRow, 0, w.batchSize)
+	flushCtx := steadyStateFlushCtx(w.ctx)
 	ticker := time.NewTicker(w.flushInterval)
 	defer ticker.Stop()
 
@@ -363,13 +384,13 @@ func (w *PostgresWriter) batchHubStatus() {
 		case row := <-w.hubBatch:
 			batch = append(batch, row)
 			if len(batch) >= w.batchSize {
-				w.flushHubStatus(w.ctx, batch)
+				w.flushHubStatus(flushCtx, batch)
 				batch = batch[:0]
 			}
 
 		case <-ticker.C:
 			if len(batch) > 0 {
-				w.flushHubStatus(w.ctx, batch)
+				w.flushHubStatus(flushCtx, batch)
 				batch = batch[:0]
 			}
 
@@ -426,11 +447,13 @@ func (w *PostgresWriter) insertHubStatus(ctx context.Context, batch []hubStatusR
 func (w *PostgresWriter) batchEvents() {
 	defer w.wg.Done()
 
+	flushCtx := steadyStateFlushCtx(w.ctx)
+
 	for {
 		select {
 		case row := <-w.eventBatch:
 			// Immediate flush for events (critical)
-			w.flushEvents(w.ctx, []eventRow{row})
+			w.flushEvents(flushCtx, []eventRow{row})
 
 		case <-w.done:
 			return

--- a/internal/postgres/writer.go
+++ b/internal/postgres/writer.go
@@ -237,7 +237,7 @@ func closeBatchResults(br pgx.BatchResults) {
 }
 
 func (w *PostgresWriter) flushObservations(ctx context.Context, batch []observationRow) {
-	w.flushWithRetry(func() error {
+	w.flushWithRetry(ctx, func() error {
 		return w.obsInserter.insertObservations(ctx, batch)
 	}, "tempest_observations", len(batch))
 }
@@ -334,7 +334,7 @@ func (w *PostgresWriter) batchRapidWind() {
 }
 
 func (w *PostgresWriter) flushRapidWind(ctx context.Context, batch []rapidWindRow) {
-	w.flushWithRetry(func() error {
+	w.flushWithRetry(ctx, func() error {
 		return w.windInserter.insertRapidWind(ctx, batch)
 	}, "tempest_rapid_wind", len(batch))
 }
@@ -407,7 +407,7 @@ func (w *PostgresWriter) batchHubStatus() {
 }
 
 func (w *PostgresWriter) flushHubStatus(ctx context.Context, batch []hubStatusRow) {
-	w.flushWithRetry(func() error {
+	w.flushWithRetry(ctx, func() error {
 		return w.insertHubStatus(ctx, batch)
 	}, "tempest_hub_status", len(batch))
 }
@@ -462,7 +462,7 @@ func (w *PostgresWriter) batchEvents() {
 }
 
 func (w *PostgresWriter) flushEvents(ctx context.Context, batch []eventRow) {
-	w.flushWithRetry(func() error {
+	w.flushWithRetry(ctx, func() error {
 		return w.insertEvents(ctx, batch)
 	}, "tempest_events", len(batch))
 }
@@ -882,8 +882,17 @@ func (w *PostgresWriter) Flush(ctx context.Context) error {
 	return nil
 }
 
-// flushWithRetry implements exponential backoff retry logic
-func (w *PostgresWriter) flushWithRetry(flushFn func() error, tableName string, batchSize int) {
+// flushWithRetry implements exponential backoff retry logic.
+//
+// ctx must be the same context the caller hands to flushFn's insert, and is
+// deliberately NOT w.ctx: SIGTERM cancels w.ctx before Close runs, so gating
+// the backoff sleep on it abandoned the first retryable failure that arrived
+// during shutdown and dropped the batch (#153) — the moment durability
+// matters most. Threading the caller's ctx makes the bound follow the flush:
+// steady-state flushes carry the cancellation-detached ctx and back off
+// normally, while a shutdown flush carries Close's ctx and so is bounded by
+// the cleanup deadline instead of aborting instantly.
+func (w *PostgresWriter) flushWithRetry(ctx context.Context, flushFn func() error, tableName string, batchSize int) {
 	backoff := time.Second
 	maxBackoff := 30 * time.Second
 
@@ -909,7 +918,7 @@ func (w *PostgresWriter) flushWithRetry(flushFn func() error, tableName string, 
 
 		// Check if context is still valid before sleeping
 		select {
-		case <-w.ctx.Done():
+		case <-ctx.Done():
 			log.Printf("postgres: context cancelled during retry for %s, dropping batch", tableName)
 			return
 		case <-time.After(backoff):

--- a/internal/postgres/writer_test.go
+++ b/internal/postgres/writer_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"syscall"
@@ -182,6 +183,115 @@ func TestPostgresWriter_DrainOnClose(t *testing.T) {
 	}
 }
 
+// ctxHonoringObsInserter mirrors the real insertObservations' ctx-sensitivity,
+// the way fakeWindInserter does for rapid wind: a real pgx insert against an
+// already-canceled ctx fails immediately with context.Canceled, which
+// isRetryable classifies as non-retryable, so flushWithRetry drops the batch.
+// The plain fakeObsInserter above ignores ctx entirely, which is precisely why
+// TestPostgresWriter_DrainOnClose passed while the live-database
+// TestPostgresWriter_DrainOnClose_Integration lost rows (#111).
+//
+// attempts counts every row handed to the inserter whether or not the write
+// succeeded, so a test can wait until the worker has actually consumed the
+// channel instead of racing it.
+type ctxHonoringObsInserter struct {
+	mu       sync.Mutex
+	rows     []observationRow
+	attempts int
+}
+
+func (f *ctxHonoringObsInserter) insertObservations(ctx context.Context, batch []observationRow) error {
+	f.mu.Lock()
+	f.attempts += len(batch)
+	f.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("insert observations: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, batch...)
+	return nil
+}
+
+func (f *ctxHonoringObsInserter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+func (f *ctxHonoringObsInserter) attemptCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+// TestPostgresWriter_SteadyStateFlushSurvivesWriterCtxCancel proves the
+// steady-state observation flush does not depend on the writer's own ctx,
+// which SIGTERM cancels *before* Close is ever called in production.
+//
+// This is the unit-level counterpart to
+// TestPostgresWriter_DrainOnClose_Integration (#111) and covers a window the
+// existing drain tests do not: a row the worker has already taken off
+// obsBatch is no longer in the channel, so Close's drainChannel cannot
+// recover it. If its flush fails, the row is gone. Canceling the writer ctx
+// before the rows are enqueued makes that window deterministic — every row is
+// dequeued and flushed while w.ctx is dead — rather than depending on which
+// case a two-ready select happens to pick.
+//
+// Reverting batchObservations to flush with w.ctx makes this test fail.
+func TestPostgresWriter_SteadyStateFlushSurvivesWriterCtxCancel(t *testing.T) {
+	// SIGTERM has already canceled the shared context the writer was
+	// constructed with; Close has not been called yet.
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+	cancelWorkerCtx()
+
+	fake := &ctxHonoringObsInserter{}
+	w := &PostgresWriter{
+		obsBatch:      make(chan observationRow, 1000),
+		windBatch:     make(chan rapidWindRow, 1000),
+		hubBatch:      make(chan hubStatusRow, 1000),
+		eventBatch:    make(chan eventRow, 1000),
+		batchSize:     100,
+		flushInterval: time.Second,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		done:          make(chan struct{}),
+		obsInserter:   fake,
+	}
+
+	w.wg.Add(1)
+	go w.batchObservations()
+
+	const wantRows = 50
+	for range wantRows {
+		w.obsBatch <- observationRow{serialNumber: "ST-STEADY-CANCEL"}
+	}
+
+	// Wait until the worker has consumed and attempted every row, so the
+	// assertion below measures the steady-state flush path rather than
+	// Close's drain silently rescuing rows the worker never reached.
+	deadline := time.Now().Add(5 * time.Second)
+	for fake.attemptCount() < wantRows {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for worker to consume rows: attempted %d of %d",
+				fake.attemptCount(), wantRows)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := fake.count(); got != wantRows {
+		t.Fatalf("expected %d rows persisted by the steady-state flush, got %d", wantRows, got)
+	}
+}
+
 // TestHandleObservationReport_NaNWetbulbYieldsNull proves a non-convergent
 // (physically impossible) observation stores SQL NULL for temp_wetbulb
 // rather than IEEE NaN. tempest_observations.temp_wetbulb is a nullable
@@ -222,9 +332,13 @@ func TestHandleObservationReport_NaNWetbulbYieldsNull(t *testing.T) {
 // fakeWindInserter is a test double for the windInserter seam, letting
 // TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx assert on the
 // worker's local in-flight batch without a live Postgres connection.
+// attempts counts every row handed to the inserter whether or not the write
+// succeeded, so a test can wait until the worker has actually flushed instead
+// of racing it.
 type fakeWindInserter struct {
-	mu   sync.Mutex
-	rows []rapidWindRow
+	mu       sync.Mutex
+	rows     []rapidWindRow
+	attempts int
 }
 
 // insertRapidWind mirrors the real insertRapidWind's ctx-sensitivity: a real
@@ -234,6 +348,10 @@ type fakeWindInserter struct {
 // would pass this test regardless of whether the shutdown flush used the
 // live or the canceled context, defeating the point of the test.
 func (f *fakeWindInserter) insertRapidWind(ctx context.Context, batch []rapidWindRow) error {
+	f.mu.Lock()
+	f.attempts += len(batch)
+	f.mu.Unlock()
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -247,6 +365,75 @@ func (f *fakeWindInserter) count() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.rows)
+}
+
+func (f *fakeWindInserter) attemptCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+// TestPostgresWriter_BatchFullFlushSurvivesWriterCtxCancel is the
+// accumulator-shaped counterpart to
+// TestPostgresWriter_SteadyStateFlushSurvivesWriterCtxCancel. batchRapidWind
+// and batchHubStatus flush on batch-full and on the ticker, and
+// flushWithRetry drops a batch that fails non-retryably — but the worker has
+// already truncated its local slice, so those rows are gone before Close ever
+// runs. A flush firing in the window after SIGTERM cancels w.ctx and before
+// Close is called must therefore not be bound to w.ctx (#111).
+//
+// Reverting batchRapidWind's batch-full flush to w.ctx makes this test fail.
+func TestPostgresWriter_BatchFullFlushSurvivesWriterCtxCancel(t *testing.T) {
+	// SIGTERM has already canceled the shared context; Close has not run yet.
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+	cancelWorkerCtx()
+
+	const wantRows = 5
+
+	fake := &fakeWindInserter{}
+	w := &PostgresWriter{
+		obsBatch:   make(chan observationRow, 10),
+		windBatch:  make(chan rapidWindRow, 10),
+		hubBatch:   make(chan hubStatusRow, 10),
+		eventBatch: make(chan eventRow, 10),
+		batchSize:  wantRows, // the wantRows-th row triggers the batch-full flush
+		// Long enough that the ticker never fires: this test is about the
+		// batch-full path specifically.
+		flushInterval: time.Hour,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		done:          make(chan struct{}),
+		windInserter:  fake,
+	}
+
+	w.wg.Add(1)
+	go w.batchRapidWind()
+
+	for range wantRows {
+		w.windBatch <- rapidWindRow{serialNumber: "ST-BATCHFULL"}
+	}
+
+	// Wait for the batch-full flush to have been attempted, so the assertion
+	// measures that flush rather than Close's shutdown flush of a local slice
+	// the worker never got around to filling.
+	deadline := time.Now().Add(5 * time.Second)
+	for fake.attemptCount() < wantRows {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for batch-full flush: attempted %d of %d",
+				fake.attemptCount(), wantRows)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := fake.count(); got != wantRows {
+		t.Fatalf("expected %d rows persisted by the batch-full flush, got %d", wantRows, got)
+	}
 }
 
 // TestPostgresWriter_ShutdownFlushesLocalBatchUnderCanceledWctx proves the

--- a/internal/postgres/writer_test.go
+++ b/internal/postgres/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"syscall"
@@ -289,6 +290,105 @@ func TestPostgresWriter_SteadyStateFlushSurvivesWriterCtxCancel(t *testing.T) {
 
 	if got := fake.count(); got != wantRows {
 		t.Fatalf("expected %d rows persisted by the steady-state flush, got %d", wantRows, got)
+	}
+}
+
+// failFirstObsInserter fails its first insert with a RETRYABLE error (io.EOF,
+// which isRetryable treats as a transient connection drop) and succeeds on
+// every later attempt. It is the shape needed to reach flushWithRetry's
+// backoff sleep at all: a non-retryable error is dropped before the sleep,
+// which is why #111's reproduction never exercised this path.
+type failFirstObsInserter struct {
+	mu    sync.Mutex
+	calls int
+	rows  []observationRow
+}
+
+func (f *failFirstObsInserter) insertObservations(ctx context.Context, batch []observationRow) error {
+	f.mu.Lock()
+	f.calls++
+	isFirst := f.calls == 1
+	f.mu.Unlock()
+
+	if isFirst {
+		return fmt.Errorf("insert observations: %w", io.EOF)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("insert observations: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, batch...)
+	return nil
+}
+
+func (f *failFirstObsInserter) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *failFirstObsInserter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+// TestPostgresWriter_RetryOutlivesWriterCtxCancel proves flushWithRetry does
+// not abandon a retryable flush just because the writer's own ctx is dead
+// (#153). Restarting Postgres and the exporter together produces exactly this
+// pairing: a transient connection error arriving while w.ctx is already
+// canceled. Gating the backoff sleep on w.ctx meant the first such failure
+// dropped the batch outright, at the moment durability matters most.
+//
+// Restoring the `case <-w.ctx.Done()` guard in flushWithRetry makes this fail.
+func TestPostgresWriter_RetryOutlivesWriterCtxCancel(t *testing.T) {
+	// SIGTERM has already canceled the shared context; Close has not run yet.
+	workerCtx, cancelWorkerCtx := context.WithCancel(context.Background())
+	cancelWorkerCtx()
+
+	fake := &failFirstObsInserter{}
+	w := &PostgresWriter{
+		obsBatch:      make(chan observationRow, 10),
+		windBatch:     make(chan rapidWindRow, 10),
+		hubBatch:      make(chan hubStatusRow, 10),
+		eventBatch:    make(chan eventRow, 10),
+		batchSize:     100,
+		flushInterval: time.Hour,
+		maxRetries:    3,
+		ctx:           workerCtx,
+		done:          make(chan struct{}),
+		obsInserter:   fake,
+	}
+
+	w.wg.Add(1)
+	go w.batchObservations()
+
+	w.obsBatch <- observationRow{serialNumber: "ST-RETRY"}
+
+	// Wait for the first (failing) attempt, so Close cannot rescue the row via
+	// its drain before the worker has even tried — which would pass the test
+	// without exercising the retry path at all.
+	deadline := time.Now().Add(5 * time.Second)
+	for fake.callCount() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the first insert attempt")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Close blocks in wg.Wait() until the worker finishes retrying, so no
+	// extra synchronisation is needed here.
+	closeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := w.Close(closeCtx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := fake.count(); got != 1 {
+		t.Fatalf("expected the retry to persist the row, got %d rows after %d attempts",
+			got, fake.callCount())
 	}
 }
 

--- a/internal/sqlite/writer.go
+++ b/internal/sqlite/writer.go
@@ -276,6 +276,16 @@ func (w *Writer) run(ctx context.Context) {
 		w.flushBatches(fctx, &obsBatch, &windBatch, &hubBatch, &evtBatch)
 	}
 
+	// The ordinary (non-shutdown) flushes below deliberately drop
+	// cancellation from ctx. Shutdown cancels ctx *before* Close runs, and
+	// flushBatches truncates each batch whether or not the insert succeeded —
+	// the insert helpers return nothing and only log — so a flush landing in
+	// that window destroys its rows outright, with no drain able to recover
+	// them (#154; the same defect as the postgres writer's #111). The
+	// <-w.done branch keeps using w.shutdownCtx, and an explicit Flush keeps
+	// using the request's own ctx, so both remain bounded by a live deadline.
+	steadyCtx := context.WithoutCancel(ctx)
+
 	ticker := time.NewTicker(w.flushInterval)
 	defer ticker.Stop()
 
@@ -295,11 +305,11 @@ func (w *Writer) run(ctx context.Context) {
 			obsBatch, windBatch, hubBatch, evtBatch = appendEnvelope(env, obsBatch, windBatch, hubBatch, evtBatch)
 			if len(obsBatch) >= w.batchSize || len(windBatch) >= w.batchSize ||
 				len(hubBatch) >= w.batchSize || len(evtBatch) >= w.batchSize {
-				flush(ctx)
+				flush(steadyCtx)
 			}
 
 		case <-ticker.C:
-			flush(ctx)
+			flush(steadyCtx)
 
 		case <-w.done:
 			// Drain whatever is still buffered in w.rows (non-blocking): the

--- a/internal/sqlite/writer_test.go
+++ b/internal/sqlite/writer_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"path/filepath"
@@ -468,6 +469,69 @@ func obsReport(serial string, ts int64, tempAir float64) *tempestudp.TempestObse
 		Obs: [][]float64{
 			{float64(ts), 1, 1, 1, 1, 1, 1013, tempAir, 50, 100, 1, 10, 0},
 		},
+	}
+}
+
+// TestWriter_BatchFullFlushSurvivesRunCtxCancel proves a batch-full flush is
+// not bound to the run ctx, which shutdown cancels before Close is called
+// (#154). flushBatches truncates each slice whether or not the insert
+// succeeded — the insert helpers return nothing and only log — so a flush
+// that fails on a dead ctx destroys those rows before Close's drain can see
+// them. This is the SQLite counterpart to
+// TestPostgresWriter_BatchFullFlushSurvivesWriterCtxCancel (#111).
+//
+// Reverting run's batch-full flush to the run ctx makes this fail.
+func TestWriter_BatchFullFlushSurvivesRunCtxCancel(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batchfull.db")
+	db, err := Open(t.Context(), dbPath, Config{BusyTimeout: 5000 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	}()
+
+	// SIGTERM has already canceled the context the writer runs under; Close
+	// has not been called yet. WriteReport below still carries a live ctx,
+	// mirroring a producer that has not noticed shutdown.
+	runCtx, cancelRunCtx := context.WithCancel(context.Background())
+
+	const n = 5
+	// FlushInterval never fires, so the only flush before Close is the
+	// batch-full one the n-th row triggers.
+	w := NewWriter(runCtx, db, Config{BatchSize: n, FlushInterval: time.Hour})
+
+	cancelRunCtx()
+
+	for i := range n {
+		if err := w.WriteReport(t.Context(), obsReport("ST-BATCHFULL", 1700000200+int64(i), 20)); err != nil {
+			t.Fatalf("WriteReport %d: %v", i, err)
+		}
+	}
+
+	// Flush is a control message on the same channel the rows travel, so FIFO
+	// ordering guarantees all n rows — and therefore the batch-full flush they
+	// triggered — have already been handled when this returns. By then the
+	// local batches are empty, so this Flush itself writes nothing; it is a
+	// barrier, not the thing under test.
+	if err := w.Flush(t.Context()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM tempest_observations WHERE serial_number = ?`,
+		"ST-BATCHFULL").Scan(&count); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if count != n {
+		t.Fatalf("expected %d rows persisted by the batch-full flush, got %d", n, count)
+	}
+
+	if err := w.Close(t.Context()); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #111, and the two related defects it turned up along the way (#153, #154). All three are the same piece of knowledge: **the durable write path must not depend on a context that shutdown cancels.**

## #111 — the root cause is a third shape

The issue suspected "a row enqueued after the drain begins, or a final partial batch not flushed". It is neither.

All four batch workers used `w.ctx` for their **steady-state** flushes. SIGTERM cancels `w.ctx` *before* `Close(cleanupCtx)` runs, so in that window a worker keeps taking rows off its channel and flushing them with a dead context. The insert fails, `isRetryable` classifies `context.Canceled` as non-retryable, and `flushWithRetry` drops the batch. By then the row is already off the channel, so `Close`'s `drainChannel` cannot recover it — no goroutine still holds a reference to it.

The earlier C-H1 fix identified this exact mechanism but only converted the `<-w.done` branch to the live `shutdownCtx`, leaving every steady-state flush bound to `w.ctx`.

**The issue's "49 of 50" is a fixed-off-by-one reading of a race.** Observed loss is 1–3 rows and varies run to run, because it depends on how many extra rows a two-ready `select` hands the worker before `<-w.done` wins. Each missing row corresponds 1:1 with a `non-retryable error ... dropping batch: context canceled` log line.

Fix: `steadyStateFlushCtx` (`context.WithoutCancel`). This does not make a flush unbounded — every `insert*` keeps its own 5s `context.WithTimeout`, and `flushWithRetry` still caps attempts.

## #153 — the retry sleep had the same dependency

`flushWithRetry` gated its backoff sleep on `w.ctx`, so a **retryable** failure arriving during shutdown (Class 08 connection drop, deadlock, `57P01`) aborted on the first attempt and dropped the batch. It survived the #111 fix because #111's failures were non-retryable and died before reaching the sleep.

It now takes the same ctx the caller passes to the insert, so the bound follows the flush rather than the process: steady-state flushes back off normally, shutdown flushes stay bounded by the cleanup deadline. `w.ctx` is no longer referenced in the retry path at all.

## #154 — SQLite had the same shape, and it is worse per occurrence

I filed #154 saying the loss was structural but **undemonstrated**, hedging on whether `modernc.org/sqlite` honours ctx on a local file write. It does — `database/sql` rejects at `ExecContext` before the driver is reached. The new test finds **zero of five** rows on disk.

Exposure differs from #111 rather than severity: Postgres lost 1–3 rows because only rows dequeued inside the race window were affected; here `flushBatches` truncates the whole batch whether or not the insert succeeded, so a batch-full or ticker flush in that window takes all of it. It stayed invisible because the insert helpers return no error — the loss is a log line, not a failure.

## The regression suite now actually runs

`-tags integration` was never passed by `task ci`, so the drain-on-close test had been red for months with nothing reporting it. `ci-test.yml` **already** provisions a Postgres service and exports `POSTGRES_URL` — its comment said the tag was omitted *because* the test was known-failing. So enabling it cost no new infrastructure.

Scope check: `-tags integration` is a superset (untagged files still compile), and exactly two tagged files exist — the #111 test and an unconditional skip in `internal/sqlite`. The tagged tests self-guard on `POSTGRES_URL`, so `task ci` stays runnable locally with no database.

The two new Postgres unit tests deliberately run in the **default** gate rather than behind the tag, covering both worker shapes (per-row immediate flush, and local-accumulator batch-full flush). They are deterministic rather than racing a two-ready `select`: `w.ctx` is cancelled up front and each waits on an attempt counter before calling `Close`.

## Verification

- `TestPostgresWriter_DrainOnClose_Integration` passes `-count=5 -race` against a live Postgres 16 (previously failed every run)
- `go test ./... -race -tags integration -count=3` — 1260 pass across 16 packages
- `POSTGRES_URL=... task ci` exits 0, so the integration tests genuinely ran rather than skipping

Each fix was written test-first, and each new test was confirmed to fail for the predicted reason before the production change: 0/50 rows, 0/5 rows, 0 rows after 1 attempt, and 0/5 rows respectively.
