### PR TITLE
fix(tempestapi): check the WeatherFlow envelope status_code in GetObservations

### DIFF
--- a/internal/tempestapi/client.go
+++ b/internal/tempestapi/client.go
@@ -109,6 +109,7 @@ type Station struct {
 // stationsResponse is the /stations payload. ListStations and ListDevices
 // both decode into it, so the JSON contract lives in exactly one place.
 type stationsResponse struct {
+	statusEnvelope
 	Stations []struct {
 		CreatedEpoch int64 `json:"created_epoch"`
 		Devices      []struct {
@@ -119,10 +120,6 @@ type stationsResponse struct {
 		Name      string `json:"name"`
 		StationID int    `json:"station_id"`
 	} `json:"stations"`
-	Status struct {
-		StatusCode    int    `json:"status_code"`
-		StatusMessage string `json:"status_message"`
-	} `json:"status"`
 }
 
 // fetchStations performs the GET /stations call and validates the status
@@ -137,11 +134,8 @@ func (c *Client) fetchStations(ctx context.Context) (*stationsResponse, error) {
 	if err := json.Unmarshal(body, &data); err != nil {
 		return nil, err
 	}
-	if data.Status.StatusCode != 0 {
-		return nil, &StatusError{
-			StatusCode: data.Status.StatusCode,
-			Message:    data.Status.StatusMessage,
-		}
+	if err := data.err(); err != nil {
+		return nil, err
 	}
 	return &data, nil
 }
@@ -230,6 +224,14 @@ func (c *Client) ListStations(ctx context.Context) ([]Station, error) {
 // listener uses, so backfilled and live rows share one decode
 // implementation. station.SerialNumber is stamped onto the decoded report
 // because the API response itself carries no serial number.
+//
+// A non-zero WeatherFlow envelope status_code is an error here. That IS an
+// observable change for ModeAPIExport: main.go's export loop calls os.Exit(1)
+// on any error from this function, so a window that used to contribute zero
+// observations and continue now aborts the run. That is deliberate — the loop
+// already aborts on 401/429/5xx and on parse failures, so an application-level
+// failure joining that set is consistent, and a silently-empty export window
+// is the data loss this reports rather than hides.
 func (c *Client) GetObservations(ctx context.Context, station Station, startAt time.Time, endAt time.Time) ([]prometheus.Metric, error) {
 	url := fmt.Sprintf("%s/observations/device/%d?time_start=%d&time_end=%d", c.baseURL, station.DeviceID, startAt.Unix(), endAt.Unix())
 	// A non-200 response now surfaces as *StatusError rather than a plain
@@ -241,6 +243,21 @@ func (c *Client) GetObservations(ctx context.Context, station Station, startAt t
 	if err != nil {
 		return nil, err
 	}
+
+	// The envelope is checked BEFORE ParseReport, because ParseReport
+	// dispatches on the top-level "type" and cannot see status at all. Two
+	// distinct failures collapse into this one check: a status-only error
+	// envelope (no "type") used to surface as `unhandled message type: ""`,
+	// which no caller can classify, and a typed error envelope with an empty
+	// obs array used to surface as zero metrics and no error at all.
+	var env statusEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("decode observation envelope: %w", err)
+	}
+	if err := env.err(); err != nil {
+		return nil, err
+	}
+
 	report, err := tempestudp.ParseReport(body)
 	if err != nil {
 		log.Printf("read %s", string(body))

--- a/internal/tempestapi/client_test.go
+++ b/internal/tempestapi/client_test.go
@@ -811,6 +811,55 @@ func TestClient_ChecksStatusCode(t *testing.T) {
 	}
 }
 
+// GetObservations must classify a non-zero WeatherFlow envelope status_code as
+// a *StatusError, exactly as fetchStations and Observations already do.
+//
+// Both response shapes are covered deliberately, because they fail differently
+// today and only one of them matches the way issue #49 describes the gap:
+// without the top-level "type" discriminator ParseReport already rejects the
+// body, but with it the envelope is ignored and the caller sees zero metrics
+// and no error.
+func TestGetObservations_APIStatusFailure_ClassifiesAsStatusError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "status-only envelope",
+			body: `{"status":{"status_code":2,"status_message":"BAD TOKEN"}}`,
+		},
+		{
+			name: "typed envelope with empty obs",
+			body: `{"type":"obs_st","status":{"status_code":2,"status_message":"BAD TOKEN"},"obs":[]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(srv.Close)
+			c := NewClient("test-token", WithBaseURL(srv.URL))
+
+			station := Station{DeviceID: 1, SerialNumber: "ST-1"}
+			_, err := c.GetObservations(t.Context(), station, time.Unix(0, 0), time.Unix(60, 0))
+			if err == nil {
+				t.Fatal("GetObservations() error = nil, want a *StatusError for non-zero status_code")
+			}
+			var se *StatusError
+			if !errors.As(err, &se) {
+				t.Fatalf("GetObservations() error = %v (%T), want errors.As to find a *StatusError", err, err)
+			}
+			if se.StatusCode != 2 {
+				t.Errorf("StatusError.StatusCode = %d, want 2", se.StatusCode)
+			}
+			if se.Message != "BAD TOKEN" {
+				t.Errorf("StatusError.Message = %q, want %q", se.Message, "BAD TOKEN")
+			}
+		})
+	}
+}
+
 func TestListDevicesReturnsEverySTDevice(t *testing.T) {
 	// One station, TWO Tempest sensors, plus a hub that must be ignored.
 	body := `{"status":{"status_code":0,"status_message":"SUCCESS"},"stations":[{

--- a/internal/tempestapi/errors.go
+++ b/internal/tempestapi/errors.go
@@ -28,3 +28,33 @@ func (e *StatusError) Error() string {
 	}
 	return fmt.Sprintf("weatherflow API status %d", e.HTTPStatus)
 }
+
+// statusEnvelope is WeatherFlow's application-level status wrapper, carried by
+// every REST response this client decodes. It is declared once rather than
+// per response type because the wire shape and the rule applied to it are a
+// single piece of knowledge — if WeatherFlow renamed either field, or changed
+// what a non-zero code means, all three decode sites would have to change
+// together to stay correct.
+//
+// Embed it in a response struct; encoding/json promotes the tagged field, so
+// the decoded JSON shape is unchanged.
+type statusEnvelope struct {
+	Status struct {
+		StatusCode    int    `json:"status_code"`
+		StatusMessage string `json:"status_message"`
+	} `json:"status"`
+}
+
+// err reports the envelope as a *StatusError when WeatherFlow signalled an
+// application-level failure, and nil otherwise. A zero status_code — including
+// a response that omits the envelope entirely — is a success, because an empty
+// observation window is a legitimate answer rather than an error.
+func (e statusEnvelope) err() error {
+	if e.Status.StatusCode == 0 {
+		return nil
+	}
+	return &StatusError{
+		StatusCode: e.Status.StatusCode,
+		Message:    e.Status.StatusMessage,
+	}
+}

--- a/internal/tempestapi/observations.go
+++ b/internal/tempestapi/observations.go
@@ -23,10 +23,7 @@ import (
 // array for ObservationSet, so a response may legitimately omit both `type`
 // and `obs` — that is an empty window, not an error.
 type observationSet struct {
-	Status struct {
-		StatusCode    int    `json:"status_code"`
-		StatusMessage string `json:"status_message"`
-	} `json:"status"`
+	statusEnvelope
 	Obs [][]*float64 `json:"obs"`
 }
 
@@ -103,11 +100,8 @@ func (c *Client) Observations(ctx context.Context, station Station, start, end t
 	// A non-zero status_code is a real, non-transient API failure. A zero
 	// status_code with an absent/null/empty obs is an empty window: zero
 	// rows, no error.
-	if set.Status.StatusCode != 0 {
-		return nil, &StatusError{
-			StatusCode: set.Status.StatusCode,
-			Message:    set.Status.StatusMessage,
-		}
+	if err := set.err(); err != nil {
+		return nil, err
 	}
 
 	// at returns ob[i] when the tuple is long enough, nil otherwise. This is


### PR DESCRIPTION
Closes #49.

## Reproduced first, in two shapes

The issue describes one failure. A table-driven test against a stubbed HTTP response found **two**, and they behave differently — so the reproduction is worth reading before the fix:

| Response body (HTTP 200) | Behaviour before | Behaviour after |
|---|---|---|
| `{"type":"obs_st","status":{"status_code":2,…},"obs":[]}` | **0 metrics, `err == nil`** — genuinely silent | `*StatusError{StatusCode: 2}` |
| `{"status":{"status_code":2,…}}` (no `type`) | errors, but as `unhandled message type: ""` | `*StatusError{StatusCode: 2}` |

Only the first matches #49 as written ("silently treated as zero observations"). The second was already an error, just an unclassifiable one naming the wrong cause — `ParseReport` dispatches on the top-level `type`, sees `""`, and reports a decode problem for what is actually an API rejection.

Both are cured by the same check, placed **before** `ParseReport` because `ParseReport` cannot see `status` at all.

Mutation-checked: disabling the new check takes the package from 55 passed to 52 passed / 3 failed, so the tests are load-bearing rather than decorative.

## The empty-window contract is unchanged

`status_code == 0` with an absent, null, or empty `obs` remains a legitimately empty window, not an error — matching the published `ObservationSet` schema, which declares no `required` array. `TestGetObservations_EmptyObservations` still passes untouched.

## Behaviour change in ModeAPIExport — deliberate, not absorbed

`main.go:709` exits 1 on **any** error from `GetObservations`. So a window that used to contribute zero observations and continue now aborts the export run.

That was raised as a decision rather than shipped as a side effect, and the chosen option is to let it abort: the loop already aborts on 401/429/5xx and on parse failures, so an application-level failure joining that set is consistent — and a silently-empty export window is exactly the data loss this issue is about. No `main.go` change.

## Also: the status envelope is now single-sourced

It was declared identically in `stationsResponse` and `observationSet`, and this fix would have added a third copy. The wire shape and the "non-zero means application-level failure" rule are one piece of knowledge that must change together, so they now live once in `statusEnvelope.err()`. Behaviour-preserving; the existing `ListStations`/`Observations` envelope tests pin it.

## Verification

- `task ci` → exit **0** in a clean worktree checkout (golangci-lint `0 issues`, govulncheck clean, actionlint/hadolint run).
- `go test ./internal/tempestapi/ ./internal/backfill/` → 111 passed.

## Not verified

WeatherFlow's actual `status_code` catalogue was not confirmed against the live API. The codebase's existing assumption — documented in `observations.go` and relied on by backfill's permanent-hole detection — is that an empty window comes back as `status_code == 0` with empty `obs`, not as a non-zero code. If WeatherFlow ever used a non-zero code for a benign "no data in range", this would turn ordinary gaps into export aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)