### PR TITLE
chore: remove release-as now that v1.0.0 is cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,7 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "include-v-in-tag": true,
-      "release-as": "1.0.0"
+      "include-v-in-tag": true
     }
   }
 }


### PR DESCRIPTION
Phase 5 of #198. Closes out the release reset.

## What this does

Removes `"release-as": "1.0.0"` from `packages["."]` in `release-please-config.json`. One line net.

```json
"packages": { ".": { "release-type": "go", "include-v-in-tag": true } }
```

## Why it has to happen now

`release-as` was the pin that let release-please cut a **fresh** `v1.0.0` over a version line that had already reached `v4.0.0`. That worked — the 8 old releases and tags are deleted and the new `v1.0.0` was cut at `8b1c562` (published `2026-08-26T10:35:24Z`, and it is the repo's only release).

The pin has now done its job. Left in place it would **pin every future release to 1.0.0**, and the failure is quiet: the symptom is a release PR that keeps proposing a version which already shipped. #198 §5.3 calls this "the easiest step in the whole issue to forget and the most annoying to notice later."

With this removed, `.release-please-manifest.json` (`{".": "1.0.0"}`) is the sole source of the current version, which is how release-please is meant to work — it reads the manifest, not the git tags.

## Verification

`task ci` — **EXIT=0** locally.

Beyond that:

- `jq -e . release-please-config.json` → exit 0 (valid JSON after removing the trailing comma)
- `grep -rn "release-as" release-please-config.json .release-please-manifest.json .github/` → no matches

**The real proof is not this diff.** It is the next release PR proposing `1.0.1` or `1.1.0` instead of `1.0.0`. Note a `chore:` commit does not bump a version on its own, so that evidence arrives with the next `feat`/`fix` to land on `main` — it will not appear as a result of merging this PR.

Refs #198