### PR TITLE
fix: unblock the frozen Go and boto3 dependency lanes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,7 +90,11 @@ runs:
       shell: bash
       env:
         # renovate: datasource=github-releases depName=golangci/golangci-lint
-        VERSION: 2.12.2
+        # Must be built with a Go >= the module's toolchain, or it refuses to
+        # run at all: "the Go language version used to build golangci-lint is
+        # lower than the targeted Go version". 2.13.2 is built with go1.27.0.
+        # renovate.json groups this with go-toolchain so the two move together.
+        VERSION: 2.13.2
       run: |
         set -euo pipefail
         curl -sSfL "https://github.com/golangci/golangci-lint/releases/download/v${VERSION}/golangci-lint-${VERSION}-linux-amd64.tar.gz" \

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/jacaudi/stormglass"],
       "enabled": false
+    },
+    {
+      "description": "golangci-lint refuses to run when the Go version it was built with is older than the module's toolchain, so its pin has to lead every Go bump rather than trail it. As separate groups the two can never be ordered -- #161 sat red because the toolchain moved to 1.27 while the linter pin was still a 1.26 build, and the failure was not in that PR's own diff. Grouping them means one PR carries both and the ordering question disappears. The go-toolchain group itself comes from the shared jacaudi/renovate-config:go preset; this rule only adds the linter to it, locally, rather than changing a preset six repos consume.",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["golangci/golangci-lint"],
+      "groupName": "go-toolchain"
     }
   ]
 }

--- a/.taskfiles/python.yml
+++ b/.taskfiles/python.yml
@@ -55,10 +55,26 @@ tasks:
       # ModuleNotFoundError, the exact trap the comment above warns about,
       # arriving by a different route. --with-requirements installs the pinned
       # set, so tests run against the versions radar actually ships.
+      #
+      # Second deviation: when an excludes.txt sits beside requirements.txt, the
+      # environment is built with `uv pip install --excludes` into a throwaway
+      # venv instead of by `uv run`. `uv run` accepts no excludes/overrides file
+      # -- neither the flag nor UV_OVERRIDE reaches it, and uv.toml's
+      # override-dependencies does not apply outside a project -- so it would
+      # resolve the unexcluded graph and fail outright where the image succeeds.
+      # Matching the image's resolution is the whole point: an env that differs
+      # from what ships is not a test of what ships (#232).
       - |
         set -eu
         if [ -d tests ] || [ -d test ]; then
-          if [ -f requirements.txt ]; then
+          if [ -f requirements.txt ] && [ -f excludes.txt ]; then
+            venv=$(mktemp -d)
+            trap 'rm -rf "${venv}"' EXIT
+            uv venv --quiet "${venv}"
+            VIRTUAL_ENV="${venv}" uv pip install --quiet \
+              -r requirements.txt --excludes excludes.txt
+            "${venv}/bin/pytest"
+          elif [ -f requirements.txt ]; then
             uv run --with-requirements requirements.txt pytest
           else
             uv run --with pytest pytest

--- a/radar/Dockerfile
+++ b/radar/Dockerfile
@@ -27,12 +27,18 @@ RUN apt-get update \
 RUN python -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 
+# uv, not pip: excludes.txt drops arm-pyart's unused s3fs dependency, which is
+# the only thing pinning boto3 under aiobotocore's botocore ceiling (#232). pip
+# has no way to exclude a transitive dependency. Pinned by digest like every
+# other base here.
+COPY --from=ghcr.io/astral-sh/uv:0.12.7@sha256:95f2aa1fe59274951cfe9b0cbc7972e879ff1004bc8945d130a32eb0dbd85945 /uv /usr/local/bin/uv
+
 WORKDIR /app
-COPY requirements.txt .
+COPY requirements.txt excludes.txt ./
 # pytest is a test-only dep pinned in requirements.txt (shared with the test
 # suite); drop it here so it doesn't ship in the runtime image.
-RUN pip install --no-cache-dir -r requirements.txt \
-    && pip uninstall -y --no-input pytest
+RUN uv pip install --no-cache -r requirements.txt --excludes excludes.txt \
+    && uv pip uninstall pytest
 
 FROM python:3.12-slim
 

--- a/radar/excludes.txt
+++ b/radar/excludes.txt
@@ -1,0 +1,38 @@
+# Packages dropped from this sidecar's dependency resolution (uv --excludes).
+#
+# Both the image build and the test task pass this file, so the two
+# environments resolve identically. If you add a consumer, pass it there too --
+# a resolution that sees this file and one that does not are different
+# environments, and the tests stop testing what ships.
+#
+# WHY s3fs
+#
+# arm-pyart declares s3fs as a hard, non-optional dependency, and s3fs pulls
+# aiobotocore, which caps botocore below the boto3 this sidecar wants:
+#
+#   boto3 >= 1.43.57  ->  botocore >= 1.43.57
+#   arm-pyart -> s3fs -> aiobotocore -> botocore < 1.43.57
+#
+# No published combination satisfies both ends, so boto3 sat frozen under that
+# ceiling and every Renovate bump failed to resolve. aiobotocore chronically
+# lags botocore's release cadence, so the ceiling rises slowly while boto3 moves
+# fast: waiting it out is not a fix, it is a standing tax on triage.
+#
+# s3fs is safe to drop because nothing imports it. It appears nowhere in pyart's
+# own source, and nothing in this directory imports it either -- the sidecar
+# reads the public NEXRAD bucket through boto3 directly, with an unsigned
+# client. fsspec dispatches to s3fs only for s3:// URLs, which this code never
+# opens.
+#
+# DO NOT ADD fsspec HERE. pyart/io/common.py imports it at module top level, so
+# excluding it breaks `import pyart` outright -- and the image would still build
+# green, failing only on first import. That is exactly the shape of #186, where
+# a broken cartopy extension passed the build and died at runtime. Verify a
+# change here by booting the image (`task radar-smoke`), never by building it.
+#
+# Verified before landing: boto3 resolves to 1.43.83, aiobotocore leaves the
+# graph entirely, `import pyart` and `pyart.io.nexrad_archive` both succeed, the
+# test suite passes, and the built image boots and serves /healthz.
+#
+# Refs #232.
+s3fs

