### PR TITLE
fix: render an awaiting-data state when the observation store is empty

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1272,6 +1272,41 @@
 }
 
 /* --- Error screen ------------------------------------------------ */
+.empty-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.empty-screen h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.empty-screen p {
+  margin: 0;
+  max-width: 44ch;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.empty-screen-hint {
+  font-size: 0.9rem;
+}
+
+.empty-screen code {
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+
 .error-screen {
   display: flex;
   flex-direction: column;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { useWeatherData } from './hooks/useWeatherData';
 import type { WeatherData } from './hooks/useWeatherData';
 import type { CurrentObservation, ForecastDay, RecordsSummary, StationAlmanac, StationMeta } from './types/weather';
 import { PrecipitationType, PressureTrend } from './types/weather';
@@ -183,6 +184,7 @@ const mockWeatherData: WeatherData = {
   error: null,
   lastUpdated: new Date(),
   isStale: false,
+  awaitingData: false,
   capabilities: { forecast: true, radar: false, almanac: false },
   refresh: vi.fn(),
 };
@@ -190,6 +192,63 @@ const mockWeatherData: WeatherData = {
 vi.mock('./hooks/useWeatherData', () => ({
   useWeatherData: vi.fn(() => mockWeatherData),
 }));
+
+// #218: a fresh deployment has an empty store, so the core observation
+// endpoint 404s and there is no `current`. That is a healthy appliance waiting
+// for its first broadcast -- it must not render the Connection Error screen,
+// and it must not render nothing at all.
+describe('App on a fresh deployment with no observations yet', () => {
+  afterEach(() => {
+    vi.mocked(useWeatherData).mockReturnValue(mockWeatherData);
+  });
+
+  it('renders an awaiting-data state instead of the connection error screen', () => {
+    vi.mocked(useWeatherData).mockReturnValue({
+      ...mockWeatherData,
+      current: null,
+      summary: null,
+      awaitingData: true,
+      error: null,
+      lastUpdated: null,
+    });
+
+    render(<App />);
+
+    expect(screen.queryByText('Connection Error')).not.toBeInTheDocument();
+    expect(screen.getByText(/Waiting for the first observation/i)).toBeInTheDocument();
+  });
+
+  it('names the likely causes so a misconfigured deployment is diagnosable', () => {
+    vi.mocked(useWeatherData).mockReturnValue({
+      ...mockWeatherData,
+      current: null,
+      summary: null,
+      awaitingData: true,
+      error: null,
+      lastUpdated: null,
+    });
+
+    render(<App />);
+
+    expect(screen.getByText(/--net=host/)).toBeInTheDocument();
+    expect(screen.getByText(/50222/)).toBeInTheDocument();
+  });
+
+  it('still shows the connection error screen for a genuine failure', () => {
+    vi.mocked(useWeatherData).mockReturnValue({
+      ...mockWeatherData,
+      current: null,
+      summary: null,
+      awaitingData: false,
+      error: '/api/observations/current responded with 503',
+      lastUpdated: null,
+    });
+
+    render(<App />);
+
+    expect(screen.getByText('Connection Error')).toBeInTheDocument();
+  });
+});
 
 describe('App dashboard layout', () => {
   it('renders the Records card before the 7-Day Forecast', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,7 +23,7 @@ import './App.css';
 
 function App() {
   const { prefs, setPrefs } = useUnits();
-  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, refresh, summary, capabilities } =
+  const { station, current, forecast, status, almanac, isLoading, error, lastUpdated, isStale, awaitingData, refresh, summary, capabilities } =
     useWeatherData(undefined, prefs.recordsWindowDays);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -40,6 +40,32 @@ function App() {
       <div className="loading-screen">
         <div className="loading-spinner" />
         <p>Connecting to station...</p>
+      </div>
+    );
+  }
+
+  // An empty store is a healthy appliance that has not heard from the station
+  // yet, not a failure — every fresh deployment passes through this state for
+  // up to a minute, and stays in it indefinitely if the broadcasts never
+  // arrive. Rendering the Connection Error screen here told a correctly
+  // configured operator their deployment was broken, and gave a misconfigured
+  // one nothing to act on (#218).
+  if (awaitingData && !current) {
+    return (
+      <div className="empty-screen">
+        <div className="loading-spinner" />
+        <h2>Waiting for the first observation</h2>
+        <p>
+          Stormglass is running and its store is empty. A Tempest station
+          broadcasts about once a minute, so this usually clears on its own.
+        </p>
+        <p className="empty-screen-hint">
+          If it does not, the broadcasts are not reaching this container. Check
+          that it runs with <code>--net=host</code> and that UDP port{' '}
+          <code>50222</code> is open on the path between the station and this
+          host. Setting <code>LOG_UDP=true</code> logs every packet received.
+        </p>
+        <button className="glass-btn" onClick={refresh}>Check now</button>
       </div>
     );
   }

--- a/web/src/api/stormglassApi.test.ts
+++ b/web/src/api/stormglassApi.test.ts
@@ -78,6 +78,23 @@ describe('fetchCurrentObservation', () => {
 });
 
 describe('fetchStationStatus', () => {
+  // #218: an empty store answers /api/observations/current with 404, which is
+  // a normal startup state, not a fault. The transport must carry the status
+  // through so callers can tell "no data yet" from "the server is broken" --
+  // collapsing both into a bare Error is what rendered the Connection Error
+  // screen on every fresh deployment.
+  it('carries the HTTP status on a failed request so callers can classify it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    await expect(fetchCurrentObservation()).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('distinguishes an empty store (404) from a server fault (503)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+    await expect(fetchCurrentObservation()).rejects.toMatchObject({ status: 503 });
+  });
+
   it('rejects instead of returning an offline default when the underlying fetch fails', async () => {
     // A transient server error must surface as a rejection so useWeatherData's
     // allSettled retains the prior good status, rather than fetchStationStatus

--- a/web/src/api/stormglassApi.ts
+++ b/web/src/api/stormglassApi.ts
@@ -48,10 +48,25 @@ const STATION_ONLINE_THRESHOLD_SECONDS = 5 * 60;
 // The "fetch, reject non-OK, parse JSON" sequence is identical for every
 // endpoint below -- shared knowledge (how a Contract C response is read),
 // not just shared shape, so it is written once here.
+// Carries the HTTP status alongside the message so callers can classify a
+// failure rather than only report it. /api/observations/current answers 404
+// when the store is simply empty -- a normal state on a fresh deployment, not
+// a fault -- and a bare Error made that indistinguishable from a real outage
+// (#218).
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(url: string, status: number) {
+    super(`${url} responded with ${status}`);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 async function getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(url, { signal });
   if (!res.ok) {
-    throw new Error(`${url} responded with ${res.status}`);
+    throw new ApiError(url, res.status);
   }
   return (await res.json()) as T;
 }

--- a/web/src/hooks/useWeatherData.test.ts
+++ b/web/src/hooks/useWeatherData.test.ts
@@ -13,7 +13,8 @@ import type {
   Capabilities,
 } from '../types/weather';
 
-vi.mock('../api/stormglassApi', () => ({
+vi.mock('../api/stormglassApi', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/stormglassApi')>()),
   fetchCurrentObservation: vi.fn(),
   fetchStationMeta: vi.fn(),
   fetchForecast: vi.fn(),
@@ -108,6 +109,43 @@ beforeEach(() => {
 });
 
 describe('useWeatherData', () => {
+  // #218: a fresh deployment's store is empty, and /api/observations/current
+  // answers 404. That is "no data yet", not a fault -- it must not set `error`,
+  // because App blanks the dashboard for the Connection Error screen whenever
+  // `error && !current`.
+  it('reports awaitingData rather than error when the store is empty (404)', async () => {
+    mockedApi.fetchCurrentObservation.mockRejectedValue(
+      new api.ApiError('/api/observations/current', 404)
+    );
+    mockedApi.fetchStationMeta.mockResolvedValue(baseStation);
+    mockedApi.fetchForecast.mockResolvedValue([]);
+    mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
+    mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
+
+    const { result } = renderHook(() => useWeatherData());
+
+    await waitFor(() => expect(result.current.awaitingData).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.current).toBeNull();
+  });
+
+  it('still reports error for a genuine server fault (503)', async () => {
+    mockedApi.fetchCurrentObservation.mockRejectedValue(
+      new api.ApiError('/api/observations/current', 503)
+    );
+    mockedApi.fetchStationMeta.mockResolvedValue(baseStation);
+    mockedApi.fetchForecast.mockResolvedValue([]);
+    mockedApi.fetchStationStatus.mockResolvedValue(baseStatus);
+    mockedApi.fetchStationAlmanac.mockResolvedValue(baseAlmanac);
+    mockedApi.fetchRecordsSummary.mockResolvedValue(baseSummary);
+
+    const { result } = renderHook(() => useWeatherData());
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.awaitingData).toBe(false);
+  });
+
   it('retains prior data and flips isStale when a refetch of the core observation fails', async () => {
     mockedApi.fetchCurrentObservation
       .mockResolvedValueOnce(baseObs)

--- a/web/src/hooks/useWeatherData.ts
+++ b/web/src/hooks/useWeatherData.ts
@@ -18,7 +18,16 @@ import {
   fetchStationAlmanac,
   fetchRecordsSummary,
   fetchCapabilities,
+  ApiError,
 } from '../api/stormglassApi';
+
+// An empty observation store answers /api/observations/current with 404. That
+// is the normal state of a fresh deployment -- the station has not broadcast
+// yet -- and must be told apart from a fault, because App blanks the dashboard
+// for the Connection Error screen whenever `error && !current` (#218).
+function isEmptyStore(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
 
 // There is no WebSocket backend (Contract C is plain JSON, see design §11),
 // so live-ness comes from polling the core observation instead. 30s keeps
@@ -55,6 +64,10 @@ export interface WeatherData {
   // successful fetch (§14 P1.6). False immediately after a successful
   // refresh.
   isStale: boolean;
+  // True when the core observation endpoint reports an empty store: the
+  // deployment is healthy and simply has no observation yet. Distinct from
+  // `error`, which means the fetch genuinely failed.
+  awaitingData: boolean;
   // Which optional cards the server has enabled. `null` means unknown --
   // either not yet fetched or the fetch failed -- and is treated exactly like
   // all-false, so a card is never mounted on a guess (issue #145).
@@ -94,6 +107,7 @@ export function useWeatherData(
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isStale, setIsStale] = useState(false);
+  const [awaitingData, setAwaitingData] = useState(false);
   const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
   const [capsSettled, setCapsSettled] = useState(false);
   // Bumped by refresh() to re-run the records-summary effect below. The
@@ -215,9 +229,14 @@ export function useWeatherData(
       setCurrent(obsResult.value);
       setIsStale(false);
       setError(null);
+      setAwaitingData(false);
       setLastUpdated(new Date());
+    } else if (isEmptyStore(obsResult.reason)) {
+      setAwaitingData(true);
+      setError(null);
     } else {
       setIsStale(true);
+      setAwaitingData(false);
       setError(describeError(obsResult));
     }
   }, [stationId, forecastEnabled, almanacEnabled]);
@@ -249,10 +268,17 @@ export function useWeatherData(
       setStatus(stationStatusFrom(obs));
       setIsStale(false);
       setError(null);
+      setAwaitingData(false);
       setLastUpdated(new Date());
     } catch (err) {
       if (signal.aborted) return; // superseded/unmounted, not a real failure
+      if (isEmptyStore(err)) {
+        setAwaitingData(true);
+        setError(null);
+        return;
+      }
       setIsStale(true);
+      setAwaitingData(false);
       setError(err instanceof Error ? err.message : 'Failed to load weather data');
     }
   }, [stationId]);
@@ -341,6 +367,7 @@ export function useWeatherData(
     error,
     lastUpdated,
     isStale,
+    awaitingData,
     capabilities,
     refresh,
   };


### PR DESCRIPTION
Closes #218. **Stacked on #228** — the base is `worktree-readme-quickstart`, so this diff is only the #218 change. It retargets to `main` when #228 merges.

## Root cause

Not the error boundary — the **transport layer**.

The server already distinguishes the two cases. An empty store answers `/api/observations/current` with `404 {"error":"no observation available"}`; a fault answers 5xx. But `getJSON` collapsed every non-2xx into a bare `Error` carrying only a message string:

```ts
if (!res.ok) throw new Error(`${url} responded with ${res.status}`);
```

By the time that reached `App`, "no data yet" and "the server is broken" were indistinguishable, so `error && !current` rendered the connection-error screen on every fresh deployment.

| Layer | Before |
|---|---|
| `observations.go:266` | `404 "no observation available"` — a specific signal |
| `stormglassApi.ts:53` | **signal destroyed** — all non-2xx become one `Error` |
| `useWeatherData.ts:221` | `setError(...)` |
| `App.tsx:50` | `error && !current` → "Connection Error" |

## The fix

`getJSON` throws `ApiError`, which carries `status`. `useWeatherData` classifies a 404 on the core observation as `awaitingData` rather than `error` — on **both** the initial load and the poll path. `App` renders an awaiting-data screen for that state.

The screen says the store is empty and a station reports about once a minute, then names what to check if it doesn't clear: `--net=host`, UDP `50222`, and `LOG_UDP=true` to see whether packets arrive at all. #218 asked for exactly that — *"ideally naming the likely causes"*.

## The wire contract is deliberately unchanged

#218 left open whether the endpoint should move to 204 or 200-with-null. It stays 404, verified safe:

- `/api/observations/current` is registered **unconditionally** (`observations.go:240`), not behind a feature gate, so it never 404s for "route not registered" the way disabled features do.
- The empty-store 404 at `:266` is the **only** `StatusNotFound` on its path.

So the status is already unambiguous, and changing it would break a shipped wire surface for no gain — which also keeps this patch-safe.

## TDD

Six tests, each written and watched failing first.

**Transport** — RED was `Error { message }` with no `status`:
```
- { "status": 503 }
+ Error { "message": "/api/observations/current responded with 503" }
```

**Hook** — RED was `awaitingData: undefined`. Covers both 404 → `awaitingData` with `error` null, and 503 → `error` with `awaitingData` false.

**App** — RED failed on the missing awaiting-data text. The third test, *"still shows the connection error screen for a genuine failure"*, **passed from the start** — deliberately, to prove the real-error path wasn't being traded away for the new one.

## Verification

- Full web suite: **192 passed, 0 failed**
- `task ci` → `EXIT=0`
- Patch-only check clean on subject, body and PR title
- Both CSS custom properties used by the new screen (`--bg-secondary`, `--text-secondary`) confirmed defined in `index.css` — an earlier draft referenced a `--glass-bg` that does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
