### PR TITLE
fix(deploy): let release-please own the shipped image tag

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -20,7 +20,8 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "extra-files": ["deploy/kubernetes/values.yaml"]
     }
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["python"],
       "enabled": false
+    },
+    {
+      "description": "This repo publishes ghcr.io/jacaudi/stormglass, and deploy/kubernetes/values.yaml pins it as a deployment example. Left enabled, Renovate tracks our own release and opens a bump PR after every cut -- so the shipped example is permanently one release stale and the PR is superseded before it merges (#238 proposed v1.0.2 while v1.0.3 was being tagged). release-please now owns that tag through the extra-files entry in release-please-config.json and the x-release-please-version annotation on the line, which updates it inside the release PR itself. This rule must stay AFTER the docker-images group above: later rules win, and that group's \"**\" would otherwise pull this image back in.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/jacaudi/stormglass"],
+      "enabled": false
     }
   ]
 }

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -35,7 +35,12 @@ controllers:
       app:
         image:
           repository: ghcr.io/jacaudi/stormglass
-          tag: v1.0.1
+          # release-please owns this tag: the release PR rewrites it via the
+          # extra-files entry in .github/release-please-config.json, and
+          # .github/renovate.json disables Renovate on this image so the two
+          # cannot fight over it. Renovate tracking our own published image
+          # made this line permanently one release stale.
+          tag: v1.0.3 # x-release-please-version
         env:
           HTTP_ADDR: ":8080"
           SQLITE_PATH: /data/stormglass.db

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -7,8 +7,19 @@
 # This file is the single source of truth for the deployment config;
 # helmrelease.yaml wraps it for Flux rather than restating it.
 #
-# Change before use: station coordinates, RADAR_SITE, image tags, and the
-# OTLP endpoint.
+# Change before use: station coordinates, RADAR_SITE, the radar image tag, and
+# the OTLP endpoint.
+#
+# Do NOT hand-edit the stormglass image tag. release-please owns it: the release
+# PR rewrites it through the extra-files entry in
+# .github/release-please-config.json, keyed on the trailing annotation comment
+# that must stay on that line. .github/renovate.json disables Renovate for this
+# one image so the two cannot fight over it -- Renovate tracking our own
+# published release left this tag permanently one cut stale.
+#
+# That annotation is the only one in this file, and it must stay that way: the
+# updater rewrites a version on every line carrying it, so repeating the token
+# in prose would arm a second rewrite site.
 controllers:
   stormglass:
     # StatefulSet, not Deployment: /data holds one SQLite database with a WAL
@@ -35,11 +46,6 @@ controllers:
       app:
         image:
           repository: ghcr.io/jacaudi/stormglass
-          # release-please owns this tag: the release PR rewrites it via the
-          # extra-files entry in .github/release-please-config.json, and
-          # .github/renovate.json disables Renovate on this image so the two
-          # cannot fight over it. Renovate tracking our own published image
-          # made this line permanently one release stale.
           tag: v1.0.3 # x-release-please-version
         env:
           HTTP_ADDR: ":8080"

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -10,8 +10,14 @@
 # Change before use: station coordinates, RADAR_SITE, the radar image tag, and
 # the OTLP endpoint.
 #
-# Do NOT hand-edit the stormglass image tag. release-please owns it: the release
-# PR rewrites it through the extra-files entry in
+# Every note about a field lives here rather than beside it, so the body stays
+# pure config. Each note names the key it is about.
+#
+#
+# IMAGE TAG
+#
+# app.image.tag -- do NOT hand-edit. release-please owns it: the release PR
+# rewrites it through the extra-files entry in
 # .github/release-please-config.json, keyed on the trailing annotation comment
 # that must stay on that line. .github/renovate.json disables Renovate for this
 # one image so the two cannot fight over it -- Renovate tracking our own
@@ -20,22 +26,61 @@
 # That annotation is the only one in this file, and it must stay that way: the
 # updater rewrites a version on every line carrying it, so repeating the token
 # in prose would arm a second rewrite site.
+#
+#
+# POD
+#
+# type: statefulset -- not Deployment. /data holds one SQLite database with a
+# WAL that Litestream is streaming, and a rolling Deployment update would
+# briefly run two pods with two writers on one file.
+#
+# hostNetwork: true -- REQUIRED for UDP ingestion. Tempest stations broadcast
+# to :50222 as link-local traffic, which does not cross the CNI pod network.
+# Without this the pod starts, passes its probes, serves the dashboard -- and
+# receives no observations at all.
+#
+# dnsPolicy: ClusterFirstWithHostNet -- must accompany hostNetwork. Without it
+# the pod inherits the node's resolv.conf and loses cluster DNS, so in-cluster
+# service names (the OTel collector, Postgres) stop resolving. The default
+# ClusterFirst is silently wrong here rather than an error.
+#
+#
+# CONTAINERS
+#
+# radar -- optional; drop this container if ENABLE_RADAR is false. With
+# hostNetwork the app reaches it on localhost:8081, no service needed.
+#
+# radar.resources.requests.memory -- not padding: decoding a NEXRAD volume scan
+# loads the whole scan into memory, and one tile response can be several MB of
+# GeoJSON.
+#
+# litestream -- optional; streams the SQLite WAL off-node. Shares /data with the
+# app and OWNS checkpointing, which is why Stormglass does not configure
+# wal_autocheckpoint itself. Drop its two volumes below with it. Needs a Secret
+# `stormglass-litestream` with access-key-id and secret-access-key.
+#
+#
+# SERVICE
+#
+# service.app.ports -- for the deprecated scrape path, add a
+# `metrics: {port: 9000}` entry and set ENABLE_PROMETHEUS_METRICS. See
+# servicemonitor.yaml.
+#
+#
+# PERSISTENCE
+#
+# data -- needs a PVC named stormglass-data. ReadWriteOnce is fine; hostNetwork
+# pins the pod to a node anyway.
+#
+# litestream-config -- ConfigMap holding litestream.yml; use
+# deploy/litestream.yml as the content, with the db path /data/stormglass.db.
+#
+# tmp -- readOnlyRootFilesystem is on, so the app needs somewhere writable.
 controllers:
   stormglass:
