### PR TITLE
fix: make TZ the station's timezone and deprecate STATION_TIMEZONE

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,7 +130,7 @@ Prometheus push writer (`internal/prometheus/writer.go`), not the general path.
 ## Configuration
 
 **`docs/configuration.md` is authoritative** for the complete environment
-variable surface (37 variables), the operational-mode matrix, and the
+variable surface (38 variables), the operational-mode matrix, and the
 fatal-versus-degraded startup rules. It is derived from the code's real read
 sites. Do not restate it here — two hand-maintained copies of one surface is
 what produced issue #217.
@@ -147,10 +147,12 @@ Points an agent gets wrong most often:
   **exits at startup** if that database cannot be opened. Postgres is opt-in and
   can fan out alongside SQLite.
 - **A malformed value is fatal; a missing one is not.** Unparseable or
-  out-of-range values abort startup naming *every* offender at once. An
-  unmet optional-card precondition logs an `ERROR`, leaves the route
-  unregistered, and lets ingestion continue — a card flag must never be able to
-  stop the data path.
+  out-of-range values — including an unknown `STATION_TIMEZONE` — abort startup
+  naming *every* offender at once. (The one exception is `TZ`: a value the Go
+  runtime cannot resolve logs a `WARN` and degrades to UTC rather than
+  aborting.) An unmet optional-card precondition logs an `ERROR`, leaves the
+  route unregistered, and lets ingestion continue — a card flag must never be
+  able to stop the data path.
 - **Booleans go through `strconv.ParseBool`**, so `1`/`t`/`T`/`TRUE` all work,
   and an unparseable value is a fatal error rather than a silent false.
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Two things about that command are not optional:
 
 That is the whole required configuration. Everything else is optional — the
 three variables most people set next are `STATION_LATITUDE` /
-`STATION_LONGITUDE` and `STATION_TIMEZONE`, which turn on the almanac:
+`STATION_LONGITUDE` and `TZ`, which turn on the almanac:
 
 ```bash
 docker run -d --name stormglass --net=host -v stormglass-data:/data \
   -e STATION_LATITUDE=39.7392 -e STATION_LONGITUDE=-104.9903 \
-  -e STATION_TIMEZONE=America/Denver -e ENABLE_ALMANAC=true \
+  -e TZ=America/Denver -e ENABLE_ALMANAC=true \
   ghcr.io/jacaudi/stormglass
 ```
 

--- a/cmd/stormglass/main.go
+++ b/cmd/stormglass/main.go
@@ -527,7 +527,7 @@ func unknownRadarSiteReason(site string, lat, lon *float64) string {
 // cannot disagree. A precondition that is MET but degraded by an unintended
 // default produces a WARN instead: the route is registered and the capability
 // is true, because the card works -- it is just not what the operator meant.
-// STATION_TIMEZONE is the only such case today (issue #165).
+// An unconfigured timezone is the only such case today (issue #165).
 //
 // A MALFORMED value is a different matter and is already fatal, in
 // config.LoadStation: absent means "the operator did not configure this
@@ -570,11 +570,11 @@ func decideUI(flags uiFlags, station config.StationConfig, hasStore bool) uiDeci
 			// will render is noise when nothing renders at all.
 			if !station.TimezoneConfigured {
 				d.Warnings = append(d.Warnings,
-					"ENABLE_ALMANAC is true and coordinates are set, but STATION_TIMEZONE "+
-						"is not: sunrise and sunset will render as UTC clock times, the "+
-						"Today/This Week/This Month/This Year windows will use UTC calendar "+
-						"boundaries, and the record date labels (\"Today\", \"Jan 2\") will be "+
-						"UTC-dated. Set STATION_TIMEZONE to the station's IANA zone "+
+					"ENABLE_ALMANAC is true and coordinates are set, but no timezone "+
+						"is configured: sunrise and sunset will render as UTC clock times, "+
+						"the Today/This Week/This Month/This Year windows will use UTC "+
+						"calendar boundaries, and the record date labels (\"Today\", "+
+						"\"Jan 2\") will be UTC-dated. Set TZ to the station's IANA zone "+
 						"(e.g. America/Denver).")
 			}
 		}
