### PR TITLE
ci: build radar/Dockerfile so radar-only changes cannot go green untested

### DIFF
--- a/.github/workflows/ci-radar.yml
+++ b/.github/workflows/ci-radar.yml
@@ -1,0 +1,56 @@
+# Stage e — compiles radar/Dockerfile so a radar-only change cannot go green untested (#137).
+name: ci-radar
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  radar:
+    name: build radar image
+    runs-on: ubuntu-latest
+    # cartopy and arm-pyart are compiled from source against GEOS/PROJ; a cold
+    # cache is several minutes. 30 leaves headroom while capping a hang well
+    # under GitHub's 6-hour default, matching ci-build.yml's reasoning.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Build only — deliberately never pushed. The radar sidecar is opt-in
+      # (deploy/docker-compose.yml's `radar` profile), so nothing consumes a
+      # published radar image today; the requirement in #137 is that the
+      # Dockerfile is *compiled*, not that it is distributed.
+      #
+      # This is also why it is NOT a second ci-build.yml call: that stage
+      # hardcodes `push: true` and defaults its image name to
+      # ghcr.io/<owner>/<repo>, so calling it for radar would publish the
+      # sidecar OVER the main application image's `latest` and `sha` tags.
+      #
+      # No QEMU and no `platforms:` — ubuntu-latest is native linux/amd64, so
+      # the single arch this needs comes for free. Emulating the arm64 leg
+      # would be both slow and unreliable for this image: compiling
+      # arm-pyart's C extensions under QEMU reproducibly crashes cc1 with an
+      # internal compiler error, which is an emulation artifact rather than a
+      # real dependency failure (it compiles cleanly on native hardware).
+      - name: Build radar image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: radar
+          file: radar/Dockerfile
+          push: false
+          # Restores the compiled scientific-Python layers when radar/ is
+          # unchanged, so this stage costs seconds on the pushes that do not
+          # touch it. That is what makes running on every push affordable, and
+          # it is why there is no path filter here: a filter would add a
+          # `skipped` result the `ci` gate must then accept, which is the same
+          # silent-green hole #137 exists to close.
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,17 @@ jobs:
   test:
     uses: ./.github/workflows/ci-test.yml
 
+  # Compiles radar/Dockerfile. `task ci` lints it with hadolint and runs the
+  # sidecar's pytest suite, but nothing ever built it — so a change touching
+  # only radar/ got a green `ci` with no evidence the image still builds.
+  # That is exactly how #73 bumped the base image to python:3.14-slim and
+  # merged (4cca78b) having never been compiled (#137).
+  #
+  # Independent of `context`: this is a code check like `test`, not an image
+  # publish, so it runs on every push rather than only when a PR is open.
+  radar:
+    uses: ./.github/workflows/ci-radar.yml
+
   # The GHCR jobs (build/smoke and their release twins) deliberately do NOT
   # receive APP_ID/APP_PRIVATE_KEY, so they authenticate with GITHUB_TOKEN.
   #
@@ -145,7 +156,7 @@ jobs:
     # `context` MUST be here. Without it, a failing context skips build and
     # smoke, this gate accepts `skipped`, and the required check goes GREEN on a
     # PR whose image was never built or tested.
-    needs: [context, test, build, smoke]
+    needs: [context, test, radar, build, smoke]
     if: ${{ !cancelled() }}   # required: else this is SKIPPED on failure, which can satisfy protection
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -154,12 +165,17 @@ jobs:
         env:
           CONTEXT: ${{ needs.context.result }}
           TEST: ${{ needs.test.result }}
+          RADAR: ${{ needs.radar.result }}
           BUILD: ${{ needs.build.result }}
           SMOKE: ${{ needs.smoke.result }}
         run: |
           set -euo pipefail
           fail=0
-          for stage in context:"${CONTEXT}" test:"${TEST}"; do
+          # radar sits in the must-succeed tier, not the may-skip one: it has
+          # no `if:` and no path filter, so anything other than success is a
+          # real failure. Adding it to `needs` without asserting it here would
+          # recreate the silent green #137 is about.
+          for stage in context:"${CONTEXT}" test:"${TEST}" radar:"${RADAR}"; do
             name="${stage%%:*}"; result="${stage##*:}"
             printf '%-8s %s (must be success)\n' "${name}" "${result}"
             [ "${result}" = "success" ] || fail=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,25 @@ Multi-backend data utilities for Tempest weather stations. The application opera
 
 ### The CI contract
 
