### PR TITLE
fix(prometheus): strip explicit timestamps on the push path so a real Pushgateway accepts pushes

### DIFF
--- a/internal/prometheus/server_test.go
+++ b/internal/prometheus/server_test.go
@@ -260,3 +260,41 @@ func TestMetricsServer_Flush(t *testing.T) {
 		t.Errorf("expected nil error from Flush, got %v", err)
 	}
 }
+
+// TestScrapePath_StillCarriesTimestamps is the companion regression to
+// #187's push-path fix. Stripping timestamps is correct for a Pushgateway
+// and WRONG for the scrape endpoint, where the explicit timestamp is how a
+// sporadic UDP broadcast keeps its real observation time. The fix is scoped
+// to the push collector; this asserts the scrape path was not caught in it.
+func TestScrapePath_StillCarriesTimestamps(t *testing.T) {
+	desc := prometheus.NewDesc("stormglass_scrape_ts_probe", "probe", []string{"serial"}, nil)
+	base := prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1, "ST-0001")
+	ts := time.Unix(1700000000, 0)
+
+	c := &latestMetricsCollector{metrics: make(map[string]prometheus.Metric)}
+	c.Update([]prometheus.Metric{prometheus.NewMetricWithTimestamp(ts, base)})
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(c); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "stormglass_scrape_ts_probe" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if m.TimestampMs == nil {
+				t.Fatal("scrape path lost its timestamp -- the push-path strip must not reach it")
+			}
+			if got := m.GetTimestampMs(); got != ts.UnixMilli() {
+				t.Errorf("TimestampMs = %d, want %d", got, ts.UnixMilli())
+			}
+		}
+		return
+	}
+	t.Fatal("probe metric not gathered")
+}

--- a/internal/prometheus/writer.go
+++ b/internal/prometheus/writer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
 
@@ -49,7 +50,7 @@ func NewPrometheusWriter(pushURL, jobName string) *PrometheusWriter {
 	more := make(chan bool, 1)
 
 	// Create collector that drains outbox
-	collector := &outboxCollector{outbox: outbox}
+	collector := newPushCollector(outbox)
 
 	// Create pusher
 	pusher := push.New(pushURL, jobName).
@@ -143,22 +144,77 @@ func (w *PrometheusWriter) pushWorker() {
 	}
 }
 