@@ -711,6 +711,20 @@ func main() {
 	// Runs in both modes. A malformed STATION_* value is an operator error
 	// wherever it appears; absent values are never an error.
 	stationCfg, err := config.LoadStation(time.Local)
+	// Logged BEFORE the fatal check, so a malformed STATION_LATITUDE cannot
+	// hide a timezone diagnostic (go-standards §15.3). Ranging a nil slice is
+	// legal, and stationCfg is fully formed even on the error path.
+	//
+	// Here rather than in startAPIServer because that returns nil unless
+	// mode == ModeUDP (main.go:644-646), and these notices apply to both
+	// modes. That places them before configureOTel installs the slog bridge,
+	// so they reach the pre-bridge stderr default rather than the OTel log
+	// pipeline -- the same accepted limitation
+	// internal/prometheus/deprecation.go:32-39 documents for its own
+	// transitional deprecation notice.
+	for _, n := range stationCfg.TimezoneNotices {
+		slog.Default().Warn("timezone configuration", "notice", n)
+	}
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/stormglass/main.go
+++ b/cmd/stormglass/main.go
@@ -710,7 +710,7 @@ func main() {
 	//
 	// Runs in both modes. A malformed STATION_* value is an operator error
 	// wherever it appears; absent values are never an error.
-	stationCfg, err := config.LoadStation()
+	stationCfg, err := config.LoadStation(time.Local)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/stormglass/main_test.go
+++ b/cmd/stormglass/main_test.go
@@ -363,14 +363,23 @@ func TestDecideUI(t *testing.T) {
 			// The card MOUNTS and works -- it is just on the wrong clock. So
 			// this is a warning, not a reason: capabilities.almanac stays true
 			// and the route stays registered.
-			name:         "almanac_without_a_timezone_warns_but_mounts",
-			flags:        uiFlags{Almanac: true},
-			station:      locatedNoTZ,
-			hasStore:     true,
-			wantAlmanac:  true,
-			wantWarnings: []string{"ENABLE_ALMANAC", "STATION_TIMEZONE", "UTC"},
+			name:        "almanac_without_a_timezone_warns_but_mounts",
+			flags:       uiFlags{Almanac: true},
+			station:     locatedNoTZ,
+			hasStore:    true,
+			wantAlmanac: true,
+			// "Set TZ to" rather than a bare "TZ": the substring "TZ" is
+			// satisfied by the word STATION_TIMEZONE, so a bare "TZ" would
+			// pass against the OLD warning text and assert nothing.
+			wantWarnings: []string{"ENABLE_ALMANAC", "Set TZ to", "UTC"},
 		},
 		{
+			// The "not when only TZ is set" half of the contract. decideUI
+			// cannot see TZ; it sees only TimezoneConfigured, which a bare TZ
+			// now sets. The other half of the link --
+			// that TZ alone sets the flag -- is
+			// TestLoadStation_TimezoneResolution/tz_only_supplies_the_zone in
+			// internal/config.
 			name:        "almanac_with_a_timezone_is_silent",
 			flags:       uiFlags{Almanac: true},
 			station:     located,
@@ -476,7 +485,7 @@ func TestStartAPIServer_EmitsDecisionDiagnostics(t *testing.T) {
 	// These four are the only names startAPIServer reads unconditionally; it
 	// also reads RADAR_SIDECAR_URL, but only when the radar card mounts.
 	// Station identity is NOT read from the environment here -- it arrives as
-	// the `station` parameter, filled by config.LoadStation() in main.
+	// the `station` parameter, filled by config.LoadStation(time.Local) in main.
 	t.Setenv("HTTP_ADDR", "127.0.0.1:0")
 	t.Setenv("ENABLE_FORECAST", "true")
 	t.Setenv("ENABLE_ALMANAC", "true")
@@ -540,8 +549,10 @@ func TestStartAPIServer_EmitsDecisionDiagnostics(t *testing.T) {
 	if warnIdx < 0 {
 		t.Fatalf("no WARN record for a degraded card -- the warning loop did not run.\ngot:\n%s", out)
 	}
-	if !strings.Contains(out, `warning="ENABLE_ALMANAC`) || !strings.Contains(out, "STATION_TIMEZONE") {
-		t.Errorf("the WARN record must carry a warning attribute naming STATION_TIMEZONE.\ngot:\n%s", out)
+	// As above: "Set TZ to", not "TZ" -- the latter is satisfied by
+	// STATION_TIMEZONE and would pass against the old text.
+	if !strings.Contains(out, `warning="ENABLE_ALMANAC`) || !strings.Contains(out, "Set TZ to") {
+		t.Errorf("the WARN record must carry a warning attribute telling the operator to set TZ.\ngot:\n%s", out)
 	}
 
 	// Ordering is deliberate: a startup with both prints every not-mounted

--- a/cmd/stormglass/main_test.go
+++ b/cmd/stormglass/main_test.go
@@ -435,6 +435,41 @@ func TestDecideUI(t *testing.T) {
 	}
 }
 
+// TestDecideUI_TimezoneWarningExactText pins the issue #165 warning verbatim,
+// the way internal/config's TestTimezoneMessages_ExactText pins the five
+// notice constants. Everywhere else this string is asserted by the substrings
+// "ENABLE_ALMANAC", "Set TZ to" and "UTC", all three of which survive dropping
+// half the sentence or losing the "Today"/"Jan 2" examples -- so without this
+// the one warning that tells an operator their almanac is on the wrong clock
+// is free to drift.
+//
+// This string carries no em dash, unlike the config constants; if one is ever
+// added, write it here as — so a file-level normalisation cannot silently
+// make the test agree with a corrupted constant.
+//
+// If the warning legitimately changes, update this test AND re-check that
+// every clause is true in every state that reaches it. Do not update it to
+// match whatever the code now says.
+func TestDecideUI_TimezoneWarningExactText(t *testing.T) {
+	lat, lon := 39.74, -104.98
+	locatedNoTZ := config.StationConfig{Latitude: &lat, Longitude: &lon}
+
+	got := decideUI(uiFlags{Almanac: true}, locatedNoTZ, true)
+
+	want := "ENABLE_ALMANAC is true and coordinates are set, but no timezone is configured: " +
+		"sunrise and sunset will render as UTC clock times, the Today/This Week/This Month/" +
+		"This Year windows will use UTC calendar boundaries, and the record date labels " +
+		"(\"Today\", \"Jan 2\") will be UTC-dated. Set TZ to the station's IANA zone " +
+		"(e.g. America/Denver)."
+
+	if len(got.Warnings) != 1 {
+		t.Fatalf("got %d warnings, want exactly 1: %#v", len(got.Warnings), got.Warnings)
+	}
+	if got.Warnings[0] != want {
+		t.Errorf("warning drifted.\n got: %q\nwant: %q", got.Warnings[0], want)
+	}
+}
+
 // TestDecideUI_ReportsEveryUnmetPrecondition proves an operator with three
 // broken flags learns all three from one startup, not one per restart.
 func TestDecideUI_ReportsEveryUnmetPrecondition(t *testing.T) {

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,7 +45,7 @@ ENABLE_ALMANAC=false
 
 # --- Station identity -------------------------------------------------------
 # The store holds no coordinates and UDP carries none, so these are config.
-# None is required; a MALFORMED value is a fatal startup error.
+# None is required; a MALFORMED value is generally a fatal startup error.
 # Latitude and longitude must be set together, and are what the almanac and
 # radar cards need.
 #STATION_NAME=Backyard

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -52,12 +52,18 @@ ENABLE_ALMANAC=false
 #STATION_LATITUDE=39.7392
 #STATION_LONGITUDE=-104.9903
 #STATION_ELEVATION=1609
-# IANA zone for the almanac. Defaults to UTC, which affects more than the
-# window boundaries: sunrise/sunset render as UTC clock times (a Denver
-# station shows "Sunrise 2:17 PM · Sunset 11:39 PM" on the December
-# solstice), the Today/This Week/This Month/This Year windows use UTC
-# calendar boundaries, and the record date labels are UTC-dated. Enabling
-# the almanac with coordinates but without this logs a WARN at startup.
+# IANA zone for the almanac AND for log timestamps. Defaults to UTC, which
+# affects more than the window boundaries: sunrise/sunset render as UTC clock
+# times (a Denver station shows "Sunrise 2:17 PM · Sunset 11:39 PM" on the
+# December solstice), the Today/This Week/This Month/This Year windows use UTC
+# calendar boundaries, and the record date labels are UTC-dated. Enabling the
+# almanac with coordinates but without this logs a WARN at startup. A value
+# the runtime cannot resolve is not fatal -- it warns and falls back to UTC.
+#TZ=America/Denver
+
+# DEPRECATED, removal in a future release: STATION_TIMEZONE still works and
+# still takes precedence over TZ, so existing deployments keep their current
+# behaviour. Setting it logs a WARN. Set TZ to the same value and remove it.
 #STATION_TIMEZONE=America/Denver
 
 # --- Grafana -----------------------------------------------------------------

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -57,13 +57,16 @@ ENABLE_ALMANAC=false
 # times (a Denver station shows "Sunrise 2:17 PM · Sunset 11:39 PM" on the
 # December solstice), the Today/This Week/This Month/This Year windows use UTC
 # calendar boundaries, and the record date labels are UTC-dated. Enabling the
-# almanac with coordinates but without this logs a WARN at startup. A value
-# the runtime cannot resolve is not fatal -- it warns and falls back to UTC.
+# almanac with coordinates and a store, but with neither this nor
+# STATION_TIMEZONE, logs a WARN at startup. A value the runtime cannot resolve
+# is not fatal -- it warns and falls back to UTC.
 #TZ=America/Denver
 
 # DEPRECATED, removal in a future release: STATION_TIMEZONE still works and
-# still takes precedence over TZ, so existing deployments keep their current
-# behaviour. Setting it logs a WARN. Set TZ to the same value and remove it.
+# still takes precedence over TZ, so a deployment that SETS IT keeps its
+# current behaviour. One that set only TZ does change -- see the "Upgrading
+# from v1.0.2" section of docs/configuration.md. Setting it logs a WARN. Set TZ
+# to the same value and remove it.
 #STATION_TIMEZONE=America/Denver
 
 # --- Grafana -----------------------------------------------------------------

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -69,6 +69,21 @@ services:
       STATION_LATITUDE: ${STATION_LATITUDE:-}
       STATION_LONGITUDE: ${STATION_LONGITUDE:-}
       STATION_ELEVATION: ${STATION_ELEVATION:-}
+      # The default MUST stay empty, never ${TZ:-UTC}: an explicit UTC renders
+      # the same zone but tells Stormglass a timezone WAS configured, deleting
+      # the startup warning for every operator who set coordinates and no
+      # timezone. os.Getenv cannot distinguish empty from absent, so an empty
+      # value is treated as unset.
+      #
+      # Note this delivers TZ="" (set-but-empty), not TZ-unset. Go's runtime
+      # treats the two differently -- unset consults /etc/localtime, empty does
+      # not -- which is moot on the distroless base, since it ships no
+      # /etc/localtime.
+      TZ: ${TZ:-}
+      # DEPRECATED (removal in a future release), and kept for exactly that
+      # reason: this file has no env_file: key, so ${...} interpolation is the
+      # only path from .env to the container. Deleting this line would silently
+      # revert every existing operator's station to UTC.
       STATION_TIMEZONE: ${STATION_TIMEZONE:-}
       TOKEN: ${TOKEN:-}
       STORMGLASS_SERIAL: ${STORMGLASS_SERIAL:-}

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -48,7 +48,7 @@ controllers:
           STATION_LATITUDE: "47.6"
           STATION_LONGITUDE: "-122.3"
           STATION_ELEVATION: "150"
-          STATION_TIMEZONE: America/Los_Angeles
+          TZ: America/Los_Angeles
         probes:
           liveness:
             enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 Every setting is an environment variable — Stormglass has no config file. This
-page is the authoritative reference for the **37 variables Stormglass itself
+page is the authoritative reference for the **38 variables Stormglass itself
 reads**; see [Scope](#scope) for what deliberately lives elsewhere.
 
 ## How values are read
@@ -22,8 +22,8 @@ prevents startup: an optional card whose prerequisites are missing logs an
 take down ingestion.
 
 The one middle case is a prerequisite that is met but degraded: coordinates set
-without `STATION_TIMEZONE` logs a `WARN` and the almanac still mounts, rendering
-every time on UTC.
+without a timezone logs a `WARN` and the almanac still mounts, rendering every
+time on UTC.
 
 ## Mode selection
 
@@ -117,6 +117,45 @@ See [Storage](storage.md) for the schema and the Litestream replication path.
 only works with the OTel one. This trips people up; see
 [Metrics](metrics.md) before choosing.
 
+## Timezone
+
+One variable sets the station's clock and the log timestamps together.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TZ` | `UTC` | IANA name, e.g. `America/Denver`. Sets the zone for sunrise/sunset, the almanac's calendar windows and its record date labels, and for log timestamps |
+
+`TZ` is the conventional container timezone variable. The Go runtime reads it
+to set the process's local zone, and Stormglass reads it to set the station's.
+A value the runtime cannot resolve — a POSIX rule form such as
+`EST5EDT,M3.2.0/2,M11.1.0/2`, or a typo — is **not** fatal: it logs a `WARN`
+and the zone it would have supplied falls back to UTC. (If `STATION_TIMEZONE`
+is also set, it keeps supplying the station's times; only the log timestamps
+fall back.) This is deliberately unlike the `STATION_*` variables, where a
+malformed value aborts startup: `TZ` is an OS-level variable this project does
+not own, and crash-looping the appliance over a display setting would stop
+weather ingestion.
+
+> **`STATION_TIMEZONE` is deprecated** and will be removed in a future release.
+> It still works, and while it is set it **takes precedence over `TZ`** for the
+> station's times, so no existing deployment changes behaviour. Setting it logs
+> a one-time `WARN`. Set `TZ` to the same value and remove it.
+
+**Setting `TZ` sets the flag, whoever set it.** Stormglass records only that
+*a* zone was supplied, not that it is the *station's*. Clusters that inject `TZ`
+fleet-wide — a shared `envFrom` ConfigMap, a mutating webhook — will therefore
+satisfy that check with the node's zone, and a Denver station on a Frankfurt
+cluster renders its almanac in Frankfurt with no warning. Set `TZ` explicitly
+on the Stormglass workload if your platform does this.
+
+### Upgrading from v1.0.2
+
+A deployment that set **`TZ` but not `STATION_TIMEZONE`** changes on upgrade:
+the almanac moves from UTC to local calendar boundaries, sunrise and sunset
+become local clock times, and because the temperature records are computed over
+those windows, **the four record values change**. A deployment that sets
+`STATION_TIMEZONE` is unaffected.
+
 ## Station identity
 
 No UDP message carries the station's location, so identity is configuration.
@@ -128,16 +167,17 @@ Nothing here is required and no combination of missing values prevents startup.
 | `STATION_LONGITUDE` | — | Decimal degrees, −180 to 180. **Must be set together with latitude** |
 | `STATION_ELEVATION` | — | Metres. Display only; any finite value is accepted. Absent renders `—` |
 | `STATION_NAME` | — | Display only. When absent the dashboard renders `Tempest Station` |
-| `STATION_TIMEZONE` | `UTC` | IANA name, e.g. `America/Denver`. Server-side only — the server preformats every timezone-dependent value, so it never appears on the wire |
+| `STATION_TIMEZONE` | `UTC` | *(deprecated — use [`TZ`](#timezone))* IANA name, e.g. `America/Denver`. Still honoured and still takes precedence over `TZ`. Server-side only — the server preformats every timezone-dependent value, so it never appears on the wire |
 
 Setting only one of latitude/longitude is a fatal startup error. Both are
 required by the almanac and radar cards.
 
-**`STATION_TIMEZONE` matters more than it looks.** With coordinates set and the
-timezone unset, the almanac mounts but renders on UTC: sunrise and sunset become
-UTC clock times (a Denver station shows "Sunrise 2:17 PM · Sunset 11:39 PM" on
-the December solstice), calendar windows fall on UTC boundaries, and record date
-labels are UTC-dated. That case logs a `WARN`.
+**The timezone matters more than it looks.** With coordinates set and no
+timezone configured, the almanac mounts but renders on UTC: sunrise and sunset
+become UTC clock times (a Denver station shows "Sunrise 2:17 PM · Sunset
+11:39 PM" on the December solstice), calendar windows fall on UTC boundaries,
+and record date labels are UTC-dated. That case logs a `WARN`. Set
+[`TZ`](#timezone).
 
 ## Dashboard cards
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,23 +139,30 @@ weather ingestion.
 
 > **`STATION_TIMEZONE` is deprecated** and will be removed in a future release.
 > It still works, and while it is set it **takes precedence over `TZ`** for the
-> station's times, so no existing deployment changes behaviour. Setting it logs
-> a one-time `WARN`. Set `TZ` to the same value and remove it.
+> station's times, so **no deployment that sets `STATION_TIMEZONE` changes
+> behaviour**. (One that sets only `TZ` does — see
+> [Upgrading from v1.0.2](#upgrading-from-v102).) Setting it logs a one-time
+> `WARN`. Set `TZ` to the same value and remove it.
 
 **Setting `TZ` sets the flag, whoever set it.** Stormglass records only that
 *a* zone was supplied, not that it is the *station's*. Clusters that inject `TZ`
 fleet-wide — a shared `envFrom` ConfigMap, a mutating webhook — will therefore
 satisfy that check with the node's zone, and a Denver station on a Frankfurt
-cluster renders its almanac in Frankfurt with no warning. Set `TZ` explicitly
-on the Stormglass workload if your platform does this.
+cluster renders its almanac in Frankfurt with no warning. The compose
+deployment has the same shape: `deploy/docker-compose.yml` interpolates
+`TZ: ${TZ:-}`, and Compose resolves that against the **host shell** first, so a
+shell that exports `TZ` overrides the value in `.env` and reaches the container
+unannounced. Set `TZ` explicitly on the Stormglass workload — or in the shell
+that runs `docker compose` — if your platform does this.
 
 ### Upgrading from v1.0.2
 
 A deployment that set **`TZ` but not `STATION_TIMEZONE`** changes on upgrade:
 the almanac moves from UTC to local calendar boundaries, sunrise and sunset
 become local clock times, and because the temperature records are computed over
-those windows, **the four record values change**. A deployment that sets
-`STATION_TIMEZONE` is unaffected.
+those windows, **the eight record values** — a high and a low for each of the
+Today/Week/Month/Year columns — **and their date labels can change**. A
+deployment that sets `STATION_TIMEZONE` is unaffected.
 
 ## Station identity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,12 +14,13 @@ rather than silently disabling the card.
 
 **Malformed is fatal; missing is not.** A value that cannot be parsed — an
 unparseable or out-of-range coordinate, a non-finite number, an unknown
-timezone, half of a coordinate pair — aborts startup, and **every** offending
-variable is named at once rather than just the first. An *absent* value never
-prevents startup: an optional card whose prerequisites are missing logs an
-`ERROR`, leaves its route unregistered, reports itself false at
-`/api/capabilities`, and the data path keeps running. A card flag can never
-take down ingestion.
+`STATION_TIMEZONE`, half of a coordinate pair — aborts startup, and **every**
+offending variable is named at once rather than just the first. (The one
+exception is `TZ`: a value the runtime cannot resolve is not fatal — see
+[Timezone](#timezone).) An *absent* value never prevents startup: an optional
+card whose prerequisites are missing logs an `ERROR`, leaves its route
+unregistered, reports itself false at `/api/capabilities`, and the data path
+keeps running. A card flag can never take down ingestion.
 
 The one middle case is a prerequisite that is met but degraded: coordinates set
 without a timezone logs a `WARN` and the almanac still mounts, rendering every

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -33,10 +33,10 @@ No UDP message carries the station's location, so it is configuration. Nothing
 is required, and no combination of missing values prevents startup. See
 [Configuration](configuration.md) for the variables, ranges and defaults.
 
-The one setting worth calling out is `STATION_TIMEZONE`: with coordinates set
-and the timezone unset, the almanac still mounts but renders every time on UTC,
-and logs a `WARN`. It is server-side only — the server preformats every
-timezone-dependent value, so the timezone never appears on the wire.
+The one setting worth calling out is `TZ`: with coordinates set and no timezone
+configured, the almanac still mounts but renders every time on UTC, and logs a
+`WARN`. The timezone is server-side only — the server preformats every
+timezone-dependent value, so it never appears on the wire.
 
 ## HTTP endpoints
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -23,9 +23,10 @@ An unmet precondition is never fatal. The card is not mounted, an `ERROR` names
 what is missing, `/api/capabilities` reports it false, and ingestion continues.
 A card flag cannot take down the data path.
 
-A *malformed* value — an unparseable coordinate, an unknown timezone, half a
-coordinate pair — is a different matter and **is** a fatal startup error, naming
-every offending variable at once.
+A *malformed* value — an unparseable coordinate, an unknown `STATION_TIMEZONE`,
+half a coordinate pair — is a different matter and **is** a fatal startup
+error, naming every offending variable at once. (`TZ` failures are not: see
+[Configuration](configuration.md#timezone).)
 
 ## Station identity
 

--- a/internal/config/station.go
+++ b/internal/config/station.go
@@ -81,11 +81,13 @@ const (
 
 // The timezone notices are pinned constants rather than inline strings
 // because each one has to stay true in every reachable state. The deprecation
-// has two variants because the parsed one's every clause is false when the
-// value did not parse; the advisory has two because a single one would be
-// false whenever STATION_TIMEZONE supplied the zone; and the suffix says "is
-// also set" rather than "differs" because no string compare can decide whether
-// two spellings name one zone. TestTimezoneMessages_ExactText pins all five.
+// has three variants because the parsed one's every clause is false when the
+// value did not parse, and its LAST clause is false -- and actively harmful --
+// for "Local", which parses but names no zone TZ can load; the advisory has
+// two because a single one would be false whenever STATION_TIMEZONE supplied
+// the zone; and the suffix says "is also set" rather than "differs" because no
+// string compare can decide whether two spellings name one zone.
+// TestTimezoneMessages_ExactText pins all six.
 const (
 	tzDeprecationMsg = "STATION_TIMEZONE is deprecated and will be removed in a future release. " +
 		"It is still honoured and still takes precedence over TZ, so this station's times use %q. " +
@@ -98,6 +100,20 @@ const (
 	tzDeprecationMalformedMsg = "STATION_TIMEZONE is deprecated and will be removed in a future " +
 		"release; set TZ instead. The value %q did not parse, so it supplied no zone — the " +
 		"startup error below names it."
+
+	// Used instead of tzDeprecationMsg when the value is exactly "Local".
+	// time.LoadLocation special-cases that name and returns the process zone,
+	// so the value PARSES and does supply the station's times -- it is not
+	// malformed, and routing it to the variant above would both lie and change
+	// behaviour. Only tzDeprecationMsg's last clause is wrong for it, and
+	// wrong in the worst direction: the runtime cannot load "Local" from TZ
+	// (initLocal finds no such zone and falls back to UTC), so an operator who
+	// followed "set TZ to the same value" would silently move the almanac to
+	// UTC while the station kept rendering correctly right up until they did.
+	tzDeprecationLocalMsg = "STATION_TIMEZONE is deprecated and will be removed in a future " +
+		"release. It is still honoured and still takes precedence over TZ, so this station's " +
+		"times use %q. Local is not an IANA zone name and TZ=Local falls back to UTC, so set " +
+		"TZ to the station's actual zone (e.g. America/Denver) and remove STATION_TIMEZONE."
 
 	// "is also set", never "differs": whether the two spellings name the same
 	// zone is not something a string compare can decide -- utc/UTC,
@@ -127,7 +143,7 @@ const (
 // No value is ever required: an unset variable yields a nil pointer and no
 // error, and no combination of absent values can prevent the process from
 // starting. A MALFORMED value -- unparseable, out of range, non-finite, an
-// unknown timezone, or a half-set coordinate pair -- is a fatal
+// unknown STATION_TIMEZONE, or a half-set coordinate pair -- is a fatal
 // configuration error, matching ParseBoolEnv's stance that a typo is an
 // operator error rather than a silently disabled feature.
 //
@@ -137,10 +153,14 @@ const (
 // produce a fatal error -- an unresolvable value degrades to UTC with a
 // notice.)
 //
-// local is the process's local zone, injected rather than read from
-// time.Local so tests are deterministic: time.Local resolves lazily on first
-// use, which makes a test that reads it directly order-dependent. Production
-// passes time.Local. A nil local is normalised to time.UTC, so
+// PRECONDITION: local must be the runtime's own resolution of TZ. Production
+// passes time.Local, which is exactly that; it is injected rather than read
+// here so tests are deterministic, because time.Local resolves lazily on first
+// use and a test that reads it directly is order-dependent. The notices are
+// only true under this precondition -- "log timestamps follow TZ" is inferred
+// from local, so an incoherent pair (a non-UTC local beside an unresolvable
+// TZ) would make that clause false. That pair is unreachable in production,
+// and no test may construct it. A nil local is normalised to time.UTC, so
 // StationConfig.Location's never-nil guarantee is a property of this function
 // rather than of the caller.
 //
@@ -281,7 +301,7 @@ func timezoneNotices(local *time.Location, stationTZ, tz string, stationTZOK boo
 	// use %q / set TZ to the same value" clauses is true in that state.
 	if stationTZ != "" {
 		if stationTZOK {
-			n := fmt.Sprintf(tzDeprecationMsg, stationTZ)
+			n := fmt.Sprintf(deprecationMsgFor(stationTZ), stationTZ)
 			// tzResolved is correctness; the TrimPrefix compare is only
 			// noise suppression, so the common "both set to the same
 			// string" deployment stays quiet. The suffix no longer claims
@@ -320,6 +340,23 @@ func timezoneNotices(local *time.Location, stationTZ, tz string, stationTZOK boo
 	return notices
 }
 
+// localZoneName is time.LoadLocation's one name that parses without naming an
+// IANA zone: it returns the process's local zone. The stdlib switches on this
+// literal, so the comparison below is an exact match of a documented special
+// case rather than a heuristic -- "local" and "LOCAL" do not reach it and are
+// ordinary unknown zones.
+const localZoneName = "Local"
+
+// deprecationMsgFor picks the deprecation variant for a STATION_TIMEZONE that
+// parsed. Extracted rather than inlined so timezoneNotices stays at its
+// measured gocyclo of 10; see LoadStation's note on the same budget.
+func deprecationMsgFor(stationTZ string) string {
+	if stationTZ == localZoneName {
+		return tzDeprecationLocalMsg
+	}
+	return tzDeprecationMsg
+}
+
 // isUTCSpelling reports whether tz is a spelling of UTC or GMT, so an operator
 // who deliberately chose UTC is not advised about it.
 //
@@ -330,8 +367,10 @@ func timezoneNotices(local *time.Location, stationTZ, tz string, stationTZOK boo
 // String()=="UTC", and this arm is what suppresses the advisory for it.
 //
 // Accepted false positives -- spellings Go cannot load but the operator
-// plainly meant as UTC, which therefore still produce an advisory -- are
-// exactly "UTC0", "Z" and "UTC+0".
+// plainly meant as UTC, which therefore still produce an advisory -- include
+// "UTC0", "Z", "UTC+0" and "UTC-0"; the set is platform-dependent and is not
+// enumerated here. The advisory stays TRUE in all of them (the runtime really
+// did land on UTC); it is only redundant.
 func isUTCSpelling(tz string) bool {
 	name := strings.TrimPrefix(tz, ":")
 	return strings.EqualFold(name, "UTC") || strings.EqualFold(name, "GMT")

--- a/internal/config/station.go
+++ b/internal/config/station.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	// time/tzdata embeds the IANA database in the binary (~450 KB) so
@@ -36,12 +37,28 @@ type StationConfig struct {
 	RadarSite *string
 	Location  *time.Location
 
-	// TimezoneConfigured records whether STATION_TIMEZONE was set and parsed.
+	// TimezoneConfigured records whether a timezone was supplied at all --
+	// either STATION_TIMEZONE (set AND parsed) or a non-empty TZ.
+	//
+	// It records that A zone was supplied, not that it is the STATION's. TZ is
+	// routinely injected cluster-wide (a shared envFrom ConfigMap, a mutating
+	// webhook) to set the node's zone, and such an injection sets this flag,
+	// so a Denver station on a Frankfurt cluster renders its almanac in
+	// Frankfurt with no diagnostic. That is the accepted price of making TZ
+	// the documented variable.
+	//
 	// Location cannot carry this: it defaults to time.UTC, and
 	// time.LoadLocation("UTC") returns that same pointer, so an operator who
 	// deliberately chose UTC is indistinguishable from one who set nothing.
 	// The almanac warns only the second (issue #165). Not serialised.
 	TimezoneConfigured bool
+
+	// TimezoneNotices are non-fatal, operator-facing messages about how the
+	// station zone was resolved -- the STATION_TIMEZONE deprecation and the
+	// unresolvable-TZ advisory. main logs them at WARN; LoadStation stays a
+	// pure decoder and never logs. nil when there is nothing to say. Not
+	// serialised.
+	TimezoneNotices []string
 }
 
 // Coordinate bounds. Elevation is unbounded in metres (the Dead Sea shore is
@@ -62,6 +79,49 @@ const (
 	maxElevationM = math.MaxFloat64
 )
 
+// The timezone notices are pinned constants rather than inline strings
+// because each one has to stay true in every reachable state. The deprecation
+// has two variants because the parsed one's every clause is false when the
+// value did not parse; the advisory has two because a single one would be
+// false whenever STATION_TIMEZONE supplied the zone; and the suffix says "is
+// also set" rather than "differs" because no string compare can decide whether
+// two spellings name one zone. TestTimezoneMessages_ExactText pins all five.
+const (
+	tzDeprecationMsg = "STATION_TIMEZONE is deprecated and will be removed in a future release. " +
+		"It is still honoured and still takes precedence over TZ, so this station's times use %q. " +
+		"Set TZ to the same value and remove STATION_TIMEZONE."
+
+	// Used instead of tzDeprecationMsg when the value did not parse. Every
+	// clause of tzDeprecationMsg is false in that state, and "set TZ to the
+	// same value" is actively harmful -- an invalid zone name is invalid in TZ
+	// too.
+	tzDeprecationMalformedMsg = "STATION_TIMEZONE is deprecated and will be removed in a future " +
+		"release; set TZ instead. The value %q did not parse, so it supplied no zone — the " +
+		"startup error below names it."
+
+	// "is also set", never "differs": whether the two spellings name the same
+	// zone is not something a string compare can decide -- utc/UTC,
+	// US/Mountain/America/Denver and an absolute path are each one zone that
+	// fails an equality test. This wording asserts only what is always true.
+	tzDeprecationAlsoSetMsg = " Note TZ=%q is also set; log timestamps follow TZ while station " +
+		"times follow STATION_TIMEZONE."
+
+	// Used when STATION_TIMEZONE did NOT supply the zone, so UTC really does
+	// reach every station-local value.
+	tzAdvisoryStationUnsetMsg = "TZ=%q resolved to UTC, so log timestamps and every station-local " +
+		"time — sunrise/sunset, the almanac's calendar windows and its record date labels " +
+		"— will use UTC. If that is not what you intended, set TZ to an IANA zone name such " +
+		"as America/Denver."
+
+	// Used when STATION_TIMEZONE DID supply the zone. Claiming station times
+	// use UTC here would be false -- measured, TZ=EST5EDT,M3.2.0/2,M11.1.0/2
+	// with STATION_TIMEZONE=America/Denver renders a 14:17Z sunrise as
+	// "7:17 AM", not "2:17 PM".
+	tzAdvisoryStationSetMsg = "TZ=%q resolved to UTC, so log timestamps will use UTC. Station times " +
+		"are unaffected because STATION_TIMEZONE takes precedence. If that is not what you " +
+		"intended, set TZ to an IANA zone name such as America/Denver."
+)
+
 // LoadStation decodes the station identity from the environment.
 //
 // No value is ever required: an unset variable yields a nil pointer and no
@@ -72,13 +132,23 @@ const (
 // operator error rather than a silently disabled feature.
 //
 // EVERY malformed value is reported in one aggregated error, per
-// go-standards §15.3: with six variables, failing on the first would cost an
-// operator six restart cycles.
+// go-standards §15.3: an operator with three bad values fixes them in one
+// deploy cycle, not three. (TZ is the one variable read here that can never
+// produce a fatal error -- an unresolvable value degrades to UTC with a
+// notice.)
+//
+// local is the process's local zone, injected rather than read from
+// time.Local so tests are deterministic: time.Local resolves lazily on first
+// use, which makes a test that reads it directly order-dependent. Production
+// passes time.Local. A nil local is normalised to time.UTC, so
+// StationConfig.Location's never-nil guarantee is a property of this function
+// rather than of the caller.
 //
 // LoadStation deliberately does not read feature flags. RADAR_SITE is
 // decoded here unconditionally; main clears it when ENABLE_RADAR is false,
 // so flag interpretation stays in one place and this stays a pure decoder.
-func LoadStation() (StationConfig, error) {
+// For the same reason it returns TimezoneNotices instead of logging them.
+func LoadStation(local *time.Location) (StationConfig, error) {
 	cfg := StationConfig{Location: time.UTC}
 	var errs []error
 
@@ -122,17 +192,149 @@ func LoadStation() (StationConfig, error) {
 		cfg.Elevation = elev
 	}
 
-	if v := os.Getenv("STATION_TIMEZONE"); v != "" {
-		loc, err := time.LoadLocation(v)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid IANA timezone %q for STATION_TIMEZONE: %w", v, err))
+	// Extracted rather than inline: inlining this logic puts LoadStation well
+	// over .golangci.yml's gocyclo budget of 15 (independent reconstructions
+	// measured 23 and 25, depending on the exact inline shape). Extracted,
+	// LoadStation and timezoneNotices each measure 10.
+	zone, tzConfigured, notices, tzErr := resolveTimezone(local,
+		os.Getenv("STATION_TIMEZONE"), os.Getenv("TZ"))
+	if tzErr != nil {
+		errs = append(errs, tzErr)
+	}
+	cfg.Location = zone
+	cfg.TimezoneConfigured = tzConfigured
+	cfg.TimezoneNotices = notices
+
+	return cfg, errors.Join(errs...)
+}
+
+// resolveTimezone performs the three independent resolutions of the timezone
+// design: the station's zone, the TimezoneConfigured flag, and the operator
+// notices. The returned zone is never nil.
+//
+// PRECONDITION: local must be the runtime's own resolution of tz -- production
+// passes time.Local, which is exactly that. The notices below are only true
+// under it: "log timestamps follow TZ" is inferred from local, so an incoherent
+// pair (a non-UTC local beside an unresolvable tz) would make that clause
+// false. Unreachable in production, and no test may construct it.
+//
+// The returned error is the malformed-STATION_TIMEZONE error, which stays
+// fatal. A TZ the runtime could not resolve is deliberately NOT an error: TZ
+// is an OS-level variable this project does not own -- glibc accepts POSIX
+// forms such as EST5EDT,M3.2.0/2,M11.1.0/2 that time.LoadLocation rejects --
+// and making those fatal would crash-loop the appliance over a display
+// setting, the exact failure decideUI's design rejects for card flags.
+func resolveTimezone(local *time.Location, stationTZ, tz string) (*time.Location, bool, []string, error) {
+	if local == nil {
+		local = time.UTC
+	}
+
+	zone := time.UTC
+	stationTZOK := false
+	var err error
+	if stationTZ != "" {
+		loc, loadErr := time.LoadLocation(stationTZ)
+		if loadErr != nil {
+			err = fmt.Errorf("invalid IANA timezone %q for STATION_TIMEZONE: %w", stationTZ, loadErr)
 		} else {
-			cfg.Location = loc
-			cfg.TimezoneConfigured = true
+			zone, stationTZOK = loc, true
 		}
 	}
 
-	return cfg, errors.Join(errs...)
+	// STATION_TIMEZONE wins while it exists. "else" here means
+	// "STATION_TIMEZONE did not yield a zone", not "was unset": a malformed
+	// STATION_TIMEZONE leaves the zone at UTC even when TZ is set. Production
+	// never observes that state -- the error above is fatal in main -- but a
+	// test asserting Location there would otherwise resolve two ways.
+	//
+	// The tz != "" guard is load-bearing. Applying local unconditionally would
+	// render the almanac in the host zone on any base image that ships
+	// /etc/localtime, while the issue #165 warning -- keyed on
+	// TimezoneConfigured -- announced that everything renders UTC.
+	if !stationTZOK && tz != "" {
+		zone = local
+	}
+
+	// The parse check on the STATION_TIMEZONE half is required: the flag is
+	// documented as "set AND parsed", and a malformed value must leave it
+	// false. For the TZ half there is nothing to parse, so non-empty is the
+	// test.
+	return zone, stationTZOK || tz != "", timezoneNotices(local, stationTZ, tz, stationTZOK), err
+}
+
+// timezoneNotices builds the non-fatal, operator-facing messages. It returns
+// nil when there is nothing to say. Evaluated independently of the zone
+// resolution, so a TZ that lost the zone is still diagnosed.
+func timezoneNotices(local *time.Location, stationTZ, tz string, stationTZOK bool) []string {
+	var notices []string
+
+	// tzResolved is the negation of the advisory predicate below: TZ named a
+	// zone the runtime actually landed on, or the operator asked for UTC and
+	// got it. It gates the "is also set" suffix, because that suffix claims
+	// log timestamps follow TZ -- which contradicts the advisory whenever TZ
+	// did not resolve.
+	tzResolved := tz != "" && (local.String() != "UTC" || isUTCSpelling(tz))
+
+	// Fires even when the value is malformed and the load is about to fail,
+	// so the operator learns the deprecation and the typo in one restart --
+	// but with different text, because none of the "still honoured / times
+	// use %q / set TZ to the same value" clauses is true in that state.
+	if stationTZ != "" {
+		if stationTZOK {
+			n := fmt.Sprintf(tzDeprecationMsg, stationTZ)
+			// tzResolved is correctness; the TrimPrefix compare is only
+			// noise suppression, so the common "both set to the same
+			// string" deployment stays quiet. The suffix no longer claims
+			// the two DIFFER, so a spelling this compare cannot equate
+			// (utc/UTC, a tzdata Link alias, an absolute path) yields a
+			// redundant true sentence rather than a false one.
+			if tzResolved && strings.TrimPrefix(tz, ":") != stationTZ {
+				n += fmt.Sprintf(tzDeprecationAlsoSetMsg, tz)
+			}
+			notices = append(notices, n)
+		} else {
+			notices = append(notices, fmt.Sprintf(tzDeprecationMalformedMsg, stationTZ))
+		}
+	}
+
+	// Expressed as !tzResolved rather than as its own predicate: "TZ resolved"
+	// and "TZ landed on UTC unintentionally" are one piece of knowledge, and
+	// writing them as two hand-maintained De Morgan duals is exactly the
+	// invariant whose breakage produced this design's earlier false
+	// diagnostics.
+	//
+	// local.String() is the only available signal, and the notice says only
+	// that the runtime LANDED on UTC -- never why. The runtime's own TZ
+	// handling (initLocal, $(go env GOROOT)/src/time/zoneinfo_unix.go:28-69)
+	// strips a leading colon and loads absolute paths, neither of which
+	// time.LoadLocation does, so re-deriving the resolution here would be
+	// wrong in both directions.
+	if tz != "" && !tzResolved {
+		if stationTZOK {
+			notices = append(notices, fmt.Sprintf(tzAdvisoryStationSetMsg, tz))
+		} else {
+			notices = append(notices, fmt.Sprintf(tzAdvisoryStationUnsetMsg, tz))
+		}
+	}
+
+	return notices
+}
+
+// isUTCSpelling reports whether tz is a spelling of UTC or GMT, so an operator
+// who deliberately chose UTC is not advised about it.
+//
+// The leading colon is stripped because initLocal accepts ":UTC" while the
+// name it records does not carry the colon. EqualFold is required because
+// TZ=utc yields String()=="utc" on a case-insensitive filesystem (darwin) and
+// "UTC" on Linux. The GMT arm is not dead code: on Linux TZ=gmt gives
+// String()=="UTC", and this arm is what suppresses the advisory for it.
+//
+// Accepted false positives -- spellings Go cannot load but the operator
+// plainly meant as UTC, which therefore still produce an advisory -- are
+// exactly "UTC0", "Z" and "UTC+0".
+func isUTCSpelling(tz string) bool {
+	name := strings.TrimPrefix(tz, ":")
+	return strings.EqualFold(name, "UTC") || strings.EqualFold(name, "GMT")
 }
 
 // parseFloatEnv reads key as a finite float in [lo, hi]. An unset or empty

--- a/internal/config/station_test.go
+++ b/internal/config/station_test.go
@@ -9,7 +9,7 @@ import (
 func TestLoadStation_AllUnset(t *testing.T) {
 	clearStationEnv(t)
 
-	cfg, err := LoadStation()
+	cfg, err := LoadStation(time.UTC)
 	if err != nil {
 		t.Fatalf("LoadStation: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestLoadStation_Valid(t *testing.T) {
 	t.Setenv("STATION_TIMEZONE", "America/New_York")
 	t.Setenv("RADAR_SITE", "TLX")
 
-	cfg, err := LoadStation()
+	cfg, err := LoadStation(time.UTC)
 	if err != nil {
 		t.Fatalf("LoadStation: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestLoadStation_ZeroCoordinatesAreRealValues(t *testing.T) {
 	t.Setenv("STATION_LONGITUDE", "0")
 	t.Setenv("STATION_ELEVATION", "0")
 
-	cfg, err := LoadStation()
+	cfg, err := LoadStation(time.UTC)
 	if err != nil {
 		t.Fatalf("LoadStation: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestLoadStation_MalformedValues(t *testing.T) {
 			for k, v := range tc.env {
 				t.Setenv(k, v)
 			}
-			_, err := LoadStation()
+			_, err := LoadStation(time.UTC)
 			if err == nil {
 				t.Fatal("want a non-nil error")
 			}
@@ -132,7 +132,7 @@ func TestLoadStation_ReportsEveryErrorAtOnce(t *testing.T) {
 	t.Setenv("STATION_ELEVATION", "high")
 	t.Setenv("STATION_TIMEZONE", "Nowhere/Nothing")
 
-	_, err := LoadStation()
+	_, err := LoadStation(time.UTC)
 	if err == nil {
 		t.Fatal("want a non-nil error")
 	}
@@ -150,7 +150,7 @@ func TestLoadStation_LoadsNonUTCZone(t *testing.T) {
 	clearStationEnv(t)
 	t.Setenv("STATION_TIMEZONE", "America/Denver")
 
-	cfg, err := LoadStation()
+	cfg, err := LoadStation(time.UTC)
 	if err != nil {
 		t.Fatalf("LoadStation: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestLoadStation_TimezoneConfigured(t *testing.T) {
 
 			t.Setenv("STATION_TIMEZONE", tc.value)
 
-			cfg, err := LoadStation()
+			cfg, err := LoadStation(time.UTC)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("LoadStation() err = %v, wantErr = %v", err, tc.wantErr)
 			}
@@ -202,13 +202,295 @@ func TestLoadStation_TimezoneConfigured(t *testing.T) {
 }
 
 // clearStationEnv unsets every variable LoadStation reads, so a test never
-// inherits one from the developer's shell. t.Setenv restores on cleanup.
+// inherits one from the developer's shell or from CI. t.Setenv restores on
+// cleanup.
+//
+// TZ is in the list because LoadStation reads it: with TZ=America/Denver
+// exported and a time.UTC fixture, TestLoadStation_TimezoneConfigured's
+// "unset" AND "malformed" subtests both fail, the latter because
+// STATION_TIMEZONE did not parse while a non-empty TZ still sets the flag.
+//
+// Setting TZ via t.Setenv also pins this package's time.Local to UTC for the
+// life of the test binary (time.Local resolves lazily, once). That is benign
+// here because nothing in package config reads time.Local -- the local zone is
+// a LoadStation parameter -- but it is stated rather than left to be
+// discovered.
 func clearStationEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"STATION_NAME", "STATION_LATITUDE", "STATION_LONGITUDE",
-		"STATION_ELEVATION", "STATION_TIMEZONE", "RADAR_SITE",
+		"STATION_ELEVATION", "STATION_TIMEZONE", "RADAR_SITE", "TZ",
 	} {
 		t.Setenv(k, "")
+	}
+}
+
+// TestLoadStation_TimezoneResolution is the whole timezone contract: the
+// station's zone, the TimezoneConfigured flag, and the notices, across every
+// combination that behaves differently.
+//
+// Every row asserts notice CONTENT, not merely the count. A defect that emits
+// two advisories, or the deprecation text where the advisory belongs, must not
+// pass. "is deprecated" and "resolved to UTC" are the discriminators.
+//
+// local is a parameter, so each row passes an explicit fixture and nothing
+// depends on the machine's or the CI runner's zone.
+func TestLoadStation_TimezoneResolution(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Fatalf("LoadLocation(America/Denver): %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		local     *time.Location
+		tz        string
+		stationTZ string
+		wantZone  string // Location.String()
+		wantFlag  bool
+		wantErr   bool
+		// wantNotices is ordered: entry i lists substrings that notice i must
+		// contain. len(wantNotices) is also the exact expected notice count.
+		wantNotices [][]string
+		// wantAbsent lists substrings that must appear in NO notice.
+		wantAbsent []string
+	}{
+		{
+			// r2 regression guard: applying local unconditionally rendered the
+			// almanac in the host zone while the #165 warning said UTC.
+			name: "both_unset_ignores_local", local: denver,
+			wantZone: "UTC", wantFlag: false,
+		},
+		{
+			name: "tz_only_supplies_the_zone", local: denver, tz: "America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+		},
+		{
+			name: "tz_unresolvable_advises_and_degrades_to_utc", local: time.UTC, tz: "Nonsense/Zone",
+			wantZone: "UTC", wantFlag: true,
+			wantNotices: [][]string{{"resolved to UTC"}},
+			wantAbsent:  []string{"Station times are unaffected", "is deprecated"},
+		},
+		{
+			// glibc accepts this POSIX form; time.LoadLocation does not. D2:
+			// non-fatal.
+			name: "tz_posix_rule_form_advises", local: time.UTC, tz: "EST5EDT,M3.2.0/2,M11.1.0/2",
+			wantZone: "UTC", wantFlag: true,
+			wantNotices: [][]string{{"resolved to UTC"}},
+		},
+		{
+			name: "tz_Local_advises", local: time.UTC, tz: "Local",
+			wantZone: "UTC", wantFlag: true,
+			wantNotices: [][]string{{"resolved to UTC"}},
+		},
+		{
+			// An operator who deliberately chose UTC must not be advised.
+			name: "tz_UTC_is_silent", local: time.UTC, tz: "UTC",
+			wantZone: "UTC", wantFlag: true,
+		},
+		{
+			// EqualFold: TZ=utc yields String()=="utc" on a case-insensitive
+			// filesystem (darwin) and "UTC" on Linux.
+			name: "tz_lowercase_utc_is_silent", local: time.UTC, tz: "utc",
+			wantZone: "UTC", wantFlag: true,
+		},
+		{
+			// TrimPrefix: the runtime strips a leading colon; the recorded
+			// name does not carry it.
+			name: "tz_colon_prefixed_utc_is_silent", local: time.UTC, tz: ":UTC",
+			wantZone: "UTC", wantFlag: true,
+		},
+		{
+			// The GMT arm is not dead code: on Linux TZ=gmt gives
+			// String()=="UTC", and this arm is what suppresses it.
+			name: "tz_lowercase_gmt_is_silent", local: time.UTC, tz: "gmt",
+			wantZone: "UTC", wantFlag: true,
+		},
+		{
+			name: "tz_colon_prefixed_zone_is_forwarded", local: denver, tz: ":America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+		},
+		{
+			name: "tz_absolute_path_is_forwarded", local: denver,
+			tz:       "/usr/share/zoneinfo/America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+		},
+		{
+			name: "station_timezone_still_wins_and_is_deprecated", local: time.UTC,
+			stationTZ: "America/Denver",
+			wantZone:  "America/Denver", wantFlag: true,
+			wantNotices: [][]string{{"is deprecated", "takes precedence over TZ"}},
+			wantAbsent:  []string{"is also set", "resolved to UTC"},
+		},
+		{
+			// D2: malformed STATION_TIMEZONE stays fatal, the flag stays
+			// false, and the zone stays UTC -- but the deprecation notice
+			// still fires, so the operator learns both in one restart.
+			name: "station_timezone_malformed_is_fatal_and_still_notices", local: time.UTC,
+			stationTZ: "Not/AZone",
+			wantZone:  "UTC", wantFlag: false, wantErr: true,
+			wantNotices: [][]string{{"is deprecated", "did not parse"}},
+			// The parsed variant's clauses are all false here.
+			wantAbsent: []string{"still honoured", "Set TZ to the same value", "takes precedence"},
+		},
+		{
+			name: "both_set_and_equal_is_silent", local: denver,
+			tz: "America/Denver", stationTZ: "America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+			wantNotices: [][]string{{"is deprecated"}},
+			wantAbsent:  []string{"is also set"},
+		},
+		{
+			// Without this suffix an operator who set TZ alongside a stale
+			// STATION_TIMEZONE would not learn why their logs and their
+			// dashboard disagree.
+			name: "both_set_to_different_zones_carries_the_also_set_suffix", local: time.UTC,
+			tz: "UTC", stationTZ: "America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+			wantNotices: [][]string{{"is deprecated", "is also set", "log timestamps follow TZ"}},
+			wantAbsent:  []string{"resolved to UTC"},
+		},
+		{
+			// Two notices, and the advisory MUST carry the unaffected clause:
+			// station times really are unaffected here, so S3's wording would
+			// be false.
+			name: "unresolvable_tz_beside_a_valid_station_timezone", local: time.UTC,
+			tz: "Nonsense/Zone", stationTZ: "America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+			wantNotices: [][]string{
+				{"is deprecated"},
+				{"resolved to UTC", "Station times are unaffected"},
+			},
+			// No "also set" suffix: it would say log timestamps follow TZ,
+			// while the advisory beside it says they use UTC. TZ did not
+			// resolve, so the advisory is the true one.
+			wantAbsent: []string{"is also set"},
+		},
+		{
+			// Location must never be nil, even when the caller hands us one.
+			name: "nil_local_with_everything_unset_does_not_panic", local: nil,
+			wantZone: "UTC", wantFlag: false,
+		},
+		{
+			// The row that actually kills the nil-guard mutation: with TZ set,
+			// a missing guard assigns nil to Location, which the
+			// "Location must never be nil" assertion catches. The all-unset
+			// row above never enters that path. It does NOT panic:
+			// (*time.Location)(nil).String() returns "UTC" because
+			// Location.get() nil-checks.
+			name: "nil_local_with_tz_set_falls_back_to_utc", local: nil, tz: "America/Denver",
+			wantZone: "UTC", wantFlag: true,
+			wantNotices: [][]string{{"resolved to UTC"}},
+			wantAbsent:  []string{"Station times are unaffected"},
+		},
+		{
+			// The runtime strips a leading colon, so these are one zone
+			// spelled two ways and the suffix is pure noise. Suppression
+			// only -- the suffix would not be FALSE here, just redundant.
+			name: "colon_prefixed_tz_matching_station_timezone_is_silent", local: denver,
+			tz: ":America/Denver", stationTZ: "America/Denver",
+			wantZone: "America/Denver", wantFlag: true,
+			wantNotices: [][]string{{"is deprecated"}},
+			wantAbsent:  []string{"is also set"},
+		},
+		{
+			// Both halves bad: the malformed deprecation plus the
+			// stationTZOK==false advisory, and still fatal.
+			name: "both_malformed_emits_both_notices_and_is_fatal", local: time.UTC,
+			tz: "Nonsense/Zone", stationTZ: "Not/AZone",
+			wantZone: "UTC", wantFlag: true, wantErr: true,
+			wantNotices: [][]string{
+				{"is deprecated", "did not parse"},
+				{"resolved to UTC", "every station-local time"},
+			},
+			wantAbsent: []string{"Station times are unaffected", "is also set"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearStationEnv(t)
+			t.Setenv("TZ", tc.tz)
+			t.Setenv("STATION_TIMEZONE", tc.stationTZ)
+
+			cfg, err := LoadStation(tc.local)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("LoadStation() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if cfg.Location == nil {
+				t.Fatal("Location must never be nil")
+			}
+			if got := cfg.Location.String(); got != tc.wantZone {
+				t.Errorf("Location = %q, want %q", got, tc.wantZone)
+			}
+			if cfg.TimezoneConfigured != tc.wantFlag {
+				t.Errorf("TimezoneConfigured = %v, want %v", cfg.TimezoneConfigured, tc.wantFlag)
+			}
+			if len(cfg.TimezoneNotices) != len(tc.wantNotices) {
+				t.Fatalf("got %d notices, want %d: %#v",
+					len(cfg.TimezoneNotices), len(tc.wantNotices), cfg.TimezoneNotices)
+			}
+			for i, wants := range tc.wantNotices {
+				for _, want := range wants {
+					if !strings.Contains(cfg.TimezoneNotices[i], want) {
+						t.Errorf("notice[%d] = %q, must contain %q", i, cfg.TimezoneNotices[i], want)
+					}
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				for i, n := range cfg.TimezoneNotices {
+					if strings.Contains(n, absent) {
+						t.Errorf("notice[%d] = %q, must not contain %q", i, n, absent)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestTimezoneMessages_ExactText pins the operator-facing strings verbatim.
+// The resolution table asserts only short discriminating substrings, so
+// without this a dropped sentence, a reworded clause, or a "--" substituted
+// for the em dash ships silently. Each clause of these messages had to be
+// true in every state that can reach it, which is why they are not free to
+// drift -- see the design's §3.2.1 and §3.2.2.
+//
+// If a message legitimately changes, update this test AND re-check the
+// reachable-state analysis. Do not update it to match whatever the code now
+// says.
+func TestTimezoneMessages_ExactText(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"deprecation_parsed", tzDeprecationMsg,
+			"STATION_TIMEZONE is deprecated and will be removed in a future release. " +
+				"It is still honoured and still takes precedence over TZ, so this station's " +
+				"times use %q. Set TZ to the same value and remove STATION_TIMEZONE."},
+		{"deprecation_malformed", tzDeprecationMalformedMsg,
+			"STATION_TIMEZONE is deprecated and will be removed in a future release; set TZ " +
+				"instead. The value %q did not parse, so it supplied no zone \u2014 the startup " +
+				"error below names it."},
+		{"deprecation_also_set", tzDeprecationAlsoSetMsg,
+			" Note TZ=%q is also set; log timestamps follow TZ while station times follow " +
+				"STATION_TIMEZONE."},
+		{"advisory_station_unset", tzAdvisoryStationUnsetMsg,
+			"TZ=%q resolved to UTC, so log timestamps and every station-local time \u2014 " +
+				"sunrise/sunset, the almanac's calendar windows and its record date labels " +
+				"\u2014 will use UTC. If that is not what you intended, set TZ to an IANA zone " +
+				"name such as America/Denver."},
+		{"advisory_station_set", tzAdvisoryStationSetMsg,
+			"TZ=%q resolved to UTC, so log timestamps will use UTC. Station times are " +
+				"unaffected because STATION_TIMEZONE takes precedence. If that is not what " +
+				"you intended, set TZ to an IANA zone name such as America/Denver."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("message drifted.\n got: %q\nwant: %q", tc.got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/config/station_test.go
+++ b/internal/config/station_test.go
@@ -247,8 +247,15 @@ func TestLoadStation_TimezoneResolution(t *testing.T) {
 		tz        string
 		stationTZ string
 		wantZone  string // Location.String()
-		wantFlag  bool
-		wantErr   bool
+		// wantLocalZone asserts pointer identity with time.Local instead of a
+		// name, and is the only way to assert STATION_TIMEZONE=Local: that
+		// value resolves through time.LoadLocation's "Local" special case,
+		// whose NAME is whatever the runner's TZ made time.Local -- exactly
+		// the order dependence the injected local parameter exists to avoid.
+		// wantZone is ignored when this is set.
+		wantLocalZone bool
+		wantFlag      bool
+		wantErr       bool
 		// wantNotices is ordered: entry i lists substrings that notice i must
 		// contain. len(wantNotices) is also the exact expected notice count.
 		wantNotices [][]string
@@ -332,6 +339,22 @@ func TestLoadStation_TimezoneResolution(t *testing.T) {
 			wantNotices: [][]string{{"is deprecated", "did not parse"}},
 			// The parsed variant's clauses are all false here.
 			wantAbsent: []string{"still honoured", "Set TZ to the same value", "takes precedence"},
+		},
+		{
+			// "Local" is the one name that time.LoadLocation accepts and the
+			// runtime cannot load from TZ, so the parsed deprecation's "set
+			// TZ to the same value" would silently move this station to UTC.
+			// It is NOT malformed: it still parses and still supplies the
+			// zone, so it must not be routed to the malformed variant.
+			name:          "station_timezone_Local_does_not_advise_copying_the_value_to_tz",
+			local:         time.UTC,
+			stationTZ:     "Local",
+			wantLocalZone: true, wantFlag: true,
+			wantNotices: [][]string{{
+				"is deprecated", "still honoured", "takes precedence over TZ",
+				"not an IANA zone name", "falls back to UTC",
+			}},
+			wantAbsent: []string{"Set TZ to the same value", "did not parse", "resolved to UTC"},
 		},
 		{
 			name: "both_set_and_equal_is_silent", local: denver,
@@ -420,7 +443,11 @@ func TestLoadStation_TimezoneResolution(t *testing.T) {
 			if cfg.Location == nil {
 				t.Fatal("Location must never be nil")
 			}
-			if got := cfg.Location.String(); got != tc.wantZone {
+			if tc.wantLocalZone {
+				if cfg.Location != time.Local {
+					t.Errorf("Location = %p, want time.Local (%p)", cfg.Location, time.Local)
+				}
+			} else if got := cfg.Location.String(); got != tc.wantZone {
 				t.Errorf("Location = %q, want %q", got, tc.wantZone)
 			}
 			if cfg.TimezoneConfigured != tc.wantFlag {
@@ -472,6 +499,14 @@ func TestTimezoneMessages_ExactText(t *testing.T) {
 			"STATION_TIMEZONE is deprecated and will be removed in a future release; set TZ " +
 				"instead. The value %q did not parse, so it supplied no zone \u2014 the startup " +
 				"error below names it."},
+		// No em dash by design: this variant's last clause is the corrective
+		// advice, and it reads as two plain sentences.
+		{"deprecation_local", tzDeprecationLocalMsg,
+			"STATION_TIMEZONE is deprecated and will be removed in a future release. It is " +
+				"still honoured and still takes precedence over TZ, so this station's times " +
+				"use %q. Local is not an IANA zone name and TZ=Local falls back to UTC, so " +
+				"set TZ to the station's actual zone (e.g. America/Denver) and remove " +
+				"STATION_TIMEZONE."},
 		{"deprecation_also_set", tzDeprecationAlsoSetMsg,
 			" Note TZ=%q is also set; log timestamps follow TZ while station times follow " +
 				"STATION_TIMEZONE."},


### PR DESCRIPTION
Closes #239.

Configuring one physical location took two environment variables: `TZ`, which
the application never read (it reached the process only through the Go
runtime's `time.Local` and governed log timestamps), and `STATION_TIMEZONE`,
which governed the almanac's calendar windows, sunrise/sunset clock times and
record date labels. Neither defaulted from the other, so setting only the
conventional `TZ` produced a UTC dashboard beside correctly-zoned logs.

`config.LoadStation` now takes the process local zone as a parameter and reads
`TZ`. `STATION_TIMEZONE` is deprecated but still honoured, and **still takes
precedence** while it is set, so no deployment that sets it changes behaviour.

- A malformed `STATION_TIMEZONE` stays fatal. A `TZ` the runtime cannot resolve
  is not: it warns and falls back to UTC. `TZ` is an OS-level variable this
  project does not own — glibc accepts POSIX forms such as
  `EST5EDT,M3.2.0/2,M11.1.0/2` that `time.LoadLocation` rejects — and
  crash-looping the appliance over a display setting would stop ingestion.
- The issue #165 startup warning now names `TZ`. It still fires only when
  neither variable supplied a zone.
- Timezone resolution is extracted into `resolveTimezone` / `timezoneNotices`
  so `LoadStation` stays inside the repo's `gocyclo` budget of 15; inline it
  exceeds that budget.

## Upgrading

**A deployment with `TZ` set and `STATION_TIMEZONE` unset changes on upgrade.**
The almanac moves from UTC to local calendar boundaries, sunrise and sunset
become local clock times, and because the temperature records are computed over
those windows, the eight record values — a high and a low for each of the
Today/Week/Month/Year columns — and their date labels can change. This is the
fix, not a regression. Deployments that set `STATION_TIMEZONE` are unaffected.

`TZ` records that *a* zone was supplied, not that it is the *station's*. A
cluster that injects `TZ` fleet-wide, or a shell that exports it before
`docker compose`, will now satisfy that check with the host's zone and suppress
the warning; set `TZ` explicitly on the Stormglass workload if that applies.

## Review findings folded in

Three rounds of adversarial review ran against this branch. Everything below was
found and fixed here rather than left for a follow-up.

**A class of documentation sentence this branch falsified.** "An unknown
timezone … aborts startup" was true before `TZ` was read and false after. It
existed in **four** places — `docs/configuration.md`, `docs/dashboard.md`,
`.claude/CLAUDE.md`, and `LoadStation`'s own exported doc comment, inside the
very function that introduced the exception. Patching the instances as they were
noticed found two of four; a systematic sweep over 22 tracked hits found the
rest and left the 20 genuinely-true ones alone.

**Two claims that over-quantified.** "No existing deployment changes behaviour"
contradicted this file's own upgrade note eleven lines below it, and
`.claude/CLAUDE.md` still advertised 37 environment variables where there are
now 38.

**The #165 warning had no exact-text test.** Every other operator-facing string
was pinned verbatim; this one was asserted by substrings that survive dropping
half the sentence or swapping an em dash. It is pinned now.

## Verification

`task ci` green: `go test ./... -race -tags integration` (584 tests, 18
packages), `golangci-lint` 0 issues, `govulncheck` no vulnerabilities,
`actionlint` / `yamllint` / `hadolint`, 192 vitest tests, all 32 layout-harness
assertions, `ruff`, `pytest`.

`gocyclo`: `LoadStation` 10, `timezoneNotices` 10, against a budget of 15, with
no `nolint` anywhere in `internal/config`.

The notice logic was checked by enumerating the reachable states from the code
rather than from the tests: ten reachable notice sets, no constructible
contradictory pair. Go's `TZ` handling was measured across 27 values on
darwin/arm64 **and** alpine/musl — which is what establishes that the `GMT` arm
of the UTC-spelling check is not dead code (`TZ=gmt` resolves to `UTC` on Linux
but stays `gmt` on darwin).

## Known gaps

- The notice-logging loop in `main()` has no automated test; `main()` has no
  harness, and restructuring it was out of scope. Three real process runs were
  substituted and are recorded.