-    # StatefulSet, not Deployment: /data holds one SQLite database with a WAL
-    # that Litestream is streaming, and a rolling Deployment update would
-    # briefly run two pods with two writers on one file.
     type: statefulset
     pod:
-      # REQUIRED for UDP ingestion. Tempest stations broadcast to :50222 as
-      # link-local traffic, which does not cross the CNI pod network. Without
-      # this the pod starts, passes its probes, serves the dashboard — and
-      # receives no observations at all.
       hostNetwork: true
-      # Must accompany hostNetwork. Without it the pod inherits the node's
-      # resolv.conf and loses cluster DNS, so in-cluster service names (the
-      # OTel collector below, Postgres) stop resolving. The default
-      # ClusterFirst is silently wrong here rather than an error.
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
         runAsUser: 65532
@@ -91,8 +136,6 @@ controllers:
           limits:
             memory: 256Mi
 
-      # Optional; drop this container if ENABLE_RADAR is false. With
-      # hostNetwork the app reaches it on localhost:8081, no service needed.
       radar:
         image:
           repository: ghcr.io/jacaudi/stormglass-radar
@@ -110,17 +153,10 @@ controllers:
         resources:
           requests:
             cpu: 50m
-            # Not padding: decoding a NEXRAD volume scan loads the whole scan
-            # into memory, and one tile response can be several MB of GeoJSON.
             memory: 512Mi
           limits:
             memory: 2Gi
 
-      # Optional; streams the SQLite WAL off-node. Shares /data with the app
-      # and OWNS checkpointing, which is why Stormglass does not configure
-      # wal_autocheckpoint itself. Drop its two volumes below with it.
-      # Needs a Secret `stormglass-litestream` with access-key-id and
-      # secret-access-key.
       litestream:
         image:
           repository: litestream/litestream
@@ -141,15 +177,11 @@ controllers:
 service:
   app:
     controller: stormglass
-    # For the deprecated scrape path, add a `metrics: {port: 9000}` entry
-    # below and set ENABLE_PROMETHEUS_METRICS. See servicemonitor.yaml.
     ports:
       http:
         port: 8080
 
 persistence:
-  # Needs a PVC named stormglass-data. ReadWriteOnce is fine — hostNetwork
-  # pins the pod to a node anyway.
   data:
     existingClaim: stormglass-data
     advancedMounts:
@@ -158,8 +190,6 @@ persistence:
           - path: /data
         litestream:
           - path: /data
-  # ConfigMap holding litestream.yml; use deploy/litestream.yml as the
-  # content, with the db path /data/stormglass.db.
   litestream-config:
     type: configMap
     name: stormglass-litestream
@@ -169,7 +199,6 @@ persistence:
           - path: /etc/litestream.yml
             subPath: litestream.yml
             readOnly: true
-  # readOnlyRootFilesystem is on, so the app needs somewhere writable.
   tmp:
     type: emptyDir
     advancedMounts:


### PR DESCRIPTION
`deploy/kubernetes/values.yaml` pins `ghcr.io/jacaudi/stormglass` as a
deployment example, and Renovate was tracking that image — this repo's own
published release. That loop can never settle: every cut leaves the shipped
example one release behind and opens a bump PR that is superseded before anyone
merges it. #238 proposed `v1.0.2` while `v1.0.3` was being tagged, and `main`
still carried `v1.0.1`, two releases stale.

release-please owns the line now, through an `extra-files` entry and an
`x-release-please-version` annotation, so the tag moves *inside* the release PR
that publishes the image it names — correct at every commit rather than
eventually. Renovate is disabled for this one image so the two cannot fight over
it.

## Details worth checking in review

- **The rule's position matters.** It sits after the `docker-images` group
  because later rules win in Renovate, and that group's `"**"` would otherwise
  pull the image straight back in.
- **The `v` prefix survives.** release-please's generic updater replaces only
  the semver on an annotated line. Verified against its own `VERSION_REGEX`:
  `tag: v1.0.1` becomes `tag: v1.0.4`, prefix intact. The docs do not state this
  either way.
- **Only one line is annotated.** The file's other two tags — the radar sidecar
  and litestream — are untouched, confirmed by running the updater's regex over
  the whole file.
- **The pin is corrected to `v1.0.3`**, the currently published release, so the
  example is accurate now rather than only after the next cut.

## Verification

`task ci` green: Go build/vet/test with `-race`, `golangci-lint` 0 issues,
`govulncheck`, `actionlint`, `yamllint`, `hadolint`, 192 vitest tests, the full
layout harness, `ruff`, `pytest`.

## Follow-up filed separately

`values.yaml` also pins `ghcr.io/jacaudi/stormglass-radar:v1.0.0`, which is
never published — `ci-radar.yml` sets `push: false` deliberately. That is a
different bug from this one and is tracked as #242; this PR does not
touch it.