--- a/radar/requirements.txt
+++ b/radar/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.141.1
 uvicorn[standard]==0.52.4
 arm-pyart==2.2.5
-boto3==1.43.46
+boto3==1.43.83
 geojsoncontour==0.5.1
 matplotlib==3.11.1
 pytest==9.1.1


### PR DESCRIPTION
Two frozen dependency lanes, each blocked by a repo change Renovate cannot make
itself. Both are unblocked here, and both were verified by reproducing the
failure first rather than trusting the issue text.

Closes #232. Refs #231. Unblocks #161 and #65.

## #231 — the golangci-lint pin has to lead the Go toolchain

golangci-lint refuses to run at all when the Go version it was built with is
older than the module's toolchain. #161 sat red for that reason, and the cause
was not in its own diff: it bumps `toolchain` and the Dockerfile builder
together and consistently, then dies on a third pin it does not touch.

Reproduced both directions against this tree with `toolchain go1.27.0`:

| pin | built with | result |
|---|---|---|
| 2.12.2 (current) | go1.26.2 | `the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.0)` |
| 2.13.2 (this PR) | go1.27.0 | clean |

2.13.2 is also clean against the **current** toolchain — `run` and `fmt --diff`
both report no issues on go1.26.6 — so the bump does not smuggle in new findings
ahead of the toolchain PR that needs it.

**Grouping is what stops this recurring.** Two independent Renovate groups cannot
be ordered, and every future Go major hits the same wall in the same order, so
the linter joins the `go-toolchain` group and one PR carries both. That group
comes from the shared `jacaudi/renovate-config:go` preset; this adds the linter
to it *locally* rather than changing a preset six repos consume.

## #232 — arm-pyart's unused s3fs was freezing boto3

`arm-pyart` declares `s3fs` as a hard dependency, `s3fs` pulls `aiobotocore`,
and `aiobotocore` caps `botocore` below the `boto3` the sidecar wants. Nothing
published satisfies both ends, so `boto3` sat frozen and every Renovate bump
failed to resolve.

**The issue's proposed fix would have broken the image.** It suggested excluding
"`s3fs`/`aiobotocore`" and warned that `--no-deps` means owning arm-pyart's
dependency list by hand. Neither is needed, and one half is dangerous:

- **`fsspec` is load-bearing.** `pyart/io/common.py` imports it at module top
  level, so excluding it breaks `import pyart` outright. The issue grepped
  *this repo* for fsspec, not pyart's own source.
- **`s3fs` appears nowhere in pyart's source.** fsspec dispatches to it lazily
  for `s3://` URLs, which this sidecar never opens — it reads the public NEXRAD
  bucket through boto3 with an unsigned client.

So the fix is narrower than proposed: **keep `fsspec`, exclude `s3fs` alone.**
uv's `--excludes` expresses that directly; pip cannot exclude a transitive
dependency at all, which is why the builder switches to uv.

Measured:

| | boto3 resolves to |
|---|---|
| with `s3fs` | **1.43.56** — the ceiling |
| without `s3fs` | **1.43.83**, and `aiobotocore` leaves the graph |

## Verification

`task ci` green. Beyond that, the radar image was **built and booted**, because
#186 is the standing proof that a green build is not evidence for this image:

- `import pyart` and `pyart.io.nexrad_archive` succeed
- the radar test suite passes
- the container serves `/healthz`
- inside the image: `boto3 1.43.83`, `fsspec 2026.7.0`, and `s3fs`,
  `aiobotocore`, `pytest` all **absent**

## Why the task file changed too

`uv run` accepts no excludes or overrides file — not the flag, not
`UV_OVERRIDE`, and `uv.toml`'s `override-dependencies` does not apply outside a
project. Left alone, `task python:test` would resolve the *unexcluded* graph and
fail where the image succeeds. It now builds its environment the way the image
does, in a throwaway venv. An environment that differs from what ships is not a
test of what ships.

This is a second documented deviation from the shared template in that file; the
first one is already recorded there.

## Still open on #231

`.taskfiles/go.yml` runs the gate fail-fast with `fmt:check` first, so a
formatting failure means `govulncheck` never executes — a red toolchain PR is
therefore *unverified* rather than *unsafe*. Nothing can merge in that state, so
the cost is misattribution during triage rather than a shipping risk. Reordering
that file diverges from the shared template it is generated against, which is a
wider decision than this PR. Left for you.
