### PR TITLE
fix(ci): always run actionlint instead of change-detecting against a possibly-null base

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -53,10 +53,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # 0, not 2: `task lint` diffs against BASE_REF to decide whether to run
-          # actionlint. Depth 2 only sees the last commit, so a push whose
-          # workflow edit was not the final commit silently skipped the lint.
-          fetch-depth: 0
 
       - name: Set up toolchains
         uses: ./.github/actions/setup
@@ -65,9 +61,6 @@ jobs:
 
       - name: Run task ${{ inputs.task }}
         env:
-          # The real base for this run: the PR's merge base, or the previous tip
-          # on a push. Falls back to HEAD~1 inside the task when unset.
-          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
           # Unguards the internal/postgres tests against the service container
           # above. `task test` shells out to `go test`, which inherits this.
           POSTGRES_URL: postgres://postgres:postgres@localhost:5432/weather?sslmode=disable

--- a/.taskfiles/repo.yml
+++ b/.taskfiles/repo.yml
@@ -11,19 +11,12 @@ tasks:
       - task: helm
 
   actions:
-    desc: Lint GitHub Actions workflows (only when they changed)
+    desc: Lint GitHub Actions workflows (always — see #212)
     cmds:
       - task: actions:local-refs
       - |
         set -eu
         [ -d .github/workflows ] || { echo "no workflows — skipping actionlint"; exit 0; }
-        base="${BASE_REF:-HEAD~1}"
-        if git rev-parse --verify --quiet "${base}" >/dev/null; then
-          if [ -z "$(git diff --name-only "${base}" HEAD -- .github/workflows)" ]; then
-            echo "no workflow changes since ${base} — skipping actionlint"
-            exit 0
-          fi
-        fi
         command -v actionlint >/dev/null \
           || { echo "actionlint not installed: go install github.com/rhysd/actionlint/cmd/actionlint@latest" >&2; exit 1; }
         actionlint


### PR DESCRIPTION
Fixes #212

The `actions` task diffed `.github/workflows` against `BASE_REF` to decide whether to lint. On the **first push of any new branch**, `github.event.before` is the null SHA — and that is the trap:

```
$ git rev-parse --verify --quiet 0000000000000000000000000000000000000000 >/dev/null; echo $?
0
```

It verifies successfully, `git diff` against it yields nothing, so the guard concluded "no workflow changes" and skipped actionlint entirely. Every new branch got a free pass on exactly the push most likely to introduce a workflow error. This already caused a real miss (#208).

## Approach

Option 3 from the issue — which the issue itself calls most consistent with the CI contract. actionlint is sub-second here (0.10–0.14s user, measured twice), so the guard bought nothing.

## What was verified before deleting

Deleting the guard removes the only consumer of `BASE_REF`, so the env var and the `fetch-depth: 0` that existed solely to feed that diff both go. Checked first, not assumed:

```
$ grep -rn "BASE_REF" .taskfiles taskfile.yml     → zero hits
$ grep -n  "BASE_REF" .github/workflows/ci-test.yml → exactly 56 and 70
                                                      (both deleted here)
$ grep -rn "git " taskfile.yml .taskfiles/         → zero hits
```

No workflow, Dockerfile, or bake file runs `git` against history. `.golangci.yml`'s `new-from-merge-base` is **commented out** — re-enabling it would need `fetch-depth: 0` restored, which this makes a deliberate two-line revert rather than an accident.

`persist-credentials: false`, the `[ -d .github/workflows ]` no-op guard, and the fail-loud missing-tool check all stay.

## Acceptance test — this PR is the test

This branch is a brand-new branch editing workflow files, so its first-push CI run is exactly the case that used to skip. Evidence in a follow-up comment once the run completes: the log must contain **zero** occurrences of the runtime skip message `no workflow changes since`.

Locally: `task repo:actions` → `EXIT=0`, runtime skip count `0`. `task ci` → `EXIT=0`.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`, no breaking changes. CI plumbing — no behavioral test cycle (documented TDD exception).