-`task ci` is the whole gate, and it is exactly what CI runs — `ci-test.yml`
-invokes `task ci` and nothing else. If a check cannot be run locally with this
-command, it does not belong in a workflow.
+`task ci` is the whole *static* gate: `ci-test.yml` invokes `task ci` and
+nothing else. Every check it runs must be runnable locally with that one
+command — a check that cannot be is not allowed to live only in a workflow.
+
+The image-shaped stages are the deliberate exception, because a container
+build is not something to put in front of every local run. Each still has a
+named local equivalent, and CI runs the stage rather than the task:
+
+| CI stage | Local equivalent |
+|---|---|
+| `ci-build.yml` (application image) | `task build-local` |
+| `ci-smoke.yml` (boot the built image) | `IMAGE=… task smoke` |
+| `ci-radar.yml` (radar sidecar image) | `task radar-build` |
 
 ```bash
-task ci          # everything CI runs: lint, format, tidy, vuln, tests, node
+task ci          # everything the test stage runs: lint, format, tidy, vuln, tests, node, python
 task lint        # static checks only
 task test        # tests only
+task radar-build # compile the radar sidecar image
 task --list      # every available target
 ```
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -93,6 +93,20 @@ tasks:
           || { echo "::error::serves /healthz but not the embedded UI at /"; exit 1; }
         echo "ok: embedded UI served"
 
+  # The local equivalent of the ci-radar stage, paired with it exactly as
+  # build-local is paired with ci-build. Deliberately not part of `task ci`:
+  # cartopy and arm-pyart compile from source, so a cold build is minutes, and
+  # CI gets that back through its layer cache in a way a local run cannot.
+  #
+  # No --platform: on an arm64 workstation, forcing linux/amd64 runs the
+  # compile under QEMU, where cc1 reproducibly dies with an internal compiler
+  # error. Building natively is both the fast path and the honest one; CI
+  # runners are native linux/amd64, which is the arch that actually ships.
+  radar-build:
+    desc: Build the radar sidecar image locally (build-only; never pushed)
+    cmds:
+      - docker build -f radar/Dockerfile -t tempestwx-radar:local radar/
+
   # Retained from the pre-migration taskfile: the local image build is not part
   # of the CI contract but is the documented way to build by hand (CLAUDE.md).
   build-local:


### PR DESCRIPTION
Fixes #137.

`task ci` lints `radar/Dockerfile` with hadolint and runs the sidecar's pytest suite, but nothing ever **built** it. A change touching only `radar/` therefore earned a green `ci` on no evidence — which is what happened to #73, the `python:3.12-slim` → `python:3.14-slim` bump that merged as `4cca78b` having never been compiled.

## What this adds

A build-only `ci-radar.yml` stage, plus `radar` in the `ci` gate's `needs` **and** its must-succeed assertion. Adding it to `needs` alone would have recreated the very hole this closes — a job the gate does not assert on is another silent green.

## Why not a second `ci-build.yml` call

That is the obvious approach and it would have caused real damage. `ci-build.yml` hardcodes `push: true` and defaults its image name to `ghcr.io/<owner>/<repo>`, so calling it with `context: radar` would have **published the radar sidecar over the main application image's `latest` and `sha` tags**.

Build-only is also the right scope on its own terms: the sidecar is opt-in via docker-compose's `radar` profile, so nothing consumes a published radar image today. #137 asks that the Dockerfile be *compiled*, not distributed.

## No path filter, by choice

A `paths: radar/**` filter would introduce a `skipped` result the gate must then accept — the same silent-green shape as the original bug. The gha layer cache does that job instead: pushes that do not touch `radar/` restore the compiled scientific-Python layers and cost seconds.

## Platform

`linux/amd64` only, via `ubuntu-latest`'s native arch rather than QEMU — no `platforms:` and no `setup-qemu`.

This matters more than usual here. Emulating the arm64 leg makes `arm-pyart`'s C extensions die with `gcc: internal compiler error: Segmentation fault ... cc1`. That is an emulation artifact, **not** a dependency failure: the same build succeeds on native hardware, and cartopy produces a `cp314` wheel cleanly. `task radar-build` therefore sets no `--platform`, so it stays usable on arm64 workstations.

Worth noting for the Renovate backlog: this contradicts the "no cp314 wheels" reasoning previously recorded against #73. The image builds fine on Python 3.14.

## Local parity

`task radar-build` is the local equivalent, paired with the stage exactly as `task build-local` is paired with `ci-build.yml`. It is deliberately not part of `task ci` — cartopy and arm-pyart compile from source, so a cold build is minutes, and CI recovers that through its layer cache in a way a local run cannot.

`CLAUDE.md`'s CI-contract section claimed `task ci` is "exactly what CI runs". That was already overstated for `ci-build` and `ci-smoke`; it now states the image-stage exception and tables each stage against its local equivalent.

## Verification and its limit

- `actionlint` clean; `task repo:actions:local-refs` resolves the new stage
- `task ci` exits 0
- `task radar-build` builds the image

**One thing I could not verify locally: a native `linux/amd64` build.** This machine is arm64, so the only amd64 path available to me was QEMU, which fails for the emulation reason above. Native arm64 builds clean (exit 0). This PR's own `ci` run is the authoritative answer for amd64 — which is exactly the gap #137 exists to close, so please check the `radar` job's result here rather than taking the above on faith.