-// outboxCollector drains the outbox channel non-blockingly.
-type outboxCollector struct {
+// newPushCollector builds the collector the pusher gathers from.
+// newPushCollector builds the collector the pusher gathers from.
+//
+// The push path needs two things the scrape path does not (issue #187):
+//
+//  1. No timestamps. A real Pushgateway rejects any pushed sample carrying
+//     one -- 400 "pushed metrics must not have timestamps" -- so every push
+//     from this path failed. report.go wraps each metric with
+//     NewMetricWithTimestamp for the scrape path, which is correct there and
+//     fatal here.
+//
+//  2. Dedupe by series. Stripping alone would trade a 400 for a worse
+//     failure: client_golang hashes the timestamp into its uniqueness key
+//     (registry.go), so today two samples of one series hash apart. Remove
+//     the timestamps and they collide, and Gather() aborts the whole push
+//     locally -- before any HTTP request -- with "was collected before with
+//     the same name and label values". outboxCollector drains the entire
+//     channel per push, so two obs_st broadcasts between pushes make that
+//     the common case, not an edge.
+//
+// Last-queued wins, which is both correct and lossless in the only sense
+// that matters here: the Pushgateway retains just the last pushed state per
+// series, so intermediate samples in a single push could not be represented
+// even if sent -- and the scrape path's latestMetricsCollector already keeps
+// latest-per-series, so this gives the push path parity. The outbox is FIFO,
+// so last-queued is the newest broadcast.
+func newPushCollector(outbox <-chan prometheus.Metric) prometheus.Collector {
+	return &pushCollector{outbox: outbox}
+}
+
+type pushCollector struct {
 	outbox <-chan prometheus.Metric
 }
 
-func (c *outboxCollector) Describe(descs chan<- *prometheus.Desc) {
-	// Don't need to describe - metrics are already created
+func (c *pushCollector) Describe(chan<- *prometheus.Desc) {
+	// Unchecked collector: the metrics are already fully described.
 }
 
-func (c *outboxCollector) Collect(metrics chan<- prometheus.Metric) {
-	for {
+func (c *pushCollector) Collect(metrics chan<- prometheus.Metric) {
+	// Ordered so the emitted batch stays FIFO; the map holds the winner.
+	var order []string
+	latest := make(map[string]prometheus.Metric)
+
+	for drained := false; !drained; {
 		select {
 		case m := <-c.outbox:
-			metrics <- m
+			// metricKey (server.go) is desc + label NAMES AND VALUES. Keying
+			// on Desc().String() alone would carry names but not values, so
+			// two stations' serial-labelled series would collapse into one.
+			k := metricKey(m)
+			if _, seen := latest[k]; !seen {
+				order = append(order, k)
+			}
+			latest[k] = m
 		default:
-			return
+			drained = true
 		}
 	}
+
+	for _, k := range order {
+		metrics <- &timestampStrippingMetric{Metric: latest[k]}
+	}
+}
+
+// timestampStrippingMetric delegates Write, then clears TimestampMs.
+type timestampStrippingMetric struct{ prometheus.Metric }
+
+func (m *timestampStrippingMetric) Write(out *dto.Metric) error {
+	if err := m.Metric.Write(out); err != nil {
+		return err
+	}
+	out.TimestampMs = nil
+	return nil
 }

--- a/internal/prometheus/writer_test.go
+++ b/internal/prometheus/writer_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/jacaudi/stormglass/internal/tempestudp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // newTestPushGateway starts a local HTTP server that accepts any push
@@ -148,4 +151,91 @@ func TestPrometheusWriteDuringClose_NoPanic(t *testing.T) {
 	}
 
 	producers.Wait()
+}
+
+// gatherPushCollector runs the push path's collector through a real registry
+// the same way push.Pusher does (push/push.go calls Gatherers.Gather() BEFORE
+// any HTTP request), so these tests see exactly what the gateway would --
+// including a Gather() error, which is how #187's naive fix fails.
+func gatherPushCollector(t *testing.T, outbox chan prometheus.Metric) []*dto.MetricFamily {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(newPushCollector(outbox)); err != nil {
+		t.Fatalf("register push collector: %v", err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed -- this is the failure Pusher.push hits before any HTTP request: %v", err)
+	}
+	return mfs
+}
+
+func testMetric(value float64, ts time.Time, serial string) prometheus.Metric {
+	desc := prometheus.NewDesc("stormglass_test_metric", "test", []string{"serial"}, nil)
+	m := prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, serial)
+	return prometheus.NewMetricWithTimestamp(ts, m)
+}
+
+// TestPushPath_StripsTimestamps is #187 (a). A real Pushgateway rejects any
+// pushed sample carrying a timestamp with 400 "pushed metrics must not have
+// timestamps", so every push from this path failed.
+func TestPushPath_StripsTimestamps(t *testing.T) {
+	outbox := make(chan prometheus.Metric, 4)
+	outbox <- testMetric(1.0, time.Unix(1700000000, 0), "ST-0001")
+
+	mfs := gatherPushCollector(t, outbox)
+	if len(mfs) != 1 {
+		t.Fatalf("got %d metric families, want 1", len(mfs))
+	}
+	for _, m := range mfs[0].Metric {
+		if m.TimestampMs != nil {
+			t.Errorf("pushed sample carries TimestampMs=%d; a Pushgateway 400s on that", m.GetTimestampMs())
+		}
+	}
+}
+
+// TestPushPath_DrainTwoSamplesOfOneSeries is #187 (b), and it is the reason
+// the naive fix is not enough. client_golang's checkMetricConsistency hashes
+// the TIMESTAMP into its uniqueness key (registry.go:983-986), so today two
+// samples of one series hash apart and no error fires. Strip the timestamps
+// and they collide: Gather() aborts with "was collected before with the same
+// name and label values" and the push dies locally, before any HTTP request.
+// outboxCollector drains the whole channel per push, so two obs_st broadcasts
+// between pushes make this the common case, not an edge.
+//
+// Values differ (1.0 then 2.0) deliberately: once timestamps are stripped,
+// distinct values are the ONLY way to tell first-wins from last-wins.
+func TestPushPath_DrainTwoSamplesOfOneSeries(t *testing.T) {
+	outbox := make(chan prometheus.Metric, 4)
+	outbox <- testMetric(1.0, time.Unix(1700000000, 0), "ST-0001")
+	outbox <- testMetric(2.0, time.Unix(1700000060, 0), "ST-0001")
+
+	mfs := gatherPushCollector(t, outbox)
+	if len(mfs) != 1 {
+		t.Fatalf("got %d metric families, want 1", len(mfs))
+	}
+	if got := len(mfs[0].Metric); got != 1 {
+		t.Fatalf("got %d samples for one series, want exactly 1 (deduped)", got)
+	}
+	if got := mfs[0].Metric[0].GetGauge().GetValue(); got != 2.0 {
+		t.Errorf("surviving sample value = %v, want 2 (last-queued wins; the outbox is FIFO so last = newest)", got)
+	}
+}
+
+// TestPushPath_DedupeKeepsDistinctSeriesApart guards the identity choice.
+// m.Desc().String() carries label NAMES but not VALUES, so deduping on it
+// would collapse two stations' serial-labelled series into one -- real
+// cross-device data loss. metricKey includes the values.
+func TestPushPath_DedupeKeepsDistinctSeriesApart(t *testing.T) {
+	outbox := make(chan prometheus.Metric, 4)
+	outbox <- testMetric(1.0, time.Unix(1700000000, 0), "ST-0001")
+	outbox <- testMetric(2.0, time.Unix(1700000000, 0), "ST-0002")
+
+	mfs := gatherPushCollector(t, outbox)
+	if len(mfs) != 1 {
+		t.Fatalf("got %d metric families, want 1", len(mfs))
+	}
+	if got := len(mfs[0].Metric); got != 2 {
+		t.Errorf("got %d samples, want 2 -- two stations must not collapse into one series", got)
+	}
 }


### PR DESCRIPTION
Fixes #187

`report.go` wraps every metric with `NewMetricWithTimestamp`. That is correct for the scrape endpoint — a sporadic UDP broadcast needs its real observation time — and fatal for a Pushgateway, which rejects any pushed sample carrying one. So `ENABLE_PROMETHEUS_PUSHGATEWAY` failed **100% of its pushes**.

## Before / after, against a real `prom/pushgateway:v1.11.3`

**Before** — the gateway's own bookkeeping is the cleanest proof:

```
400 pushed metrics are invalid or inconsistent with existing metrics:
    pushed metrics must not have timestamps

push_failure_time_seconds{job="probe"}  1.7878610202006454e+09
push_time_seconds{job="probe"}          0            <- nothing ever landed
```

**After** — exactly inverted, with the series actually stored:

```
push_failure_time_seconds{job="probe"}  0
push_time_seconds{job="probe"}          1.7878676496359313e+09

stormglass_probe_metric{instance="",job="probe",serial="ST-0001"} 2
```

## Stripping alone would have shipped a worse bug

This is the part worth reading. `client_golang` hashes the **timestamp** into `checkMetricConsistency`'s uniqueness key, so today two samples of one series hash apart and no error fires. Remove the timestamps and they collide — and `Pusher.push` calls `Gather()` **before any HTTP request**, so the whole push dies locally:

```
Gather() failed: collected metric "stormglass_test_metric"
{label:{name:"serial" value:"ST-0001"} gauge:{value:2}}
was collected before with the same name and label values
```

That transcript is real: I applied the naive strip on its own and watched the new failure appear. The collector drains the entire outbox per push, so two `obs_st` broadcasts between pushes make this the common case, not an edge. Handling it is part of #187's fix, not a follow-up.

## The fix is both halves, in one collector

Strip the timestamp **and** dedupe by series identity, last-queued winning.

Identity is `metricKey` (`server.go`) — desc plus label names **and values**. Deduping on `Desc().String()` alone would carry names but not values and collapse two stations' `serial`-labelled series into one; `TestPushPath_DedupeKeepsDistinctSeriesApart` guards that.

Last-wins is not lossy in any sense that matters here: the Pushgateway retains only the last pushed state per series, so intermediate samples within one push could not be represented even if sent — and the scrape path's `latestMetricsCollector` already keeps latest-per-series, so this gives the push path parity. The outbox is FIFO, so last-queued is the newest broadcast.

`outboxCollector` is deleted rather than left sitting beside its replacement.

## Tests

| test | asserts |
|---|---|
| `TestPushPath_StripsTimestamps` | encoded `TimestampMs == nil` |
| `TestPushPath_DrainTwoSamplesOfOneSeries` | gather succeeds, exactly one sample, carrying the **second-queued value** (distinct values are the only way to tell first-wins from last-wins once timestamps are gone) |
| `TestPushPath_DedupeKeepsDistinctSeriesApart` | two stations stay two series |
| `TestScrapePath_StillCarriesTimestamps` | the scrape path was **not** caught in the strip |

## Accepted trade-off

Timestamp-tolerant sinks (VictoriaMetrics) now record push-time rather than broadcast-time on the push path. Skew is receive-to-push latency — seconds, since the push goroutine fires per batch.

Note this path is deprecated (`README.md:94-106`; `ENABLE_OTEL` is the supported path) but still ships in 1.0.x, and a shipped path that fails every call is a defect for as long as it ships. The CLAUDE.md docs drift is tracked separately as #217.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`, no breaking changes.