### PR TITLE
fix: report every unmet almanac precondition in one startup

### DIFF
--- a/cmd/stormglass/main.go
+++ b/cmd/stormglass/main.go
@@ -544,18 +544,30 @@ func decideUI(flags uiFlags, station config.StationConfig, hasStore bool) uiDeci
 	}
 
 	if flags.Almanac {
-		switch {
-		case !hasCoords:
+		// Sequential checks, not a switch: an operator missing BOTH
+		// coordinates and a store must learn both from one startup. A switch
+		// selects exactly one arm, costing that operator two restarts to
+		// learn two things (issue #174). This mirrors the radar block below,
+		// and extends TestDecideUI_ReportsEveryUnmetPrecondition's property
+		// -- asserted across the three flags -- to hold within this one too.
+		almanacOK := true
+		if !hasCoords {
+			almanacOK = false
 			d.Reasons = append(d.Reasons,
 				"ENABLE_ALMANAC is true but STATION_LATITUDE and STATION_LONGITUDE are not both set, "+
 					"so sunrise and sunset cannot be computed. The almanac card will not be mounted.")
-		case !hasStore:
+		}
+		if !hasStore {
+			almanacOK = false
 			d.Reasons = append(d.Reasons,
 				"ENABLE_ALMANAC is true but no observation store is configured, so the temperature "+
 					"records have no source. SQLite is the default store; this is the Postgres-only "+
 					"configuration. The almanac card will not be mounted.")
-		default:
+		}
+		if almanacOK {
 			d.Almanac = true
+			// Gated on the card actually mounting: a WARN about how times
+			// will render is noise when nothing renders at all.
 			if !station.TimezoneConfigured {
 				d.Warnings = append(d.Warnings,
 					"ENABLE_ALMANAC is true and coordinates are set, but STATION_TIMEZONE "+

--- a/cmd/stormglass/main_test.go
+++ b/cmd/stormglass/main_test.go
@@ -293,6 +293,20 @@ func TestDecideUI(t *testing.T) {
 			wantReasons: []string{"ENABLE_ALMANAC", "observation store"},
 		},
 		{
+			// #174: decideUI's almanac block used a single-select switch, so a
+			// deployment missing BOTH preconditions was told only about the
+			// first. The radar block next door already reports every one.
+			name:        "almanac_without_coordinates_or_a_store",
+			flags:       uiFlags{Almanac: true},
+			station:     config.StationConfig{},
+			hasStore:    false,
+			wantAlmanac: false,
+			wantReasons: []string{
+				"STATION_LATITUDE", "STATION_LONGITUDE", // the coordinates reason
+				"observation store", // AND the store reason
+			},
+		},
+		{
 			name:        "radar_without_a_site",
 			flags:       uiFlags{Radar: true},
 			station:     locatedNoSite,


### PR DESCRIPTION
Fixes #174

`decideUI`'s almanac block used a single-select `switch`, so a deployment missing **both** coordinates and an observation store was told only about the coordinates — fix that, restart, and only then learn about the store. Two restarts to learn two things.

Replaced with sequential checks and an `almanacOK` accumulator, mirroring the radar block directly below it (PR #173).

## Evidence

RED first — the new table row `almanac_without_coordinates_or_a_store` failed with exactly the bug:

```
main_test.go:403: reasons "ENABLE_ALMANAC is true but STATION_LATITUDE and
STATION_LONGITUDE are not both set, ..." must mention "observation store"
```

GREEN after the rewrite, and `task ci` → `EXIT=0`.

## Blast radius (checked, not assumed)

`TestDecideUI_ReportsEveryUnmetPrecondition` passes unchanged. It joins all reasons and asserts the three `ENABLE_*` names appear, so its substring assertions survive; the almanac now contributes two reasons instead of one, raising that case's total from 4 to 5.

The `STATION_TIMEZONE` WARN stays gated on the card actually mounting — a warning about how times will render is noise when nothing renders at all. Rows `almanac_without_coordinates` and `almanac_without_a_store` are untouched.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`, no breaking changes.