### PR TITLE
fix(web): refetch the records summary when Refresh is pressed

### DIFF
--- a/web/src/hooks/useWeatherData.test.ts
+++ b/web/src/hooks/useWeatherData.test.ts
@@ -447,6 +447,28 @@ describe('useWeatherData - records summary', () => {
     expect(mockedApi.fetchRecordsSummary).toHaveBeenNthCalledWith(2, 30, expect.any(AbortSignal));
   });
 
+  it('re-fetches the summary when refresh() is called', async () => {
+    setupCoreMocks();
+    const before: RecordsSummary = { ...baseSummary, rainTotal: 5 };
+    const after: RecordsSummary = { ...baseSummary, rainTotal: 9 };
+    mockedApi.fetchRecordsSummary.mockResolvedValueOnce(before).mockResolvedValueOnce(after);
+
+    const { result } = renderHook(() => useWeatherData());
+
+    await waitFor(() => expect(result.current.summary).toEqual(before));
+    expect(mockedApi.fetchRecordsSummary).toHaveBeenCalledTimes(1);
+
+    result.current.refresh();
+
+    // The manual Refresh button must cover the Records card too. Without this
+    // the card silently holds page-load extremes -- a storm's rain total and
+    // lightning count never move, and coveredTo freezes -- while every live
+    // card around it updates.
+    await waitFor(() => expect(result.current.summary).toEqual(after));
+    expect(mockedApi.fetchRecordsSummary).toHaveBeenCalledTimes(2);
+    expect(mockedApi.fetchRecordsSummary).toHaveBeenNthCalledWith(2, 7, expect.any(AbortSignal));
+  });
+
   it('retains the prior summary when a refetch after a window change fails (stale-retain)', async () => {
     setupCoreMocks();
     mockedApi.fetchRecordsSummary

--- a/web/src/hooks/useWeatherData.ts
+++ b/web/src/hooks/useWeatherData.ts
@@ -95,6 +95,13 @@ export function useWeatherData(
   const [isStale, setIsStale] = useState(false);
   const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
   const [capsSettled, setCapsSettled] = useState(false);
+  // Bumped by refresh() to re-run the records-summary effect below. The
+  // summary is not part of loadData's request set (it is keyed on window, not
+  // stationId, and reads the local store rather than the WeatherFlow proxy),
+  // so a counter in that effect's dependency array is what lets the manual
+  // Refresh button reach it -- while leaving the effect's own per-run
+  // AbortController and stale-retain behaviour exactly as they were.
+  const [summaryNonce, setSummaryNonce] = useState(0);
 
   // Stable booleans, NOT `capabilities?.forecast === true` inline in a
   // dependency array -- a computed expression there is an eslint error
@@ -275,9 +282,13 @@ export function useWeatherData(
 
   // Records summary is a separate, slow-moving slice (a 7-365 day
   // aggregate read from the local store, keyed on window not stationId) --
-  // it has its own trigger (the window pref changing), not the 30s poll or
-  // loadData's stationId-keyed refresh, so it gets its own controller and
-  // effect rather than sharing abortRef/loadData.
+  // it has its own triggers, not the 30s poll, so it gets its own controller
+  // and effect rather than sharing abortRef/loadData.
+  //
+  // Two triggers: the window pref changing, and refresh() bumping
+  // summaryNonce. It stays off the 30s poll deliberately -- a multi-day
+  // aggregate does not move on a 30s cadence, and re-running this scan every
+  // tick would put load on the store for nothing.
   useEffect(() => {
     const controller = new AbortController();
     const { signal } = controller;
@@ -295,7 +306,7 @@ export function useWeatherData(
     })();
 
     return () => controller.abort();
-  }, [recordsWindowDays]);
+  }, [recordsWindowDays, summaryNonce]);
 
   // Accepted wrinkle: if capabilities were unknown, the user presses Retry, and
   // the capability re-attempt then SUCCEEDS, the enabled-flags flip changes
@@ -305,6 +316,10 @@ export function useWeatherData(
   const refresh = useCallback(() => {
     if (capabilities === null) loadCapabilities();
     loadData();
+    // Re-runs the records-summary effect. Without this the Records card is the
+    // one slice the Refresh button does not reach, so it holds page-load
+    // extremes -- and coveredTo -- for the lifetime of the tab (issue #89).
+    setSummaryNonce((n) => n + 1);
   }, [capabilities, loadCapabilities, loadData]);
 
   return {


### PR DESCRIPTION
Closes #89.

## Reproduced first

A test that resolves two different summaries and then presses `refresh()` showed the card holding the **first** one, with `fetchRecordsSummary` never called a second time:

```
- "rainTotal": 9,     <- expected after refresh()
+ "rainTotal": 5,     <- actual: still the page-load value
```

Confirms the issue as written. The summary effect was keyed on `[recordsWindowDays]` alone, so toggling the window was the only thing that could refetch it. `refresh()` calls `loadData()`, and the summary is deliberately not in that request set — it is keyed on window rather than `stationId`, and reads the local store rather than the WeatherFlow proxy — so Refresh never reached it.

Practical effect on a long-lived dashboard: today's new high, a storm's accumulating rain total and lightning count, and `coveredTo` all freeze at page-load time while every live card around them keeps updating.

## The fix

`refresh()` bumps a `summaryNonce` counter that sits in the effect's dependency array:

```ts
const refresh = useCallback(() => {
  if (capabilities === null) loadCapabilities();
  loadData();
  setSummaryNonce((n) => n + 1);
}, [capabilities, loadCapabilities, loadData]);

useEffect(() => { /* …fetchRecordsSummary… */ }, [recordsWindowDays, summaryNonce]);
```

This reuses the existing effect wholesale, so its **per-run `AbortController` and stale-retain catch are unchanged** rather than reimplemented at a second call site. The existing stale-retain test still passes untouched.

Mutation-checked: removing just the `setSummaryNonce` call takes the suite from 15 passed to 14 passed / 1 failed, so the new test pins the actual mechanism.

## Scope decisions

- **No slow interval.** The issue also suggested "and/or a slow independent interval (e.g. every 10–30 min)". Raised as a scope call and declined — nothing should update without a user present, and this keeps the change to one counter and zero new timers. Easy to add later.
- **Still off the 30s poll.** A 7–365 day aggregate does not move on a 30s cadence, and re-running that scan every tick would load the store for nothing.
- **No `AbortSignal.any`.** Not reintroduced — it was removed for the Safari 17.4 floor and `build.target` cannot polyfill it.

## Verification

- `task ci` → exit **0** in a clean worktree checkout.
- Full web suite: **106 passed** (15 files), up one test from 105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)