### PR TITLE
fix: own /data in the image so the documented quickstart starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,18 @@ COPY --from=ui /app/web/dist ./web/dist
 RUN CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /stormglass ./cmd/stormglass
 
+# An empty /data to carry into the final stage. Docker seeds a freshly created
+# named volume from the image's directory -- ownership included -- so shipping
+# /data owned by 65532 is what makes `docker run -v vol:/data` work for the
+# unprivileged user below. Without it the volume mounts root-owned, SQLite
+# cannot open its database, and the process exits at startup (#226).
+RUN mkdir -p /seed/data
+
 # --- Final stage: non-root static image -------------------------------------
 FROM cgr.dev/chainguard/static:latest@sha256:f68e3a8244c7d0f4cd56635aaff8e6a533cf6cc3850d8fb339567a5782d6a0b0
 
 COPY --from=builder /stormglass /stormglass
+COPY --from=builder --chown=65532:65532 /seed/data /data
 
 USER 65532:65532
 

--- a/README.md
+++ b/README.md
@@ -262,8 +262,11 @@ Two details in that file are load-bearing rather than incidental:
   reason above. Everything else sits on the default compose network, and
   Stormglass reaches those services via published host ports.
 - A `stormglass-data-init` container chowns the volume before Stormglass starts.
-  The image runs as an unprivileged user, and without that step a fresh
-  `docker compose up` crash-loops on an unwritable `/data`.
+  New deployments no longer need it — the image ships `/data` owned by its own
+  unprivileged user, and Docker seeds that ownership into a newly created
+  volume. It is kept for **upgrades**: Docker only seeds an *empty* volume, so a
+  volume that already holds a database keeps its original `root` ownership and
+  Stormglass exits with `attempt to write a readonly database`.
 
 The radar sidecar is behind a compose profile, so it is off unless you ask:
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -75,10 +75,14 @@ services:
     restart: unless-stopped
 
   # One-shot init: the app image runs as non-root USER 65532:65532 (see
-  # Dockerfile), but a fresh named volume mounts /data owned root:root 0755 —
-  # nothing in the base image seeds ownership for it. SQLite is the default
-  # store and the app exits on startup if it can't open /data/stormglass.db, so
-  # without this chown a fresh `docker compose up` crash-loops `stormglass`.
+  # Dockerfile). The image now ships /data owned by 65532 (#226), and Docker
+  # seeds a NEWLY CREATED volume from the image directory — ownership included —
+  # so a fresh `docker compose up` no longer needs this chown.
+  #
+  # It is kept for UPGRADES. Docker only seeds an EMPTY volume; a volume that
+  # already holds a database keeps its original root:root ownership, and the app
+  # then fails with "attempt to write a readonly database (8)" and exits.
+  # Removing this would break every deployment created before #226.
   # litestream runs as root and can read the resulting 65532-owned DB fine,
   # so only `stormglass` needs to wait on this.
   stormglass-data-init:

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -69,17 +69,19 @@ tasks:
       - |
         set -eu
         echo "smoke testing ${IMAGE}"
-        # SQLITE_PATH is not optional here. SQLite is the DEFAULT store and the
-        # process EXITS ON STARTUP if it cannot open the database (CLAUDE.md,
-        # "fail-loud"). The image's /data is not a writable mount under a bare
-        # `docker run`, so without this the container crash-loops and the smoke
-        # test fails for a reason unrelated to the build. The container runs as
-        # USER 65532, so /tmp is the writable choice.
+        # Boot exactly the way README's quickstart tells users to: a named
+        # volume at /data, SQLite at its default path, no SQLITE_PATH override.
+        # SQLite is the DEFAULT store and the process EXITS ON STARTUP if it
+        # cannot open the database, so this asserts the image ships a /data its
+        # own unprivileged user can write -- the failure mode in #226, where a
+        # fresh named volume mounts root-owned against USER 65532.
+        SMOKE_VOL="smoke-data-$$"
+        docker volume create "${SMOKE_VOL}" >/dev/null
         docker run -d --name smoke \
           -p 8080:8080 \
