### PR TITLE
fix(web): keep the hero card dominant at one-column widths

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1598,6 +1598,21 @@
     grid-column: span 1;
   }
 
+  /* #182: at one-column widths the hero card rendered SHORTER than the WIND
+     card directly beneath it, so the most important reading on the page no
+     longer read as the most important. #194 fixed the 174px collapse this
+     issue was filed for -- .hero-content clears its 180px floor comfortably
+     -- but the CARD itself still lost to WIND (274 vs 302 at 504px), because
+     WIND's compass + readout + lull/gust row simply stack taller than the
+     hero's content.
+
+     A floor rather than larger type: scaling .hero-temp was measured and
+     REJECTED -- clamp() resolved BELOW the existing size at these widths and
+     made the card smaller still (274 -> 272 at 504). 310px clears the WIND
+     card at every one-column width with 8-14px of margin.
+     hero-dominates-when-narrow asserts it. */
+  .glass-card.hero-card { min-height: 310px; }
+
   /* Header at phone widths (in no filed issue; found by the probe). Shrink the
      competing parts -- do NOT truncate and do NOT hide anything. Every
      information-removing alternative was measured and rejected; see design

--- a/web/test/layout/measure.mjs
+++ b/web/test/layout/measure.mjs
@@ -561,6 +561,30 @@ CHECKS.push({
   pass: (m) => [504, 430, 390, 360, 320].every((w) => m.widths[w].hero.height >= 180),
 });
 
+// Sits BESIDE hero-grows-when-narrow, never replacing it. The two measure
+// different elements and #182 needs both: `hero` above is `.hero-content`,
+// the inner block, which #194 already fixed (it clears 180 comfortably).
+// This one measures the CARD, `.glass-card.hero-card`, against the WIND card
+// directly beneath it -- the issue's own falsifier was "the hero is SHORTER
+// than the WIND card". Relative and same-render, so it cannot be broken by
+// the platform font-metric differences that have bitten absolute thresholds
+// in this suite before.
+const heroCardHeight = (m, w) =>
+  m.widths[w].cards.find((c) => c.className.includes('hero-card'))?.height ?? NaN;
+const windCardHeight = (m, w) =>
+  m.widths[w].cards.find((c) => c.className.includes('wind-card'))?.height ?? NaN;
+
+CHECKS.push({
+  id: 'hero-dominates-when-narrow',
+  section: '§6.6 / #182',
+  describe: (m) =>
+    [504, 430, 390, 360, 320]
+      .map((w) => `${w}:${heroCardHeight(m, w).toFixed(0)}/${windCardHeight(m, w).toFixed(0)}`)
+      .join(' '),
+  pass: (m) =>
+    [504, 430, 390, 360, 320].every((w) => heroCardHeight(m, w) >= windCardHeight(m, w)),
+});
+
 // --- Task 7 / design §6.6a --------------------------------------------------
 // RELATIVE, because the height depends on the station name. m.headerRevert is
 // the same fixture measured with §6.6a's declarations reverted to their


### PR DESCRIPTION
Fixes #182

At one-column widths the hero card rendered **shorter than the WIND card directly beneath it**, so the most important reading on the page stopped reading as the most important.

## Both clauses of the issue

**The card-span clause closes as fixed-by-#194, on evidence.** The collapse to `span 1` at single-column widths is the deliberate responsive ladder (`App.css:1566-1569`: *"Every level clamps the spans to its own column count, which is what stops an implicit content-sized track from ever being minted"*), and two shipped checks confirm the outcome: `tracks-equal` (worst spread 0.016px at 2560) and `ladder-fires-where-intended` (`1001:3 1000:2 641:2 640:1`).

**The hero clause needed a fix.** #194 shipped `hero-grows-when-narrow` for the reported 174px collapse, and it passes — but it measures `.hero-content`, the inner block, which clears its 180px floor comfortably. The *card* still lost to WIND.

## Why the existing check didn't catch it

| | measures | at 504px |
|---|---|---|
| `hero-grows-when-narrow` (#194) | `.hero-content` | 218 ≥ 180 ✓ |
| `hero-dominates-when-narrow` (new) | `.glass-card.hero-card` vs `.wind-card` | 274 < 302 ✗ |

Different elements. Both true. The new check sits **beside** the old one, never replacing it.

## Before / after

```
before   504:274/302  430:270/299  390:268/298  360:267/297  320:267/297   FAIL
after    504:310/302  430:310/299  390:310/298  360:310/297  320:310/297   PASS
```

Full probe suite green at all 19 widths: **32 checks, 0 failures.**

## Why a floor and not bigger type

Both directions were rendered into the live built app and measured before choosing. Scaling `.hero-temp` through `clamp()` was **counterproductive** — it resolved below the existing size at these widths and made the card *smaller* (274 → 272 at 504). A combined variant with a 300px floor came 2px short at 504. The 310px floor clears WIND at every one-column width with 8–14px of margin.

## Test design

The new check is **relative and same-render** — hero card height vs wind card height within one probe pass — so it cannot be broken by the platform font-metric differences that have previously broken absolute thresholds in this suite.

Two commits (test-first, then fix), so this merges as a merge commit per the repo's policy.

Part of the v1 close-out (milestone v1). Patch-only: `fix:`/`test:`, no breaking changes.