### PR TITLE
fix(radar): raise the sidecar payload cap to 64 MiB and fail loud on overflow

### DIFF
--- a/internal/radar/proxy.go
+++ b/internal/radar/proxy.go
@@ -16,8 +16,18 @@ import (
 const (
 	// radarCacheMaxEntries bounds the LRU. ~160 sites but any one deployment
 	// tracks 1 station → a handful of sites × 2 products (N0B/N0Q) × the last
-	// few scan times; 64 is generous headroom and a hard memory bound.
-	radarCacheMaxEntries = 64
+	// few scan times; 8 is still generous for that sizing, and it keeps the
+	// "hard memory bound" honest now that radarSidecarMaxBody is 64 MiB:
+	// the worst case was 64 × 10 MiB = 640 MiB and is now 8 × 64 MiB =
+	// 512 MiB, so raising the per-payload cap LOWERS the total bound.
+	radarCacheMaxEntries = 8
+	// radarSidecarMaxBody caps a single sidecar response. A real N0B scan
+	// measured 19,471,933 bytes (site ATX, storm conditions) and ~10.7 MB on
+	// a quiet day, so the previous 10 MiB limit truncated live traffic. This
+	// is 3.45× the largest measured payload (64 MiB ÷ 19,471,933) and remains
+	// a hard bound: a body over it is rejected explicitly, never truncated
+	// and handed to the JSON decoder (issue #185).
+	radarSidecarMaxBody = 64 << 20
 	// radarCacheTTL ≈ one WSR-88D volume-scan cycle (VCP ~4–6 min); 5 min keeps
 	// a scan cached for its useful life without serving stale reflectivity.
 	radarCacheTTL = 5 * time.Minute
@@ -181,9 +191,16 @@ func (p *Proxy) fetch(ctx context.Context, site, product string) (json.RawMessag
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	// +1 so a body at exactly the cap is complete while one byte over is
+	// detectable. Truncating at the limit and parsing the fragment is the
+	// bug: it surfaced as "unexpected end of JSON input" behind a 502, with
+	// nothing pointing at a size limit (#185).
+	body, err := io.ReadAll(io.LimitReader(resp.Body, radarSidecarMaxBody+1))
 	if err != nil {
 		return nil, Metadata{}, fmt.Errorf("read radar sidecar response: %w", err)
+	}
+	if len(body) > radarSidecarMaxBody {
+		return nil, Metadata{}, fmt.Errorf("%w: radar sidecar payload exceeds %d bytes", ErrInternal, radarSidecarMaxBody)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/radar/proxy_test.go
+++ b/internal/radar/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,8 +33,14 @@ func writeSidecarError(w http.ResponseWriter, status int, code string) {
 }
 
 func TestProxy_Constants(t *testing.T) {
-	if radarCacheMaxEntries != 64 {
-		t.Errorf("radarCacheMaxEntries = %d, want 64", radarCacheMaxEntries)
+	// Lowered 64 → 8 by #185: radarSidecarMaxBody rose to 64 MiB, and 8
+	// entries keeps the const block's "hard memory bound" true (8 × 64 MiB =
+	// 512 MiB, below the previous 64 × 10 MiB = 640 MiB).
+	if radarCacheMaxEntries != 8 {
+		t.Errorf("radarCacheMaxEntries = %d, want 8", radarCacheMaxEntries)
+	}
+	if radarSidecarMaxBody != 64<<20 {
+		t.Errorf("radarSidecarMaxBody = %d, want %d", radarSidecarMaxBody, 64<<20)
 	}
 	if radarCacheTTL != 5*time.Minute {
 		t.Errorf("radarCacheTTL = %v, want %v", radarCacheTTL, 5*time.Minute)
@@ -120,5 +127,95 @@ func TestProxy_ErrorEnvelope(t *testing.T) {
 	// decode_failed is not no_recent_scan, so no N0B->N0Q fallback attempt.
 	if hits.Load() != 1 {
 		t.Errorf("sidecar hits = %d, want 1 (no fallback for decode_failed)", hits.Load())
+	}
+}
+
+// paddedSidecarBody writes a valid Contract A success envelope padded to
+// exactly total bytes. The padding lives in an unknown string field, which
+// sidecarSuccessBody ignores — so the body stays DECODABLE at any size.
+// Arbitrary filler bytes would fail on json.Unmarshal instead of proving
+// passthrough, which is the distinction #185 turns on.
+func paddedSidecarBody(t *testing.T, total int) []byte {
+	t.Helper()
+	env := map[string]any{
+		"type":     "FeatureCollection",
+		"features": []any{},
+		"metadata": map[string]any{
+			"site":      "TLX",
+			"product":   "N0B",
+			"scan_time": "2026-07-20T12:00:00Z",
+			"bbox":      []float64{-98.5, 34.9, -96.5, 36.1},
+		},
+		"pad": "",
+	}
+	base, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	padLen := total - len(base)
+	if padLen < 0 {
+		t.Fatalf("total %d smaller than the envelope itself (%d)", total, len(base))
+	}
+	env["pad"] = strings.Repeat("x", padLen)
+	out, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal padded envelope: %v", err)
+	}
+	if len(out) != total {
+		t.Fatalf("padded body = %d bytes, want exactly %d", len(out), total)
+	}
+	return out
+}
+
+// TestProxy_PayloadJustUnderCapPassesThrough is #185's (a) case: the largest
+// payload the proxy accepts must round-trip intact, not be truncated.
+// Live reference: a real N0B scan measured 19,471,933 bytes in storm
+// conditions, which the old 10 MiB cap silently truncated into a JSON decode
+// error surfaced as a 502.
+func TestProxy_PayloadJustUnderCapPassesThrough(t *testing.T) {
+	body := paddedSidecarBody(t, radarSidecarMaxBody)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	got, meta, err := NewProxy(srv.URL).Get(t.Context(), "TLX", "N0B")
+	if err != nil {
+		t.Fatalf("Get at exactly the cap (%d bytes): %v", radarSidecarMaxBody, err)
+	}
+	if len(got) != len(body) {
+		t.Errorf("body round-tripped as %d bytes, want %d — payload was truncated", len(got), len(body))
+	}
+	if meta.Site != "TLX" || meta.Product != "N0B" {
+		t.Errorf("metadata = %+v, want site=TLX product=N0B", meta)
+	}
+}
+
+// TestProxy_PayloadOverCapFailsLoud is #185's (b) case. One byte over the
+// cap must produce an explicit too-large error — NOT a JSON decode error.
+// The old code truncated at the limit and handed the fragment to
+// json.Unmarshal, so operators saw "unexpected end of JSON input" and a 502
+// with no hint that a size limit was the cause.
+func TestProxy_PayloadOverCapFailsLoud(t *testing.T) {
+	body := paddedSidecarBody(t, radarSidecarMaxBody+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	_, _, err := NewProxy(srv.URL).Get(t.Context(), "TLX", "N0B")
+	if err == nil {
+		t.Fatal("Get one byte over the cap returned no error")
+	}
+	if !strings.Contains(err.Error(), "payload exceeds") {
+		t.Errorf("error = %q, want it to contain \"payload exceeds\"", err)
+	}
+	// The regression this closes: the failure must not masquerade as bad JSON.
+	for _, decodeish := range []string{"unexpected end of JSON", "decode radar sidecar response"} {
+		if strings.Contains(err.Error(), decodeish) {
+			t.Errorf("error = %q — that is a DECODE error, not a size error (#185's whole point)", err)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #185

The proxy read the sidecar response through `io.LimitReader(..., 10<<20)` and then parsed whatever came back. A real N0B scan in storm conditions measures **19,471,933 bytes** — nearly twice that limit — so the read returned a truncated fragment, `json.Unmarshal` reported `unexpected end of JSON input`, and the operator saw a 502 with nothing pointing at a size limit.

## Evidence

RED first, against the real behavior (constant declared, read path untouched):

```
--- FAIL: TestProxy_PayloadJustUnderCapPassesThrough
    Get at exactly the cap (67108864 bytes): decode radar sidecar response: unexpected end of JSON input
--- FAIL: TestProxy_PayloadOverCapFailsLoud
    error = "decode radar sidecar response: unexpected end of JSON input" — that is a DECODE error, not a size error
```

That is #185's exact symptom. GREEN after the fix; `task ci` → `EXIT=0`.

The test bodies are **valid** Contract A envelopes padded through an unknown string field, so `sidecarSuccessBody` still decodes them — arbitrary filler would fail on decode and prove nothing about passthrough, which is the distinction this issue turns on.

## The cache bound moves too

`radarCacheMaxEntries` drops 64 → 8 in the same change, so the const block's "hard memory bound" comment stays true:

| | per-payload cap | entries | worst case |
|---|---|---|---|
| before | 10 MiB | 64 | 640 MiB |
| after | 64 MiB | 8 | **512 MiB** |

Raising the per-payload cap *lowers* the total bound. The block's own sizing ("a handful of sites × 2 products") is well within 8.

`TestProxy_Constants` pinned `radarCacheMaxEntries` at 64. That pin is updated here deliberately, in the same commit as the constants it guards, and extended to cover `radarSidecarMaxBody`.

## Accepted cost

The two boundary tests allocate ~64 MiB bodies on every CI run, taking `internal/radar` from ~0.5s to **~6.9s** under `-race`. Deliberate: the boundary is the bug, and shrinking the bodies below the real limit would stop testing it.

## Live context

Measured against a booted stack during verification: today's ATX N0B payload was 3,437,276 bytes — under both the old and new caps, consistent with the issue's own note that the overflow is data-dependent (a quiet scan). The 19.4 MB storm measurement is the case this fix exists for.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`, no breaking changes.