-          -e SQLITE_PATH=/tmp/smoke.db \
+          -v "${SMOKE_VOL}":/data \
           "${IMAGE}"
-        trap 'docker logs smoke || true; docker rm -f smoke >/dev/null 2>&1 || true' EXIT
+        trap 'docker logs smoke || true; docker rm -f smoke >/dev/null 2>&1 || true; docker volume rm "${SMOKE_VOL}" >/dev/null 2>&1 || true' EXIT
         for i in $(seq 1 30); do
           curl -sf http://localhost:8080/healthz >/dev/null && break
           [ "$i" = "30" ] && { echo "::error::container never served /healthz on :8080"; exit 1; }


### PR DESCRIPTION
Closes #226.

## The bug

The README's headline quickstart exits 1 on a clean machine:

```
$ docker run -d -v stormglass-data:/data ghcr.io/jacaudi/stormglass
$ docker logs stormglass
2026/08/28 05:28:01 failed to open sqlite: ping sqlite: unable to open database file (14)
$ docker inspect stormglass --format '{{.State.Status}} {{.State.ExitCode}}'
exited 1
```

Docker creates a fresh named volume's mountpoint **root-owned** unless the image supplies the directory. `Dockerfile:44` is `USER 65532:65532`, the base is `cgr.dev/chainguard/static`, and nothing created `/data`. SQLite is the default store and the process exits at startup when it cannot open the database.

`deploy/docker-compose.yml` already worked around this with a `stormglass-data-init` chown container, so Compose users were protected and README users were not.

## The fix

The image carries an empty `/data` owned by 65532. Docker seeds a newly created volume from the image directory — ownership included.

## Upgrades are NOT repaired, and that is why the init container stays

Measured both cases against the built image:

| Volume state | Docker re-seeds ownership? | Result |
|---|---|---|
| New / empty | Yes | `running`, ExitCode 0 |
| Already holds a database | **No** | `exited 1` — `attempt to write a readonly database (8)` |

Docker only seeds an **empty** volume. Every deployment created before this keeps its root-owned `/data` and still needs `stormglass-data-init`. That container is kept; its comment and the matching `README.md` paragraph both said a fresh `docker compose up` crash-loops without it, which this change makes false, so both now state the real reason.

## The test came first

`task smoke` set `SQLITE_PATH=/tmp/smoke.db` specifically to route around this — its own comment said so — meaning CI had **never** exercised the documented path. It now boots the image the way the README tells users to: a named volume at `/data`, default SQLite path, no override.

**RED**, against the unfixed image built from this branch:

```
::error::container never served /healthz on :8080
2026/08/28 08:10:46 failed to open sqlite: ping sqlite: unable to open database file (14)
task: Failed to run task "smoke": exit status 1
```

**GREEN**, after the Dockerfile change:

```
smoke testing stormglass:226green
ok: container serves /healthz
ok: embedded UI served
2026/08/28 08:12:15 INFO http server listening addr=:8080
```

#226's falsifying observable, verbatim:

```
$ docker run -d --name sgtest-c -v sgtest:/data <image>
$ docker inspect sgtest-c --format 'Status={{.State.Status}} ExitCode={{.State.ExitCode}}'
Status=running ExitCode=0
$ docker run --rm -v sgtest:/data busybox ls -ldn /data
drwxr-xr-x 2 65532 65532 4096 /data
```

## Verification

- `task ci` → `EXIT=0`
- Patch-only check over subject, body and PR title → no `feat:`, no `!`, no `BREAKING CHANGE:`

## Why this is in v1

Filed under the close-out's standing rule while gating #216's design. It blocks #216's acceptance criterion — *"Quick start leads with `docker run -d` and produces a working dashboard from a clean machine"* — which is why it merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
