### PR TITLE
fix(renovate): stop proposing the radar sidecar's python base bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,13 @@
       "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
       "matchPackageNames": ["**", "!golang"],
       "groupName": "docker-images"
+    },
+    {
+      "description": "The radar sidecar's python base is pinned to 3.12 and must not be bumped automatically. cartopy 0.25.0 publishes manylinux wheels for cp310-cp313 and none for cp314, so on 3.14 pip builds cartopy from source and the resulting extension fails to link libstdc++ at import time (#186). The image still BUILDS green in that state -- ci-radar.yml builds it without ever running it -- so no CI signal catches the regression. Note this bump is a MINOR update to renovate (3.12 -> 3.14 keeps major 3), so the grouping rule above does not hold it back: PR #139 carried exactly this revert inside a routine docker-images group. Bumping the base is a deliberate decision that requires checking cartopy's wheels and booting the image first; see the comment at the top of radar/Dockerfile.",
+      "matchFileNames": ["radar/Dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["python"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Closes the hole that let #139 propose reverting the radar sidecar to python 3.14.

## Why

`radar/Dockerfile` is pinned to python 3.12 (396a195, #186) because cartopy 0.25.0 publishes manylinux wheels for cp310–cp313 and **none for cp314**. On 3.14 pip builds cartopy from source and the resulting extension fails to link libstdc++ at import, so the sidecar cannot boot.

Nothing stopped Renovate from re-proposing that bump. **#139 currently carries exactly the revert** — `radar/Dockerfile` back to `python:3.14-slim` — and it is **green**, because `ci-radar.yml` builds the image and never runs it. Its own comment says so: *"Build only — deliberately never pushed."* A passing pipeline is not evidence here, so this would have merged as a routine dependency update.

## Why the existing grouping rule didn't hold it back

`3.12 → 3.14` keeps major `3`, so Renovate classifies it **minor**, and the `docker-images` group matches `minor`. That rule's description asserts *"holding one major (python 3.14, grafana 13)"* — python 3.14 is **not** a major to Renovate, and that mistaken premise is why the regression arrived inside a routine grouped bump. I have left that description untouched rather than widen this change, but it is misleading and worth a follow-up.

## Verification

`renovate --platform=local --dry-run=lookup`, run with and without the rule:

| | `skipReason` | proposed `newValue` |
|---|---|---|
| **before** (control, rule stashed) | *none* | **`3.14-slim`** |
| **after** | `disabled` | *empty updates* |

The control reproduces #139's regression, which is what makes the "after" meaningful. `renovate-config-validator` also passes.

## Scope

Only `radar/Dockerfile`'s python base. Every other docker dependency still flows through the `docker-images` group. Bumping the base remains possible as a deliberate change — which is exactly what the comment at the top of `radar/Dockerfile` already asks for.

## Follow-ups not in this PR

- **#139 still needs handling.** Once this lands, Renovate should regenerate that group PR without the python change. It must not be merged before then.
- **#186's real fix is still missing** — a CI check that *boots* the radar image. This PR stops one regression from being proposed; it does not make CI capable of catching one.

Refs #186, #139
