### PR TITLE
fix(ci): boot the radar image in CI so an unbootable build cannot go green

### DIFF
--- a/.github/workflows/ci-radar.yml
+++ b/.github/workflows/ci-radar.yml
@@ -24,10 +24,14 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      # Build only — deliberately never pushed. The radar sidecar is opt-in
-      # (deploy/docker-compose.yml's `radar` profile), so nothing consumes a
-      # published radar image today; the requirement in #137 is that the
-      # Dockerfile is *compiled*, not that it is distributed.
+      # Built and BOOTED, but deliberately never pushed. The radar sidecar is
+      # opt-in (deploy/docker-compose.yml's `radar` profile), so nothing
+      # consumes a published radar image today. #137 required the Dockerfile
+      # be *compiled*; #186 showed that is not enough -- the image built
+      # cleanly for weeks while being unbootable, because the python 3.14 bump
+      # broke the native extensions at import time and nothing ever started
+      # the container. So the image is loaded into the runner's daemon and
+      # smoke-tested below; it is still not distributed.
       #
       # This is also why it is NOT a second ci-build.yml call: that stage
       # hardcodes `push: true` and defaults its image name to
@@ -46,6 +50,11 @@ jobs:
           context: radar
           file: radar/Dockerfile
           push: false
+          # load + tags together: without `load:` the buildx result never
+          # reaches the runner's daemon, and without `tags:` the loaded image
+          # is unnamed and the smoke step has nothing to reference.
+          load: true
+          tags: stormglass-radar:ci
           # Restores the compiled scientific-Python layers when radar/ is
           # unchanged, so this stage costs seconds on the pushes that do not
           # touch it. That is what makes running on every push affordable, and
@@ -54,3 +63,18 @@ jobs:
           # silent-green hole #137 exists to close.
           cache-from: type=gha
           cache-to: type=gha,mode=min
+
+      # Task is needed only to run radar-smoke; lint-tools: false keeps a
+      # radar-only job from installing the full linter set.
+      - name: Set up toolchains
+        uses: ./.github/actions/setup
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          lint-tools: false
+
+      # The gate #186 was missing. `task radar-smoke` imports decode (the
+      # module whose native extensions broke) and then boots the container and
+      # waits for /healthz on 8081. An unbootable image now fails here instead
+      # of shipping green.
+      - name: Smoke test radar image
+        run: IMAGE=stormglass-radar:ci task radar-smoke

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -107,6 +107,34 @@ tasks:
     cmds:
       - docker build -f radar/Dockerfile -t stormglass-radar:local radar/
 
+  radar-smoke:
+    desc: Boot the built radar sidecar image and assert it serves
+    requires:
+      vars: [IMAGE]
+    # Same reason as `smoke`: accepts BOTH `IMAGE=… task radar-smoke` and
+    # `task radar-smoke IMAGE=…`.
+    env:
+      IMAGE: '{{.IMAGE}}'
+    cmds:
+      - |
+        set -eu
+        echo "smoke testing radar sidecar ${IMAGE}"
+        # The issue's own minimal check first, so an import-time failure names
+        # itself instead of surfacing as "never served /healthz". app.py:15
+        # does `import decode` at module top, and decode.py pulls the
+        # pyart/matplotlib/cartopy chain -- which is exactly how #186 failed:
+        # the native extensions did not load, so uvicorn never started.
+        docker run --rm --entrypoint python "${IMAGE}" -c "import decode"
+        echo "ok: decode imports"
+        docker run -d --name radar-smoke -p 8081:8081 "${IMAGE}"
+        trap 'docker logs radar-smoke || true; docker rm -f radar-smoke >/dev/null 2>&1 || true' EXIT
+        for i in $(seq 1 30); do
+          curl -sf http://localhost:8081/healthz >/dev/null && break
+          [ "$i" = "30" ] && { echo "::error::radar sidecar never served /healthz on :8081"; exit 1; }
+          sleep 2
+        done
+        echo "ok: radar sidecar serves /healthz"
+
   # Retained from the pre-migration taskfile: the local image build is not part
   # of the CI contract but is the documented way to build by hand (CLAUDE.md).
   build-local:


### PR DESCRIPTION
Fixes #186

`ci-radar.yml` compiled `radar/Dockerfile` and stopped there. The image built cleanly for weeks while being **completely unbootable**: the python 3.14 bump broke the native extensions `decode.py` imports, `app.py:15` does `import decode` at module top, so uvicorn never started — and nothing in CI ever started the container. Every one of those builds was green.

Compiling is not the same as running. This adds the missing half.

## Changes

- **`taskfile.yml` gains `radar-smoke`**, mirroring `smoke`. It runs the issue's own minimal check first — `python -c "import decode"` — so an import-time failure *names itself* instead of surfacing as an opaque "never served /healthz" timeout. Then it boots the container and polls `/healthz` on 8081.
- **`ci-radar.yml`'s build step gains `load: true` AND `tags: stormglass-radar:ci`.** Both are needed: without `load:` the buildx result never reaches the runner's daemon; without `tags:` the loaded image is unnamed and the smoke step has nothing to reference.
- **A smoke step runs it**, with Task from the repo's composite action at `lint-tools: false` so a radar-only job doesn't install the full linter set.

The image is still never pushed — that half of #137's reasoning is unchanged. The comment claiming the image is "deliberately never run" is updated, since this PR falsifies it.

## Negative proof — the failing-test analogue

CI plumbing has no behavioral test cycle, so the gate was proven by breaking an image on purpose:

```
$ cat radar-negative.Dockerfile
FROM stormglass-radar:local
RUN echo 'raise ImportError("negative proof: simulated broken native extension")' > /app/decode.py

$ IMAGE=radar-negative-proof task radar-smoke; echo "EXIT=$?"
    raise ImportError("negative proof: simulated broken native extension")
ImportError: negative proof: simulated broken native extension
EXIT=201            # rejected
```

And the real image:

```
$ IMAGE=stormglass-radar:local task radar-smoke; echo "EXIT=$?"
smoke testing radar sidecar stormglass-radar:local
ok: decode imports
ok: radar sidecar serves /healthz
EXIT=0
```

This is deliberately a **simulation of the import-time failure class**, not a rebuild on `python:3.14-slim`. This is an arm64 workstation, and `taskfile.yml:101-104` records that forcing `linux/amd64` locally dies in QEMU with a cc1 internal compiler error — while #186's actual failure was an amd64 *link* error. Simulating the class reproduces natively and honestly; emulating the original would have proven nothing.

## Live confirmation

Verified against a booted `deploy/docker-compose.yml --profile radar` stack during this close-out: sidecar `(healthy)`, `/healthz` 200, and `GET /api/radar/ATX` returning a real 3,437,276-byte payload. The sidecar works today — this PR makes sure CI would notice if it stopped.

Completes the three-part resolution: the 3.12 pin (#206), the renovate guard (#215), and this gate.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`, no breaking changes.